### PR TITLE
Add `assert EXPR` macro

### DIFF
--- a/examples/adventofcode/2018/day_2.savi
+++ b/examples/adventofcode/2018/day_2.savi
@@ -78,13 +78,13 @@
   :const describes: "Day2"
 
   :it "passes the A test cases"
-    @assert = Day2.has_duo("abcdef").not, @assert = Day2.has_trio("abcdef").not
-    @assert = Day2.has_duo("bababc"),     @assert = Day2.has_trio("bababc")
-    @assert = Day2.has_duo("abbcde"),     @assert = Day2.has_trio("abbcde").not
-    @assert = Day2.has_duo("abcccd").not, @assert = Day2.has_trio("abcccd")
-    @assert = Day2.has_duo("aabcdd"),     @assert = Day2.has_trio("aabcdd").not
-    @assert = Day2.has_duo("abcdee"),     @assert = Day2.has_trio("abcdee").not
-    @assert = Day2.has_duo("ababab").not, @assert = Day2.has_trio("ababab")
+    assert Day2.has_duo("abcdef").is_false, assert Day2.has_trio("abcdef").is_false
+    assert Day2.has_duo("bababc"),          assert Day2.has_trio("bababc")
+    assert Day2.has_duo("abbcde"),          assert Day2.has_trio("abbcde").is_false
+    assert Day2.has_duo("abcccd").is_false, assert Day2.has_trio("abcccd")
+    assert Day2.has_duo("aabcdd"),          assert Day2.has_trio("aabcdd").is_false
+    assert Day2.has_duo("abcdee"),          assert Day2.has_trio("abcdee").is_false
+    assert Day2.has_duo("ababab").is_false, assert Day2.has_trio("ababab")
 
     input = <<<
       abcdef

--- a/packages/bytes/test/byte_stream_chunked_reader_spec.savi
+++ b/packages/bytes/test/byte_stream_chunked_reader_spec.savi
@@ -209,20 +209,20 @@
 
     // Compare the entire stream.
     stream.advance_to_end
-    @assert = stream.is_token_equal_to("helloworld")
-    @assert = stream.is_token_equal_to("helloworldz") == False
-    @assert = stream.is_token_equal_to("helloworl") == False
-    @assert = stream.is_token_equal_to("helloWorld") == False
+    assert stream.is_token_equal_to("helloworld")
+    assert stream.is_token_equal_to("helloworldz").is_false
+    assert stream.is_token_equal_to("helloworl").is_false
+    assert stream.is_token_equal_to("helloWorld").is_false
 
     // Compare a subset of the stream.
     stream.rewind_to_marker
     @assert = try (stream.advance!(2), True | False)
     stream.mark_here
     @assert = try (stream.advance!(6), True | False)
-    @assert = stream.is_token_equal_to("llowor")
-    @assert = stream.is_token_equal_to("lloworl") == False
-    @assert = stream.is_token_equal_to("llowo") == False
-    @assert = stream.is_token_equal_to("lloWor") == False
+    assert stream.is_token_equal_to("llowor")
+    assert stream.is_token_equal_to("lloworl").is_false
+    assert stream.is_token_equal_to("llowo").is_false
+    assert stream.is_token_equal_to("lloWor").is_false
 
   :it "compares an ASCII-lowercased token for equivalence to a given string"
     stream = ByteStreamChunkedReader.new
@@ -232,20 +232,20 @@
 
     // Compare the entire stream.
     stream.advance_to_end
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloworld")
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloworldz") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloworl") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloWorld") == False
+    assert stream.is_token_ascii_lowercase_equal_to("helloworld")
+    assert stream.is_token_ascii_lowercase_equal_to("helloworldz").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("helloworl").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("helloWorld").is_false
 
     // Compare a subset of the stream.
     stream.rewind_to_marker
     @assert = try (stream.advance!(2), True | False)
     stream.mark_here
     @assert = try (stream.advance!(6), True | False)
-    @assert = stream.is_token_ascii_lowercase_equal_to("llowor")
-    @assert = stream.is_token_ascii_lowercase_equal_to("lloworl") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("llowo") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("lloWor") == False
+    assert stream.is_token_ascii_lowercase_equal_to("llowor")
+    assert stream.is_token_ascii_lowercase_equal_to("lloworl").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("llowo").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("lloWor").is_false
 
   :it "parses a token as a positive integer in decimal notation"
     stream = ByteStreamChunkedReader.new

--- a/packages/bytes/test/byte_stream_reader_spec.savi
+++ b/packages/bytes/test/byte_stream_reader_spec.savi
@@ -260,20 +260,20 @@
 
     // Compare the entire stream.
     stream.advance_to_end
-    @assert = stream.is_token_equal_to("helloworld")
-    @assert = stream.is_token_equal_to("helloworldz") == False
-    @assert = stream.is_token_equal_to("helloworl") == False
-    @assert = stream.is_token_equal_to("helloWorld") == False
+    assert stream.is_token_equal_to("helloworld")
+    assert stream.is_token_equal_to("helloworldz").is_false
+    assert stream.is_token_equal_to("helloworl").is_false
+    assert stream.is_token_equal_to("helloWorld").is_false
 
     // Compare a subset of the stream.
     stream.rewind_to_marker
     @assert = try (stream.advance!(2), True | False)
     stream.mark_here
     @assert = try (stream.advance!(6), True | False)
-    @assert = stream.is_token_equal_to("llowor")
-    @assert = stream.is_token_equal_to("lloworl") == False
-    @assert = stream.is_token_equal_to("llowo") == False
-    @assert = stream.is_token_equal_to("lloWor") == False
+    assert stream.is_token_equal_to("llowor")
+    assert stream.is_token_equal_to("lloworl").is_false
+    assert stream.is_token_equal_to("llowo").is_false
+    assert stream.is_token_equal_to("lloWor").is_false
 
   :it "compares an ASCII-lowercased token for equivalence to a given string"
     stream = ByteStreamReader.new
@@ -284,20 +284,20 @@
 
     // Compare the entire stream.
     stream.advance_to_end
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloworld")
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloworldz") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloworl") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("helloWorld") == False
+    assert stream.is_token_ascii_lowercase_equal_to("helloworld")
+    assert stream.is_token_ascii_lowercase_equal_to("helloworldz").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("helloworl").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("helloWorld").is_false
 
     // Compare a subset of the stream.
     stream.rewind_to_marker
     @assert = try (stream.advance!(2), True | False)
     stream.mark_here
     @assert = try (stream.advance!(6), True | False)
-    @assert = stream.is_token_ascii_lowercase_equal_to("llowor")
-    @assert = stream.is_token_ascii_lowercase_equal_to("lloworl") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("llowo") == False
-    @assert = stream.is_token_ascii_lowercase_equal_to("lloWor") == False
+    assert stream.is_token_ascii_lowercase_equal_to("llowor")
+    assert stream.is_token_ascii_lowercase_equal_to("lloworl").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("llowo").is_false
+    assert stream.is_token_ascii_lowercase_equal_to("lloWor").is_false
 
   :it "parses a token as a positive integer in decimal notation"
     stream = ByteStreamReader.new

--- a/packages/collections/test/map_readable_spec.savi
+++ b/packages/collections/test/map_readable_spec.savi
@@ -43,17 +43,17 @@
 
     this_key = ""
     found_it = map.each_key_until -> (key | this_key = key, key.ends_with("o"))
-    @assert = found_it
+    assert found_it
     @assert = this_key == "foo"
 
     this_key = ""
     found_it = map.each_key_until -> (key | this_key = key, key.ends_with("z"))
-    @assert = found_it
+    assert found_it
     @assert = this_key == "baz"
 
     this_key = ""
     found_it = map.each_key_until -> (key | this_key = key, key.ends_with("x"))
-    @assert = found_it.not
+    assert found_it.is_false
 
   :it "checks if any pair in the map meets the given condition"
     map = @build_map -> (map |
@@ -62,10 +62,10 @@
       map["baz"] = 33
     )
 
-    @assert = map.has_any -> (key, value | key == "foo")
-    @assert = map.has_any -> (key, value | key == "food").not
-    @assert = map.has_any -> (key, value | value == 22)
-    @assert = map.has_any -> (key, value | value == 23).not
+    assert map.has_any -> (key, value | key == "foo")
+    assert map.has_any -> (key, value | key == "food").is_false
+    assert map.has_any -> (key, value | value == 22)
+    assert map.has_any -> (key, value | value == 23).is_false
 
   :it "checks if all pairs in the map meet the given condition"
     map = @build_map -> (map |
@@ -74,7 +74,7 @@
       map["baz"] = 33
     )
 
-    @assert = map.has_all -> (key, value | key.size == 3)
-    @assert = map.has_all -> (key, value | key.starts_with("ba")).not
-    @assert = map.has_all -> (key, value | value < 50)
-    @assert = map.has_all -> (key, value | value < 30).not
+    assert map.has_all -> (key, value | key.size == 3)
+    assert map.has_all -> (key, value | key.starts_with("ba")).is_false
+    assert map.has_all -> (key, value | value < 50)
+    assert map.has_all -> (key, value | value < 30).is_false

--- a/packages/collections/test/map_spec.savi
+++ b/packages/collections/test/map_spec.savi
@@ -13,18 +13,18 @@
     map = @new_map
     @assert = map.size == 0
     @assert = try (map["example"]!, False | True)
-    @assert = map.has_key("example").not
+    assert map.has_key("example").is_false
     @assert = (map["example"] = 99) == 99
     @assert = map.size == 1
     @assert = try (map["example"]! | U64[0]) == 99
-    @assert = map.has_key("example")
+    assert map.has_key("example")
     @assert = (map["example"] = 88) == 88
     @assert = map.size == 1
     @assert = try (map["example"]! | U64[0]) == 88
-    @assert = map.has_key("example")
+    assert map.has_key("example")
     @assert = map.delete("example") <: None
     @assert = try map["example"]! <: None
-    @assert = map.has_key("example").not
+    assert map.has_key("example").is_false
     @assert = map.size == 0
 
   :it "stores values at actor keys by identity"
@@ -70,14 +70,14 @@
 
     this_key = ""
     found_it = map.each_until -> (key, value | this_key = key, value == 22)
-    @assert = found_it
+    assert found_it
     @assert = this_key == "bar"
 
     this_key = ""
     found_it = map.each_until -> (key, value | this_key = key, value == 33)
-    @assert = found_it
+    assert found_it
     @assert = this_key == "baz"
 
     this_key = ""
     found_it = map.each_until -> (key, value | this_key = key, value == 99)
-    @assert = found_it.not
+    assert found_it.is_false

--- a/packages/collections/test/ordered_map_spec.savi
+++ b/packages/collections/test/ordered_map_spec.savi
@@ -10,18 +10,18 @@
     map = @new_map
     @assert = map.size == 0
     @assert = try (map["example"]!, False | True)
-    @assert = map.has_key("example").not
+    assert map.has_key("example").is_false
     @assert = (map["example"] = 99) == 99
     @assert = map.size == 1
     @assert = try (map["example"]! | U64[0]) == 99
-    @assert = map.has_key("example")
+    assert map.has_key("example")
     @assert = (map["example"] = 88) == 88
     @assert = map.size == 1
     @assert = try (map["example"]! | U64[0]) == 88
-    @assert = map.has_key("example")
+    assert map.has_key("example")
     @assert = map.delete("example") <: None
     @assert = try map["example"]! <: None
-    @assert = map.has_key("example").not
+    assert map.has_key("example").is_false
     @assert = map.size == 0
 
   :it "can be cleared, removing all keys and values"
@@ -58,14 +58,14 @@
     count = USize[0]
     key = ""
     found_it = map.each_until -> (k, v | count += 1, key = k, v == 22)
-    @assert = found_it
+    assert found_it
     @assert = count == 2
     @assert = key == "bar"
 
     count = USize[0]
     key = ""
     found_it = map.each_until -> (k, v | count += 1, key = k, v == 33)
-    @assert = found_it
+    assert found_it
     @assert = count == 3
     @assert = key == "baz"
 
@@ -74,4 +74,4 @@
     found_it = map.each_until -> (k, v | count += 1, key = k, v == 99)
     @assert = count == 3
     @assert = key == "baz"
-    @assert = found_it.not
+    assert found_it.is_false

--- a/packages/json/test/json_parser_spec.savi
+++ b/packages/json/test/json_parser_spec.savi
@@ -5,103 +5,103 @@
   :const describes: "JsonParser"
 
   :it "parses keywords"
-    @assert = @example("null", <<<
+    assert @example("null", <<<
       [JsonTokenNull, 0, 4, 0, 0.0, ""]
     >>>)
-    @assert = @example("true", <<<
+    assert @example("true", <<<
       [JsonTokenTrue, 0, 4, 0, 0.0, ""]
     >>>)
-    @assert = @example("false", <<<
+    assert @example("false", <<<
       [JsonTokenFalse, 0, 5, 0, 0.0, ""]
     >>>)
-    @assert = @example(" \t\nnull\n\t ", <<<
+    assert @example(" \t\nnull\n\t ", <<<
       [JsonTokenNull, 3, 7, 0, 0.0, ""]
     >>>)
 
-    @assert = @example_error("nugget",    "nu")
-    @assert = @example_error("truth",     "tru")
-    @assert = @example_error("falsehood", "false")
-    @assert = @example_error("bogus",     "")
+    assert @example_error("nugget",    "nu")
+    assert @example_error("truth",     "tru")
+    assert @example_error("falsehood", "false")
+    assert @example_error("bogus",     "")
 
   :it "parses numbers"
-    @assert = @example("123", <<<
+    assert @example("123", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 3, 123, 0.0, ""]
     >>>)
-    @assert = @example("-123", <<<
+    assert @example("-123", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 4, -123, 0.0, ""]
     >>>)
-    @assert = @example("123.456", <<<
+    assert @example("123.456", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 7, 0, 123.456, ""]
     >>>)
-    @assert = @example("-123.456", <<<
+    assert @example("-123.456", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 8, 0, -123.456, ""]
     >>>)
-    @assert = @example("123e2", <<<
+    assert @example("123e2", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 5, 0, 12300, ""]
     >>>)
-    @assert = @example("-123e-2", <<<
+    assert @example("-123e-2", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 7, 0, -1.23, ""]
     >>>)
-    @assert = @example("-123.456e2", <<<
+    assert @example("-123.456e2", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 10, 0, -12345.6, ""]
     >>>)
-    @assert = @example("-123.4e-2", <<<
+    assert @example("-123.4e-2", <<<
       [JsonTokenNumberPre, 0, 0, 0, 0.0, ""]
       [JsonTokenNumber, 0, 9, 0, -1.234, ""]
     >>>)
 
-    @assert = @example_error("---",             "-")
-    @assert = @example_error("123456789ABCDEF", "123456789")
-    @assert = @example_error("0x0",             "0")
-    @assert = @example_error("123...",          "123.")
-    @assert = @example_error("123.",            "123.")
-    @assert = @example_error("127.0.0.1",       "127.0")
-    @assert = @example_error("5eed",            "5e")
-    @assert = @example_error("5e---",           "5e-")
-    @assert = @example_error("5e",              "5e")
-    @assert = @example_error("1.2e3.4",         "1.2e3")
-    @assert = @example_error(" 1 2 3 ",         " 1 ")
+    assert @example_error("---",             "-")
+    assert @example_error("123456789ABCDEF", "123456789")
+    assert @example_error("0x0",             "0")
+    assert @example_error("123...",          "123.")
+    assert @example_error("123.",            "123.")
+    assert @example_error("127.0.0.1",       "127.0")
+    assert @example_error("5eed",            "5e")
+    assert @example_error("5e---",           "5e-")
+    assert @example_error("5e",              "5e")
+    assert @example_error("1.2e3.4",         "1.2e3")
+    assert @example_error(" 1 2 3 ",         " 1 ")
 
   :it "parses strings"
-    @assert = @example(<<<"apple">>>, <<<
+    assert @example(<<<"apple">>>, <<<
       [JsonTokenStringPre, 1, 1, 0, 0.0, ""]
       [JsonTokenString, 1, 6, 0, 0.0, "apple"]
     >>>)
-    @assert = @example("                    \"apple\"   ", <<<
+    assert @example("                    \"apple\"   ", <<<
       [JsonTokenStringPre, 21, 21, 0, 0.0, ""]
       [JsonTokenString, 21, 26, 0, 0.0, "apple"]
     >>>)
-    @assert = @example("                    \"\"   ", <<<
+    assert @example("                    \"\"   ", <<<
       [JsonTokenStringPre, 21, 21, 0, 0.0, ""]
       [JsonTokenString, 21, 21, 0, 0.0, ""]
     >>>)
 
-    @assert = @example_error(" \" ",                       " \" ")
-    @assert = @example_error(" \"apple",                   " \"apple")
-    @assert = @example_error(" \"\\\"",                    " \"\\\"")
-    @assert = @example_error(" \"\\urge\" ",               " \"\\u")
-    @assert = @example_error(" \"\\u123\" ",               " \"\\u123")
-    @assert = @example_error(" \"\\ud800\\n\" ",           " \"\\ud800\\")
-    @assert = @example_error(" \"apple \\ud800 banana\" ", " \"apple \\ud800")
-    @assert = @example_error(" \"\\ud800\\ud800\" ",       " \"\\ud800\\u")
+    assert @example_error(" \" ",                       " \" ")
+    assert @example_error(" \"apple",                   " \"apple")
+    assert @example_error(" \"\\\"",                    " \"\\\"")
+    assert @example_error(" \"\\urge\" ",               " \"\\u")
+    assert @example_error(" \"\\u123\" ",               " \"\\u123")
+    assert @example_error(" \"\\ud800\\n\" ",           " \"\\ud800\\")
+    assert @example_error(" \"apple \\ud800 banana\" ", " \"apple \\ud800")
+    assert @example_error(" \"\\ud800\\ud800\" ",       " \"\\ud800\\u")
 
   :it "parses arrays"
-    @assert = @example("[]", <<<
+    assert @example("[]", <<<
       [JsonTokenArrayStart, 0, 1, 0, 0.0, ""]
       [JsonTokenArrayEnd, 1, 2, 0, 0.0, ""]
     >>>)
-    @assert = @example("  [  ]  ", <<<
+    assert @example("  [  ]  ", <<<
       [JsonTokenArrayStart, 2, 3, 0, 0.0, ""]
       [JsonTokenArrayEnd, 5, 6, 0, 0.0, ""]
     >>>)
-    @assert = @example("[1,2,3]", <<<
+    assert @example("[1,2,3]", <<<
       [JsonTokenArrayStart, 0, 1, 0, 0.0, ""]
       [JsonTokenNumberPre, 1, 1, 0, 0.0, ""]
       [JsonTokenNumber, 1, 2, 1, 0.0, ""]
@@ -111,7 +111,7 @@
       [JsonTokenNumber, 5, 6, 3, 0.0, ""]
       [JsonTokenArrayEnd, 6, 7, 3, 0.0, ""]
     >>>)
-    @assert = @example("  [  1  ,  2  ,  3  ]  ", <<<
+    assert @example("  [  1  ,  2  ,  3  ]  ", <<<
       [JsonTokenArrayStart, 2, 3, 0, 0.0, ""]
       [JsonTokenNumberPre, 5, 5, 0, 0.0, ""]
       [JsonTokenNumber, 5, 6, 1, 0.0, ""]
@@ -121,7 +121,7 @@
       [JsonTokenNumber, 17, 18, 3, 0.0, ""]
       [JsonTokenArrayEnd, 20, 21, 3, 0.0, ""]
     >>>)
-    @assert = @example("[[[true]]]", <<<
+    assert @example("[[[true]]]", <<<
       [JsonTokenArrayStart, 0, 1, 0, 0.0, ""]
       [JsonTokenArrayStart, 1, 2, 0, 0.0, ""]
       [JsonTokenArrayStart, 2, 3, 0, 0.0, ""]
@@ -131,22 +131,22 @@
       [JsonTokenArrayEnd, 9, 10, 0, 0.0, ""]
     >>>)
 
-    @assert = @example_error("]]]",                   "")
-    @assert = @example_error("[[[",                   "[[[")
-    @assert = @example_error("[1,,,]",                "[1,")
-    @assert = @example_error("[1,2,3}",               "[1,2,3")
-    @assert = @example_error(<<<["fruit":"apple"]>>>, <<<["fruit">>>)
+    assert @example_error("]]]",                   "")
+    assert @example_error("[[[",                   "[[[")
+    assert @example_error("[1,,,]",                "[1,")
+    assert @example_error("[1,2,3}",               "[1,2,3")
+    assert @example_error(<<<["fruit":"apple"]>>>, <<<["fruit">>>)
 
   :it "parses objects"
-    @assert = @example("{}", <<<
+    assert @example("{}", <<<
       [JsonTokenObjectStart, 0, 1, 0, 0.0, ""]
       [JsonTokenObjectEnd, 1, 2, 0, 0.0, ""]
     >>>)
-    @assert = @example("  {  }  ", <<<
+    assert @example("  {  }  ", <<<
       [JsonTokenObjectStart, 2, 3, 0, 0.0, ""]
       [JsonTokenObjectEnd, 5, 6, 0, 0.0, ""]
     >>>)
-    @assert = @example(<<<{"fruit":"apple","edible":true}>>>, <<<
+    assert @example(<<<{"fruit":"apple","edible":true}>>>, <<<
       [JsonTokenObjectStart, 0, 1, 0, 0.0, ""]
       [JsonTokenKeyPre, 2, 2, 0, 0.0, ""]
       [JsonTokenKey, 2, 7, 0, 0.0, "fruit"]
@@ -159,7 +159,7 @@
       [JsonTokenPairPost, 30, 30, 0, 0.0, "edible"]
       [JsonTokenObjectEnd, 30, 31, 0, 0.0, "edible"]
     >>>)
-    @assert = @example(<<<  {  "a"  :  1  ,  "b"  :  2  }  >>>, <<<
+    assert @example(<<<  {  "a"  :  1  ,  "b"  :  2  }  >>>, <<<
       [JsonTokenObjectStart, 2, 3, 0, 0.0, ""]
       [JsonTokenKeyPre, 6, 6, 0, 0.0, ""]
       [JsonTokenKey, 6, 7, 0, 0.0, "a"]
@@ -173,7 +173,7 @@
       [JsonTokenPairPost, 30, 30, 2, 0.0, "b"]
       [JsonTokenObjectEnd, 30, 31, 2, 0.0, "b"]
     >>>)
-    @assert = @example(<<<{"t":[{"e":[{"s":[{"t":[]}]}]}]}>>>, <<<
+    assert @example(<<<{"t":[{"e":[{"s":[{"t":[]}]}]}]}>>>, <<<
       [JsonTokenObjectStart, 0, 1, 0, 0.0, ""]
       [JsonTokenKeyPre, 2, 2, 0, 0.0, ""]
       [JsonTokenKey, 2, 3, 0, 0.0, "t"]
@@ -204,12 +204,12 @@
       [JsonTokenObjectEnd, 31, 32, 0, 0.0, "t"]
     >>>)
 
-    @assert = @example_error("}}}",                    "")
-    @assert = @example_error("{{{",                    "{")
-    @assert = @example_error(<<<{"a":1,,,"b":2}>>>,    <<<{"a":1,>>>)
-    @assert = @example_error(<<<{"a":{"b":>>>,         <<<{"a":{"b":>>>)
-    @assert = @example_error(<<<{"a":1,"b":2]>>>,      <<<{"a":1,"b":2>>>)
-    @assert = @example_error(<<<{"apple","edible"}>>>, <<<{"apple">>>)
+    assert @example_error("}}}",                    "")
+    assert @example_error("{{{",                    "{")
+    assert @example_error(<<<{"a":1,,,"b":2}>>>,    <<<{"a":1,>>>)
+    assert @example_error(<<<{"a":{"b":>>>,         <<<{"a":{"b":>>>)
+    assert @example_error(<<<{"a":1,"b":2]>>>,      <<<{"a":1,"b":2>>>)
+    assert @example_error(<<<{"apple","edible"}>>>, <<<{"apple">>>)
 
   :fun example(source String, expected String) Bool
     collector = _TestJsonParserCollector.new

--- a/packages/json/test/json_reader_spec.savi
+++ b/packages/json/test/json_reader_spec.savi
@@ -31,7 +31,7 @@
       )
     )
 
-    @assert = read.errors.is_empty
+    assert read.errors.is_empty
 
     @assert = try (users[0]!.name == "Alice" | False)
     @assert = try (users[0]!.admin == True | False)

--- a/packages/regex/test/regex_spec.savi
+++ b/packages/regex/test/regex_spec.savi
@@ -6,75 +6,75 @@
 
   :it "matches any character with `.`"
     regex = Regex.compile("a.c")
-    @assert = regex.matches("a").not
-    @assert = regex.matches("ac").not
-    @assert = regex.matches("a c")
-    @assert = regex.matches("abc")
-    @assert = regex.matches("abbc").not
-    @assert = regex.matches("abbbc").not
+    assert regex.matches("a").is_false
+    assert regex.matches("ac").is_false
+    assert regex.matches("a c")
+    assert regex.matches("abc")
+    assert regex.matches("abbc").is_false
+    assert regex.matches("abbbc").is_false
 
   :it "matches an optional character zero or one time with `?`"
     regex = Regex.compile("ab?c")
-    @assert = regex.matches("a").not
-    @assert = regex.matches("ac")
-    @assert = regex.matches("a c").not
-    @assert = regex.matches("abc")
-    @assert = regex.matches("abbc").not
-    @assert = regex.matches("abbbc").not
+    assert regex.matches("a").is_false
+    assert regex.matches("ac")
+    assert regex.matches("a c").is_false
+    assert regex.matches("abc")
+    assert regex.matches("abbc").is_false
+    assert regex.matches("abbbc").is_false
 
   :it "matches a character repeated zero or more times with `*`"
     regex = Regex.compile("ab*c")
-    @assert = regex.matches("a").not
-    @assert = regex.matches("ac")
-    @assert = regex.matches("a c").not
-    @assert = regex.matches("abc")
-    @assert = regex.matches("abbc")
-    @assert = regex.matches("abbbc")
+    assert regex.matches("a").is_false
+    assert regex.matches("ac")
+    assert regex.matches("a c").is_false
+    assert regex.matches("abc")
+    assert regex.matches("abbc")
+    assert regex.matches("abbbc")
 
   :it "matches a character repeated one or more times with `+`"
     regex = Regex.compile("ab+c")
-    @assert = regex.matches("a").not
-    @assert = regex.matches("ac").not
-    @assert = regex.matches("a c").not
-    @assert = regex.matches("abc")
-    @assert = regex.matches("abbc")
-    @assert = regex.matches("abbbc")
+    assert regex.matches("a").is_false
+    assert regex.matches("ac").is_false
+    assert regex.matches("a c").is_false
+    assert regex.matches("abc")
+    assert regex.matches("abbc")
+    assert regex.matches("abbbc")
 
   :it "matches one of several choices with `|`"
     regex = Regex.compile("abc|jkl|xyz")
-    @assert = regex.matches("abc")
-    @assert = regex.matches("ab").not
-    @assert = regex.matches("jkl")
-    @assert = regex.matches("kl").not
-    @assert = regex.matches("xyz")
-    @assert = regex.matches("xz").not
+    assert regex.matches("abc")
+    assert regex.matches("ab").is_false
+    assert regex.matches("jkl")
+    assert regex.matches("kl").is_false
+    assert regex.matches("xyz")
+    assert regex.matches("xz").is_false
 
     // Internally, a choice of 2 is a special case, so we test it separately.
     regex = Regex.compile("abc|jkl")
-    @assert = regex.matches("abc")
-    @assert = regex.matches("ab").not
-    @assert = regex.matches("jkl")
-    @assert = regex.matches("kl").not
-    @assert = regex.matches("xyz").not
-    @assert = regex.matches("xz").not
+    assert regex.matches("abc")
+    assert regex.matches("ab").is_false
+    assert regex.matches("jkl")
+    assert regex.matches("kl").is_false
+    assert regex.matches("xyz").is_false
+    assert regex.matches("xz").is_false
 
   :it "matches any digit with `\d`"
     regex = Regex.compile("a\dc")
-    @assert = regex.matches("a").not
-    @assert = regex.matches("ac").not
-    @assert = regex.matches("a c").not
-    @assert = regex.matches("abc").not
-    @assert = regex.matches("a0c")
-    @assert = regex.matches("a9c")
+    assert regex.matches("a").is_false
+    assert regex.matches("ac").is_false
+    assert regex.matches("a c").is_false
+    assert regex.matches("abc").is_false
+    assert regex.matches("a0c")
+    assert regex.matches("a9c")
 
   :it "matches any ASCII word character with `\w`"
     regex = Regex.compile("a\wc")
-    @assert = regex.matches("a").not
-    @assert = regex.matches("ac").not
-    @assert = regex.matches("a c").not
-    @assert = regex.matches("a_c")
-    @assert = regex.matches("abc")
-    @assert = regex.matches("a0c")
-    @assert = regex.matches("a9c")
-    @assert = regex.matches("aBc")
-    @assert = regex.matches("ABC").not
+    assert regex.matches("a").is_false
+    assert regex.matches("ac").is_false
+    assert regex.matches("a c").is_false
+    assert regex.matches("a_c")
+    assert regex.matches("abc")
+    assert regex.matches("a0c")
+    assert regex.matches("a9c")
+    assert regex.matches("aBc")
+    assert regex.matches("ABC").is_false

--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -29,13 +29,13 @@
   :is Assert2
 
   :fun report_failure(env Env) None
-    row = Inspect[@pos.row + 1]
+    line = Inspect[@pos.row + 1]
 
     env.err.write("\n")
     env.err.print(String.join([
       "    Expected the following to be True:"
       String.join(["    ", @pos.string, "\n"])
-      String.join(["    # ", @pos.filename, ":", row])
+      String.join(["    # ", @pos.filename, ":", line])
     ], "\n"))
 
     None

--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -1,0 +1,41 @@
+:primitive Assert
+  :fun non condition(
+    spec Spec
+    success Bool
+    pos SourceCodePosition = source_code_position_of_argument success
+  )
+    test = spec.test
+    assert = AssertCondition.new(test.spec, test.example, success, pos)
+    test.specs.enqueue(assert)
+
+// TODO: traits don't yet generate a singleton object
+// so we keep `:class Assert` as our singleton for the macro's call
+// and use Assert2 to sub-type `AssertCondition` and `AssertRelation`.
+//
+// We'll merge Assert and Assert2 once a `:trait` can be used as a singleton.
+:trait val Assert2
+  :let spec String
+  :let example String
+  :let success Bool
+  :let pos SourceCodePosition
+
+  :new val (@spec, @example, @success, @pos)
+
+  :: The report function will print a specific failure message \
+  :: for the different kinds of assertions.
+  :fun report_failure(env Env) None
+
+:class val AssertCondition
+  :is Assert2
+
+  :fun report_failure(env Env) None
+    row = Inspect[@pos.row + 1]
+
+    env.err.write("\n")
+    env.err.print(String.join([
+      "    Expected the following to be True:"
+      String.join(["    ", @pos.string, "\n"])
+      String.join(["    # ", @pos.filename, ":", row])
+    ], "\n"))
+
+    None

--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -9,7 +9,7 @@
     test.specs.enqueue(assert)
 
 // TODO: traits don't yet generate a singleton object
-// so we keep `:class Assert` as our singleton for the macro's call
+// so we keep `:primitive Assert` as our singleton for the macro's call
 // and use Assert2 to sub-type `AssertCondition` and `AssertRelation`.
 //
 // We'll merge Assert and Assert2 once a `:trait` can be used as a singleton.

--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -1,19 +1,4 @@
-:primitive Assert
-  :fun non condition(
-    spec Spec
-    success Bool
-    pos SourceCodePosition = source_code_position_of_argument success
-  )
-    test = spec.test
-    assert = AssertCondition.new(test.spec, test.example, success, pos)
-    test.specs.enqueue(assert)
-
-// TODO: traits don't yet generate a singleton object
-// so we keep `:primitive Assert` as our singleton for the macro's call
-// and use Assert2 to sub-type `AssertCondition` and `AssertRelation`.
-//
-// We'll merge Assert and Assert2 once a `:trait` can be used as a singleton.
-:trait val Assert2
+:trait val Assert
   :let spec String
   :let example String
   :let success Bool
@@ -25,8 +10,17 @@
   :: for the different kinds of assertions.
   :fun report_failure(env Env) None
 
+  :fun non condition(
+    spec Spec
+    success Bool
+    pos SourceCodePosition = source_code_position_of_argument success
+  )
+    test = spec.test
+    assert = AssertCondition.new(test.spec, test.example, success, pos)
+    test.specs.enqueue(assert)
+
 :class val AssertCondition
-  :is Assert2
+  :is Assert
 
   :fun report_failure(env Env) None
     line = Inspect[@pos.row + 1]

--- a/packages/spec/spec_reporter.savi
+++ b/packages/spec/spec_reporter.savi
@@ -48,13 +48,20 @@
     if (skip) (@env.err.print(" SKIP") | @env.err.print(" OK"))
 
   :fun ref event(spec String, example String, event SpecEventAssert)
+    // TODO: We shouldn't need this variable, but using `event.assert` in the `if` fails compilation.
+    assert = event.assert
+
     if event.success (
       @env.err.write(".")
     |
-      @env.err.write("\n")
-      @env.err.write(Inspect[event.pos.row + 1])
-      @env.err.write(": FAIL: ")
-      @env.err.print(event.pos.string)
+      if (assert <: Assert2) (
+        assert.report_failure(@env)
+      |
+        @env.err.write("\n")
+        @env.err.write(Inspect[event.pos.row + 1])
+        @env.err.write(": FAIL: ")
+        @env.err.print(event.pos.string)
+      )
     )
 
 :class SpecReporterLinear

--- a/packages/spec/spec_reporter.savi
+++ b/packages/spec/spec_reporter.savi
@@ -48,14 +48,11 @@
     if (skip) (@env.err.print(" SKIP") | @env.err.print(" OK"))
 
   :fun ref event(spec String, example String, event SpecEventAssert)
-    // TODO: We shouldn't need this variable, but using `event.assert` in the `if` fails compilation.
-    assert = event.assert
-
     if event.success (
       @env.err.write(".")
     |
-      if (assert <: Assert) (
-        assert.report_failure(@env)
+      try (
+        event.assert.as!(Assert).report_failure(@env)
       |
         @env.err.write("\n")
         @env.err.write(Inspect[event.pos.row + 1])

--- a/packages/spec/spec_reporter.savi
+++ b/packages/spec/spec_reporter.savi
@@ -54,7 +54,7 @@
     if event.success (
       @env.err.write(".")
     |
-      if (assert <: Assert2) (
+      if (assert <: Assert) (
         assert.report_failure(@env)
       |
         @env.err.write("\n")

--- a/packages/spec/spec_status.savi
+++ b/packages/spec/spec_status.savi
@@ -19,9 +19,9 @@
 :class val SpecEventAssert
   :let success Bool
   :let pos SourceCodePosition
-  :let assert (Assert2 | None)
+  :let assert (Assert | None)
 
   // TODO: refactor into the line below after #102 is fixed.
   // :new (@success, @pos, @assert = None)
-  :new (@success, @pos, assert (Assert2 | None) = None)
+  :new (@success, @pos, assert (Assert | None) = None)
     @assert = assert

--- a/packages/spec/spec_status.savi
+++ b/packages/spec/spec_status.savi
@@ -19,4 +19,9 @@
 :class val SpecEventAssert
   :let success Bool
   :let pos SourceCodePosition
-  :new (@success, @pos)
+  :let assert (Assert2 | None)
+
+  // TODO: refactor into the line below after #102 is fixed.
+  // :new (@success, @pos, @assert = None)
+  :new (@success, @pos, assert (Assert2 | None) = None)
+    @assert = assert

--- a/packages/spec/specs.savi
+++ b/packages/spec/specs.savi
@@ -83,3 +83,24 @@
     |
       Specs._bug(@env, "assert before the example_began and/or spec_began")
     )
+
+  // TODO: This behavior is a copy of the `:be assert` above.
+  // I added it to keep `@assert =` working while implementing the `assert` macro.
+  // In the end we won't need both of them, after we clean up `@assert =`.
+  :be enqueue(assert Assert2)
+    spec = assert.spec
+    example = assert.example
+    success = assert.success
+
+    // TODO: refactor to `SpecEventAssert.new(assert)`
+    event = SpecEventAssert.new(success, assert.pos, assert)
+
+    // If it was a failed assertion, mark the entire process as a failure.
+    if !success Specs._fail(@env)
+
+    try (
+      @statuses[spec]!.examples[example]!.events << event
+      @reporter.event(spec, example, event)
+    |
+      Specs._bug(@env, "assert before the example_began and/or spec_began")
+    )

--- a/packages/spec/specs.savi
+++ b/packages/spec/specs.savi
@@ -87,7 +87,7 @@
   // TODO: This behavior is a copy of the `:be assert` above.
   // I added it to keep `@assert =` working while implementing the `assert` macro.
   // In the end we won't need both of them, after we clean up `@assert =`.
-  :be enqueue(assert Assert2)
+  :be enqueue(assert Assert)
     spec = assert.spec
     example = assert.example
     success = assert.success

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -15,6 +15,6 @@
     assert False.is_false
     assert \
       True
-    assert Foo.with_yield -> ( false |
+    assert Foo.with_yield -> (false |
       assert !false
     )

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -1,0 +1,11 @@
+:class Foo
+  :fun non true: True
+
+:class AssertSpec
+  :is Spec
+  :const describes: "Assert"
+
+  :it "conforms to the assert macro"
+    assert True
+    assert Foo.true
+

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -1,11 +1,20 @@
 :class Foo
   :fun non true: True
+  :fun non with_yield Bool
+    yield False
+    True
 
 :class AssertSpec
   :is Spec
   :const describes: "Assert"
 
-  :it "conforms to the assert macro"
+  :it "conforms to the `assert EXPR` macro"
     assert True
     assert Foo.true
-
+    assert (True == Foo.true)
+    assert False.is_false
+    assert \
+      True
+    assert Foo.with_yield -> ( false |
+      assert !false
+    )

--- a/packages/spec/test/main.savi
+++ b/packages/spec/test/main.savi
@@ -1,0 +1,7 @@
+:source ".."
+
+:actor Main
+  :new (env)
+    Specs.run(env, [
+      SpecRun(AssertSpec).new(env)
+    ])

--- a/packages/time/test/time_spec.savi
+++ b/packages/time/test/time_spec.savi
@@ -35,27 +35,27 @@
     later = now + Time.hours(12)
     @assert = now < later
     @assert = now <= later
-    @assert = (now == later).not
-    @assert = (now >= later).not
-    @assert = (now > later).not
-    @assert = (later < now).not
-    @assert = (later <= now).not
-    @assert = (later == now).not
+    assert (now == later).is_false
+    assert (now >= later).is_false
+    assert (now > later).is_false
+    assert (later < now).is_false
+    assert (later <= now).is_false
+    assert (later == now).is_false
     @assert = later >= now
     @assert = later > now
-    @assert = (now < now).not
+    assert (now < now).is_false
     @assert = now <= now
     @assert = now == now
     @assert = now >= now
-    @assert = (now > now).not
+    assert (now > now).is_false
     @assert = now < soon
     @assert = now <= soon
-    @assert = (now == soon).not
-    @assert = (now >= soon).not
-    @assert = (now > soon).not
-    @assert = (soon < now).not
-    @assert = (soon <= now).not
-    @assert = (soon == now).not
+    assert (now == soon).is_false
+    assert (now >= soon).is_false
+    assert (now > soon).is_false
+    assert (soon < now).is_false
+    assert (soon <= now).is_false
+    assert (soon == now).is_false
     @assert = soon >= now
     @assert = soon > now
 

--- a/spec/compiler/macros/assertion_spec.cr
+++ b/spec/compiler/macros/assertion_spec.cr
@@ -1,0 +1,24 @@
+describe Savi::Compiler::Macros do
+  describe "assert" do
+    it "is transformed into Assert.condition" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new
+          assert True
+      SOURCE
+
+      ctx = Savi.compiler.compile([source], :macros)
+      ctx.errors.should be_empty
+
+      func = ctx.namespace.find_func!(ctx, source, "Main", "new")
+      func.body.not_nil!.terms.first.to_a.should eq [:group, "(", [:call,
+        [:ident, "Assert"],
+        [:ident, "condition"],
+        [:group, "(", 
+          [:ident, "@"],
+          [:ident, "True"],
+        ]
+      ]]
+    end
+  end
+end

--- a/spec/savi/prelude/array_spec.savi
+++ b/spec/savi/prelude/array_spec.savi
@@ -13,23 +13,23 @@
     data = Array(None).new
     @assert = data.space == 0
     @assert = data.size == 0
-    @assert = data.cpointer.is_null
+    assert data.cpointer.is_null
 
   :it "allocates the next highest power of two containing the requested space"
     data = Array(None).new(12)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
     data = Array(None).new(16)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
     data = Array(None).new(17)
     @assert = data.space == 32
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
   :it "won't reallocate when reserving space within the current allocation"
     data = Array(None).new(12)
@@ -38,13 +38,13 @@
     data.reserve(16)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize == orig_pointer_address
 
     data.reserve(0)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
@@ -57,7 +57,7 @@
 
     @assert = data.space == 2048
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize != orig_pointer_address
 
   :it "pushes a new element onto the end of the array and reads them back out"
@@ -95,13 +95,13 @@
   :it "can be cleared to an empty size"
     array Array(U8) = [3, 6, 12]
     @assert = array.size == 3
-    @assert = array.is_empty.not
-    @assert = array.is_not_empty
+    assert array.is_empty.not
+    assert array.is_not_empty
 
     array.clear
     @assert = array.size == 0
-    @assert = array.is_empty
-    @assert = array.is_not_empty.not
+    assert array.is_empty
+    assert array.is_not_empty.not
     @assert = try (array[0]!, False | True)
 
   :it "compares equality for the elements in the array"
@@ -125,28 +125,28 @@
     @assert = array.clone.size == 0
 
   :it "returns True if the given element is equal to one already in the array"
-    @assert = ["foo", "bar", "baz"].includes("foo")
-    @assert = ["foo", "bar", "baz"].includes("f").not
+    assert ["foo", "bar", "baz"].includes("foo")
+    assert ["foo", "bar", "baz"].includes("f").is_false
 
   :it "replaces via a yield block the element at the given index, if it exists"
     array Array(String) = ["foo", "bar", "baz"]
 
-    @assert = True == array.try_replace_at(1) -> (element |
+    assert array.try_replace_at(1) -> (element |
       @assert = element == "bar"
       "BAR"
     )
-    @assert = False == array.try_replace_at(3) -> (element |
-      @assert = False // assert that this block should never run
+    assert array.try_replace_at(3) -> (element |
+      assert False // assert that this block should never run
       "NOPE"
-    )
+    ).is_false
 
     @assert = array == ["foo", "BAR", "baz"]
 
   :it "returns True if the given element is pointer-identical to one in the array"
     opaque_1 = ArraySpecOpaqueObject.new
     opaque_2 = ArraySpecOpaqueObject.new
-    @assert = [opaque_1].includes(opaque_1)
-    @assert = [opaque_1].includes(opaque_2).not
+    assert [opaque_1].includes(opaque_1)
+    assert [opaque_1].includes(opaque_2).is_false
 
   :it "yields each element in the array, along with the index"
     array_a Array(String) = []

--- a/spec/savi/prelude/array_spec.savi
+++ b/spec/savi/prelude/array_spec.savi
@@ -95,13 +95,13 @@
   :it "can be cleared to an empty size"
     array Array(U8) = [3, 6, 12]
     @assert = array.size == 3
-    assert array.is_empty.not
+    assert array.is_empty.is_false
     assert array.is_not_empty
 
     array.clear
     @assert = array.size == 0
     assert array.is_empty
-    assert array.is_not_empty.not
+    assert array.is_not_empty.is_false
     @assert = try (array[0]!, False | True)
 
   :it "compares equality for the elements in the array"

--- a/spec/savi/prelude/bytes_spec.savi
+++ b/spec/savi/prelude/bytes_spec.savi
@@ -8,23 +8,23 @@
     data = Bytes.new
     @assert = data.space == 0
     @assert = data.size == 0
-    @assert = data.cpointer.is_null
+    assert data.cpointer.is_null
 
   :it "allocates the next highest power of two containing the requested space"
     data = Bytes.new(12)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
     data = Bytes.new(16)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
     data = Bytes.new(17)
     @assert = data.space == 32
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
   :it "won't reallocate when reserving space within the current allocation"
     data = Bytes.new(12)
@@ -33,13 +33,13 @@
     data.reserve(16)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize == orig_pointer_address
 
     data.reserve(0)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
@@ -52,7 +52,7 @@
 
     @assert = data.space == 2048
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize != orig_pointer_address
 
   :it "can expand size to expose uninitialized bytes within the space available"
@@ -85,63 +85,63 @@
 
   :it "compares bytewise equality with another bytes string"
     @assert = (b"string" == b"string")
-    @assert = (b"string" == b"other").not
+    assert (b"string" == b"other").is_false
 
   :it "checks if it starts with a substring equal to the other bytes string"
-    @assert = b"foo".starts_with(b"foo")
-    @assert = b"foo".starts_with(b"food").not
-    @assert = b"food".starts_with(b"foo")
-    @assert = b"barfood".starts_with(b"foo").not
-    @assert = b"barfood".starts_with(b"barf")
-    @assert = b"barfood".starts_with(b"")
+    assert b"foo".starts_with(b"foo")
+    assert b"foo".starts_with(b"food").is_false
+    assert b"food".starts_with(b"foo")
+    assert b"barfood".starts_with(b"foo").is_false
+    assert b"barfood".starts_with(b"barf")
+    assert b"barfood".starts_with(b"")
 
   :it "checks if it ends with a substring equal to the other bytes string"
-    @assert = b"food".ends_with(b"foo").not
-    @assert = b"foo".ends_with(b"foo")
-    @assert = b"foo".ends_with(b"food").not
-    @assert = b"snafoo".ends_with(b"foo")
-    @assert = b"snafoozled".ends_with(b"foo").not
-    @assert = b"snafoozled".ends_with(b"")
+    assert b"food".ends_with(b"foo").is_false
+    assert b"foo".ends_with(b"foo")
+    assert b"foo".ends_with(b"food").is_false
+    assert b"snafoo".ends_with(b"foo")
+    assert b"snafoozled".ends_with(b"foo").is_false
+    assert b"snafoozled".ends_with(b"")
 
   :it "checks for a common slice with another bytes string at specific offsets"
-    @assert = b"foodbar".is_slice_equal(1, b"broodbard", 2, 6)
-    @assert = b"foodbar".is_slice_equal(1, b"broodbard", 2, 5)
-    @assert = b"foodbar".is_slice_equal(2, b"broodbard", 2, 5).not
-    @assert = b"foodbar".is_slice_equal(1, b"broodbard", 2, 7).not
-    @assert = b"foodbar".is_slice_equal(1, b"broodbard", 1, 6).not
-    @assert = b"foodbar".is_slice_equal(0, b"broodbard", 1, 6).not
-    @assert = b"broodbard".is_slice_equal(2, b"foodbar", 1, 6)
-    @assert = b"broodbard".is_slice_equal(2, b"foodbar", 1, 5)
-    @assert = b"broodbard".is_slice_equal(2, b"foodbar", 2, 5).not
-    @assert = b"broodbard".is_slice_equal(2, b"foodbar", 1, 7).not
-    @assert = b"broodbard".is_slice_equal(1, b"foodbar", 1, 6).not
-    @assert = b"broodbard".is_slice_equal(1, b"foodbar", 0, 6).not
+    assert b"foodbar".is_slice_equal(1, b"broodbard", 2, 6)
+    assert b"foodbar".is_slice_equal(1, b"broodbard", 2, 5)
+    assert b"foodbar".is_slice_equal(2, b"broodbard", 2, 5).is_false
+    assert b"foodbar".is_slice_equal(1, b"broodbard", 2, 7).is_false
+    assert b"foodbar".is_slice_equal(1, b"broodbard", 1, 6).is_false
+    assert b"foodbar".is_slice_equal(0, b"broodbard", 1, 6).is_false
+    assert b"broodbard".is_slice_equal(2, b"foodbar", 1, 6)
+    assert b"broodbard".is_slice_equal(2, b"foodbar", 1, 5)
+    assert b"broodbard".is_slice_equal(2, b"foodbar", 2, 5).is_false
+    assert b"broodbard".is_slice_equal(2, b"foodbar", 1, 7).is_false
+    assert b"broodbard".is_slice_equal(1, b"foodbar", 1, 6).is_false
+    assert b"broodbard".is_slice_equal(1, b"foodbar", 0, 6).is_false
 
   :it "checks for a common slice with another string at specific offsets"
-    @assert = b"foodbar".is_slice_equal(1, "broodbard", 2, 6)
-    @assert = b"foodbar".is_slice_equal(1, "broodbard", 2, 5)
-    @assert = b"foodbar".is_slice_equal(2, "broodbard", 2, 5).not
-    @assert = b"foodbar".is_slice_equal(1, "broodbard", 2, 7).not
-    @assert = b"foodbar".is_slice_equal(1, "broodbard", 1, 6).not
-    @assert = b"foodbar".is_slice_equal(0, "broodbard", 1, 6).not
-    @assert = b"broodbard".is_slice_equal(2, "foodbar", 1, 6)
-    @assert = b"broodbard".is_slice_equal(2, "foodbar", 1, 5)
-    @assert = b"broodbard".is_slice_equal(2, "foodbar", 2, 5).not
-    @assert = b"broodbard".is_slice_equal(2, "foodbar", 1, 7).not
-    @assert = b"broodbard".is_slice_equal(1, "foodbar", 1, 6).not
-    @assert = b"broodbard".is_slice_equal(1, "foodbar", 0, 6).not
+    assert b"foodbar".is_slice_equal(1, "broodbard", 2, 6)
+    assert b"foodbar".is_slice_equal(1, "broodbard", 2, 5)
+    assert b"foodbar".is_slice_equal(2, "broodbard", 2, 5).is_false
+    assert b"foodbar".is_slice_equal(1, "broodbard", 2, 7).is_false
+    assert b"foodbar".is_slice_equal(1, "broodbard", 1, 6).is_false
+    assert b"foodbar".is_slice_equal(0, "broodbard", 1, 6).is_false
+    assert b"broodbard".is_slice_equal(2, "foodbar", 1, 6)
+    assert b"broodbard".is_slice_equal(2, "foodbar", 1, 5)
+    assert b"broodbard".is_slice_equal(2, "foodbar", 2, 5).is_false
+    assert b"broodbard".is_slice_equal(2, "foodbar", 1, 7).is_false
+    assert b"broodbard".is_slice_equal(1, "foodbar", 1, 6).is_false
+    assert b"broodbard".is_slice_equal(1, "foodbar", 0, 6).is_false
 
   :it "checks if it is empty or not"
-    @assert = b"".is_empty
-    @assert = b"".is_not_empty.not
-    @assert = b"example".is_empty.not
-    @assert = b"example".is_not_empty
-    @assert = Bytes.new.is_empty
-    @assert = Bytes.new.is_not_empty.not
-    @assert = (Bytes.new << b"example").is_empty.not
-    @assert = (Bytes.new << b"example").is_not_empty
-    @assert = (Bytes.new << b"example").clear.is_empty
-    @assert = (Bytes.new << b"example").clear.is_not_empty.not
+    assert b"".is_empty
+    assert b"".is_not_empty.is_false
+    assert b"example".is_empty.is_false
+    assert b"example".is_not_empty
+    assert Bytes.new.is_empty
+    assert Bytes.new.is_not_empty.is_false
+    assert (Bytes.new << b"example").is_empty.is_false
+    assert (Bytes.new << b"example").is_not_empty
+    assert (Bytes.new << b"example").clear.is_empty
+    assert (Bytes.new << b"example").clear.is_not_empty.is_false
 
   :it "clones itself into a new bytes buffer"
     string Bytes = b"example"
@@ -152,10 +152,10 @@
     @assert = try (b"bar food foo".offset_of!(b"bard"), False | True)
     @assert = try (b"bar food foo".offset_of!(b"nope"), False | True)
     @assert = try (b"bar food foo".offset_of!(b""),     False | True)
-    @assert = b"bar food foo".includes(b"foo")
-    @assert = b"bar food foo".includes(b"bard").not
-    @assert = b"bar food foo".includes(b"nope").not
-    @assert = b"bar food foo".includes(b"").not
+    assert b"bar food foo".includes(b"foo")
+    assert b"bar food foo".includes(b"bard").is_false
+    assert b"bar food foo".includes(b"nope").is_false
+    assert b"bar food foo".includes(b"").is_false
 
   :it "hashes the bytes of the buffer"
     @assert = (b"string".hash == 0x4CF51F4A5B5CF110)
@@ -273,28 +273,28 @@
   :it "lexically compares the buffer with another buffer of the same length"
     @assert = b"examplE" < b"example"
     @assert = b"example" > b"examplE"
-    @assert = (b"example" < b"examplE").not
-    @assert = (b"examplE" > b"example").not
+    assert (b"example" < b"examplE").is_false
+    assert (b"examplE" > b"example").is_false
     @assert = b"examplE" <= b"example"
     @assert = b"example" >= b"examplE"
-    @assert = (b"example" <= b"examplE").not
-    @assert = (b"examplE" >= b"example").not
+    assert (b"example" <= b"examplE").is_false
+    assert (b"examplE" >= b"example").is_false
 
   :it "lexically compares the buffer with an identical buffer"
-    @assert = (b"example" < b"example").not
-    @assert = (b"example" > b"example").not
+    assert (b"example" < b"example").is_false
+    assert (b"example" > b"example").is_false
     @assert = b"example" <= b"example"
     @assert = b"example" >= b"example"
 
   :it "lexically compares with a nearly identical buffer of different length"
     @assert = b"example" < b"example!"
     @assert = b"example!" > b"example"
-    @assert = (b"example!" < b"example").not
-    @assert = (b"example" > b"example!").not
+    assert (b"example!" < b"example").is_false
+    assert (b"example" > b"example!").is_false
     @assert = b"example" <= b"example!"
     @assert = b"example!" >= b"example"
-    @assert = (b"example!" <= b"example").not
-    @assert = (b"example" >= b"example!").not
+    assert (b"example!" <= b"example").is_false
+    assert (b"example" >= b"example!").is_false
 
   :it "pushes, reads, and writes native integer types at specific offsets"
     data = Bytes.new

--- a/spec/savi/prelude/c_pointer_spec.savi
+++ b/spec/savi/prelude/c_pointer_spec.savi
@@ -9,5 +9,5 @@
     @assert = CPointer(U8).from_usize(0xdeadbeef).usize == 0xdeadbeef
 
   :it "tests if it is a null pointer or not"
-    @assert = CPointer(U8).null.is_null
-    @assert = CPointer(U8).null.is_not_null.not
+    assert CPointer(U8).null.is_null
+    assert CPointer(U8).null.is_not_null.is_false

--- a/spec/savi/prelude/indexable_spec.savi
+++ b/spec/savi/prelude/indexable_spec.savi
@@ -51,7 +51,7 @@
       array << string
       string == "bar"
     )
-    @assert = early_stop == True
+    assert early_stop
     @assert = array == ["foo", "bar"]
 
     array.clear
@@ -59,7 +59,7 @@
       array << string
       string == "bard"
     )
-    @assert = early_stop == False
+    assert early_stop.is_false
     @assert = array == ["foo", "bar", "baz"]
 
   :it "yields each element of a subslice, stopping early if the criteria is met"
@@ -68,7 +68,7 @@
       array << string
       string == "d"
     )
-    @assert = early_stop == True
+    assert early_stop
     @assert = array == ["b", "c", "d"]
 
     array.clear
@@ -76,7 +76,7 @@
       array << string
       string == "z"
     )
-    @assert = early_stop == False
+    assert early_stop.is_false
     @assert = array == ["b", "c", "d", "e"]
 
   :it "finds the first element that meets the criteria"

--- a/spec/savi/prelude/numeric_spec.savi
+++ b/spec/savi/prelude/numeric_spec.savi
@@ -26,32 +26,32 @@
     )
 
   :it "indicates whether the given numeric is signed or unsigned"
-    @assert = U8   .is_signed == False
-    @assert = U16  .is_signed == False
-    @assert = U32  .is_signed == False
-    @assert = U64  .is_signed == False
-    @assert = USize.is_signed == False
-    @assert = I8   .is_signed == True
-    @assert = I16  .is_signed == True
-    @assert = I32  .is_signed == True
-    @assert = I64  .is_signed == True
-    @assert = ISize.is_signed == True
-    @assert = F32  .is_signed == True
-    @assert = F64  .is_signed == True
+    assert U8   .is_signed.is_false
+    assert U16  .is_signed.is_false
+    assert U32  .is_signed.is_false
+    assert U64  .is_signed.is_false
+    assert USize.is_signed.is_false
+    assert I8   .is_signed
+    assert I16  .is_signed
+    assert I32  .is_signed
+    assert I64  .is_signed
+    assert ISize.is_signed
+    assert F32  .is_signed
+    assert F64  .is_signed
 
   :it "indicates whether the given numeric is a floating point or an integer"
-    @assert = U8   .is_floating_point == False
-    @assert = U16  .is_floating_point == False
-    @assert = U32  .is_floating_point == False
-    @assert = U64  .is_floating_point == False
-    @assert = USize.is_floating_point == False
-    @assert = I8   .is_floating_point == False
-    @assert = I16  .is_floating_point == False
-    @assert = I32  .is_floating_point == False
-    @assert = I64  .is_floating_point == False
-    @assert = ISize.is_floating_point == False
-    @assert = F32  .is_floating_point == True
-    @assert = F64  .is_floating_point == True
+    assert U8   .is_floating_point.is_false
+    assert U16  .is_floating_point.is_false
+    assert U32  .is_floating_point.is_false
+    assert U64  .is_floating_point.is_false
+    assert USize.is_floating_point.is_false
+    assert I8   .is_floating_point.is_false
+    assert I16  .is_floating_point.is_false
+    assert I32  .is_floating_point.is_false
+    assert I64  .is_floating_point.is_false
+    assert ISize.is_floating_point.is_false
+    assert F32  .is_floating_point
+    assert F64  .is_floating_point
 
   :it "exhibits wraparound behaviour for underflowing numeric literals"
     @assert = U8[-1]                    == 0xFF
@@ -86,7 +86,7 @@
     @assert = F64  .zero == 0
 
   :it "can report the max or minimum integer based on bit width and signedness"
-    @assert = Bool .max_value == True
+    assert Bool.max_value
     @assert = U8   .max_value == 0xFF
     @assert = U16  .max_value == 0xFFFF
     @assert = U32  .max_value == 0xFFFF_FFFF
@@ -103,7 +103,7 @@
       @assert = ISize.max_value == 0x7FFF_FFFF
     )
 
-    @assert = Bool .min_value == False
+    assert Bool.min_value.is_false
     @assert = U8   .min_value == 0
     @assert = U16  .min_value == 0
     @assert = U32  .min_value == 0
@@ -163,7 +163,7 @@
     @assert = F64.neg_infinity.i8 == -128
     @assert = F64[128].i8         == 127
     @assert = F64[-129].i8        == -128
-    @assert = F64.nan.f32.is_nan
+    assert F64.nan.f32.is_nan
     @assert = F64.max_value.f32   == F32.infinity
     @assert = F64.min_value.f32   == F32.neg_infinity
 
@@ -301,12 +301,12 @@
     @assert = F64.from_bits(0x400C_CCCC_CCCC_CCCD) == 3.6
     @assert = F32.nan.bits == 0x7FC0_0000
     @assert = F64.nan.bits == 0x7FF8_0000_0000_0000
-    @assert = F32.nan.is_nan
-    @assert = F64.nan.is_nan
-    @assert = F32[0].is_nan.is_false
-    @assert = F64[0].is_nan.is_false
-    @assert = (F32[0] / 0).is_nan
-    @assert = (F64[0] / 0).is_nan
+    assert F32.nan.is_nan
+    assert F64.nan.is_nan
+    assert F32[0].is_nan.is_false
+    assert F64[0].is_nan.is_false
+    assert (F32[0] / 0).is_nan
+    assert (F64[0] / 0).is_nan
     @assert = F32.infinity.bits == 0x7F80_0000
     @assert = F64.infinity.bits == 0x7FF0_0000_0000_0000
     @assert = F32.neg_infinity.bits == 0xFF80_0000
@@ -315,47 +315,47 @@
     @assert = F64.infinity == F64[1] / 0
     @assert = F32.neg_infinity == F32[-1] / 0
     @assert = F64.neg_infinity == F64[-1] / 0
-    @assert = F32.infinity.is_nan.is_false
-    @assert = F64.infinity.is_nan.is_false
-    @assert = F32.neg_infinity.is_nan.is_false
-    @assert = F64.neg_infinity.is_nan.is_false
-    @assert = F32.max_value.is_nan.is_false
-    @assert = F64.max_value.is_nan.is_false
-    @assert = F32.min_value.is_nan.is_false
-    @assert = F64.min_value.is_nan.is_false
-    @assert = F32.nan.is_infinite.is_false
-    @assert = F64.nan.is_infinite.is_false
-    @assert = F32.infinity.is_infinite
-    @assert = F64.infinity.is_infinite
-    @assert = F32.neg_infinity.is_infinite
-    @assert = F64.neg_infinity.is_infinite
-    @assert = F32.max_value.is_infinite.is_false
-    @assert = F64.max_value.is_infinite.is_false
-    @assert = F32.min_value.is_infinite.is_false
-    @assert = F64.min_value.is_infinite.is_false
-    @assert = F32.nan.is_finite.is_false
-    @assert = F64.nan.is_finite.is_false
-    @assert = F32.infinity.is_finite.is_false
-    @assert = F64.infinity.is_finite.is_false
-    @assert = F32.neg_infinity.is_finite.is_false
-    @assert = F64.neg_infinity.is_finite.is_false
-    @assert = F32.max_value.is_finite
-    @assert = F64.max_value.is_finite
-    @assert = F32.min_value.is_finite
-    @assert = F64.min_value.is_finite
-    @assert = F64.infinity.is_positive
-    @assert = F32.infinity.is_positive
-    @assert = F64.infinity.is_negative.is_false
-    @assert = F32.infinity.is_negative.is_false
-    @assert = F64.neg_infinity.is_positive.is_false
-    @assert = F32.neg_infinity.is_positive.is_false
-    @assert = F64.neg_infinity.is_negative
-    @assert = F32.neg_infinity.is_negative
-    @assert = F64[123.456].is_positive
-    @assert = F32[123.456].is_positive
-    @assert = F64[123.456].is_negative.is_false
-    @assert = F32[123.456].is_negative.is_false
-    @assert = F64[-123.456].is_positive.is_false
-    @assert = F32[-123.456].is_positive.is_false
-    @assert = F64[-123.456].is_negative
-    @assert = F32[-123.456].is_negative
+    assert F32.infinity.is_nan.is_false
+    assert F64.infinity.is_nan.is_false
+    assert F32.neg_infinity.is_nan.is_false
+    assert F64.neg_infinity.is_nan.is_false
+    assert F32.max_value.is_nan.is_false
+    assert F64.max_value.is_nan.is_false
+    assert F32.min_value.is_nan.is_false
+    assert F64.min_value.is_nan.is_false
+    assert F32.nan.is_infinite.is_false
+    assert F64.nan.is_infinite.is_false
+    assert F32.infinity.is_infinite
+    assert F64.infinity.is_infinite
+    assert F32.neg_infinity.is_infinite
+    assert F64.neg_infinity.is_infinite
+    assert F32.max_value.is_infinite.is_false
+    assert F64.max_value.is_infinite.is_false
+    assert F32.min_value.is_infinite.is_false
+    assert F64.min_value.is_infinite.is_false
+    assert F32.nan.is_finite.is_false
+    assert F64.nan.is_finite.is_false
+    assert F32.infinity.is_finite.is_false
+    assert F64.infinity.is_finite.is_false
+    assert F32.neg_infinity.is_finite.is_false
+    assert F64.neg_infinity.is_finite.is_false
+    assert F32.max_value.is_finite
+    assert F64.max_value.is_finite
+    assert F32.min_value.is_finite
+    assert F64.min_value.is_finite
+    assert F64.infinity.is_positive
+    assert F32.infinity.is_positive
+    assert F64.infinity.is_negative.is_false
+    assert F32.infinity.is_negative.is_false
+    assert F64.neg_infinity.is_positive.is_false
+    assert F32.neg_infinity.is_positive.is_false
+    assert F64.neg_infinity.is_negative
+    assert F32.neg_infinity.is_negative
+    assert F64[123.456].is_positive
+    assert F32[123.456].is_positive
+    assert F64[123.456].is_negative.is_false
+    assert F32[123.456].is_negative.is_false
+    assert F64[-123.456].is_positive.is_false
+    assert F32[-123.456].is_positive.is_false
+    assert F64[-123.456].is_negative
+    assert F32[-123.456].is_negative

--- a/spec/savi/prelude/numeric_spec.savi
+++ b/spec/savi/prelude/numeric_spec.savi
@@ -86,7 +86,7 @@
     @assert = F64  .zero == 0
 
   :it "can report the max or minimum integer based on bit width and signedness"
-    assert Bool.max_value
+    assert Bool.max_value.is_true
     @assert = U8   .max_value == 0xFF
     @assert = U16  .max_value == 0xFFFF
     @assert = U32  .max_value == 0xFFFF_FFFF

--- a/spec/savi/prelude/string_spec.savi
+++ b/spec/savi/prelude/string_spec.savi
@@ -239,3 +239,14 @@
     @assert = codepoints == ['"', 'न', 'म', 'स', '्', 'त', 'े', '!', '"']
     @assert = indices    == [ 0,   1,   4,   7,  10,  13,  16,  19,  20]
     @assert = widths     == [ 1,   3,   3,   3,   3,   3,   3,   1,   1]
+  
+  :it "joins an array of strings"
+    @assert = String.join([
+      "foo"
+      "bar"
+    ]) == "foobar"
+
+    @assert = String.join([
+      "foo"
+      "bar"
+    ], " ") == "foo bar"

--- a/spec/savi/prelude/string_spec.savi
+++ b/spec/savi/prelude/string_spec.savi
@@ -239,7 +239,7 @@
     @assert = codepoints == ['"', 'न', 'म', 'स', '्', 'त', 'े', '!', '"']
     @assert = indices    == [ 0,   1,   4,   7,  10,  13,  16,  19,  20]
     @assert = widths     == [ 1,   3,   3,   3,   3,   3,   3,   1,   1]
-  
+
   :it "joins an array of strings"
     @assert = String.join([
       "foo"

--- a/spec/savi/prelude/string_spec.savi
+++ b/spec/savi/prelude/string_spec.savi
@@ -8,23 +8,23 @@
     data = String.new
     @assert = data.space == 0
     @assert = data.size == 0
-    @assert = data.cpointer.is_null
+    assert data.cpointer.is_null
 
   :it "allocates the next highest power of two containing the requested space"
     data = String.new(12)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
     data = String.new(16)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
     data = String.new(17)
     @assert = data.space == 32
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
 
   :it "won't reallocate when reserving space within the current allocation"
     data = String.new(12)
@@ -33,13 +33,13 @@
     data.reserve(16)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize == orig_pointer_address
 
     data.reserve(0)
     @assert = data.space == 16
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
@@ -52,7 +52,7 @@
 
     @assert = data.space == 2048
     @assert = data.size == 0
-    @assert = data.cpointer.is_not_null
+    assert data.cpointer.is_not_null
     @assert = data.cpointer.usize != orig_pointer_address
 
   :it "converts to and from an array of bytes"
@@ -65,47 +65,47 @@
 
   :it "compares bytewise equality with another string"
     @assert = ("string" == "string")
-    @assert = ("string" == "other").not
+    assert ("string" == "other").is_false
 
   :it "checks if it starts with a substring equal to the other string"
-    @assert = "foo".starts_with("foo")
-    @assert = "foo".starts_with("food").not
-    @assert = "food".starts_with("foo")
-    @assert = "barfood".starts_with("foo").not
-    @assert = "barfood".starts_with("barf")
-    @assert = "barfood".starts_with("")
+    assert "foo".starts_with("foo")
+    assert "foo".starts_with("food").is_false
+    assert "food".starts_with("foo")
+    assert "barfood".starts_with("foo").is_false
+    assert "barfood".starts_with("barf")
+    assert "barfood".starts_with("")
 
   :it "checks if it ends with a substring equal to the other string"
-    @assert = "food".ends_with("foo").not
-    @assert = "foo".ends_with("foo")
-    @assert = "foo".ends_with("food").not
-    @assert = "snafoo".ends_with("foo")
-    @assert = "snafoozled".ends_with("foo").not
-    @assert = "snafoozled".ends_with("")
+    assert "food".ends_with("foo").is_false
+    assert "foo".ends_with("foo")
+    assert "foo".ends_with("food").is_false
+    assert "snafoo".ends_with("foo")
+    assert "snafoozled".ends_with("foo").is_false
+    assert "snafoozled".ends_with("")
 
   :it "checks if it has a common bytes with another string at specific offsets"
-    @assert = "foodbar".is_byte_slice_equal(1, b"broodbard", 2, 6)
-    @assert = "foodbar".is_byte_slice_equal(1, b"broodbard", 2, 5)
-    @assert = "foodbar".is_byte_slice_equal(2, b"broodbard", 2, 5).not
-    @assert = "foodbar".is_byte_slice_equal(1, b"broodbard", 2, 7).not
-    @assert = "foodbar".is_byte_slice_equal(1, b"broodbard", 1, 6).not
-    @assert = "foodbar".is_byte_slice_equal(0, b"broodbard", 1, 6).not
-    @assert = "broodbard".is_byte_slice_equal(2, b"foodbar", 1, 6)
-    @assert = "broodbard".is_byte_slice_equal(2, b"foodbar", 1, 5)
-    @assert = "broodbard".is_byte_slice_equal(2, b"foodbar", 2, 5).not
-    @assert = "broodbard".is_byte_slice_equal(2, b"foodbar", 1, 7).not
-    @assert = "broodbard".is_byte_slice_equal(1, b"foodbar", 1, 6).not
-    @assert = "broodbard".is_byte_slice_equal(1, b"foodbar", 0, 6).not
+    assert "foodbar".is_byte_slice_equal(1, b"broodbard", 2, 6)
+    assert "foodbar".is_byte_slice_equal(1, b"broodbard", 2, 5)
+    assert "foodbar".is_byte_slice_equal(2, b"broodbard", 2, 5).is_false
+    assert "foodbar".is_byte_slice_equal(1, b"broodbard", 2, 7).is_false
+    assert "foodbar".is_byte_slice_equal(1, b"broodbard", 1, 6).is_false
+    assert "foodbar".is_byte_slice_equal(0, b"broodbard", 1, 6).is_false
+    assert "broodbard".is_byte_slice_equal(2, b"foodbar", 1, 6)
+    assert "broodbard".is_byte_slice_equal(2, b"foodbar", 1, 5)
+    assert "broodbard".is_byte_slice_equal(2, b"foodbar", 2, 5).is_false
+    assert "broodbard".is_byte_slice_equal(2, b"foodbar", 1, 7).is_false
+    assert "broodbard".is_byte_slice_equal(1, b"foodbar", 1, 6).is_false
+    assert "broodbard".is_byte_slice_equal(1, b"foodbar", 0, 6).is_false
 
   :it "checks if it is an empty string or not"
-    @assert = "".is_empty
-    @assert = "".is_not_empty.not
-    @assert = "example".is_empty.not
-    @assert = "example".is_not_empty
-    @assert = String.new.is_empty
-    @assert = String.new.is_not_empty.not
-    @assert = (String.new << "example").is_empty.not
-    @assert = (String.new << "example").is_not_empty
+    assert "".is_empty
+    assert "".is_not_empty.is_false
+    assert "example".is_empty.is_false
+    assert "example".is_not_empty
+    assert String.new.is_empty
+    assert String.new.is_not_empty.is_false
+    assert (String.new << "example").is_empty.is_false
+    assert (String.new << "example").is_not_empty
 
   :it "clones itself into a new string"
     string String = "example"
@@ -116,10 +116,10 @@
     @assert = try ("bar food foo".offset_of!("bard"), False | True)
     @assert = try ("bar food foo".offset_of!("nope"), False | True)
     @assert = try ("bar food foo".offset_of!(""),     False | True)
-    @assert = "bar food foo".includes("foo")
-    @assert = "bar food foo".includes("bard").not
-    @assert = "bar food foo".includes("nope").not
-    @assert = "bar food foo".includes("").not
+    assert "bar food foo".includes("foo")
+    assert "bar food foo".includes("bard").is_false
+    assert "bar food foo".includes("nope").is_false
+    assert "bar food foo".includes("").is_false
 
   :it "hashes the bytes of the string"
     @assert = ("string".hash == 0x4CF51F4A5B5CF110)
@@ -176,28 +176,28 @@
   :it "lexically compares the string with another string of the same length"
     @assert = "examplE" < "example"
     @assert = "example" > "examplE"
-    @assert = ("example" < "examplE").not
-    @assert = ("examplE" > "example").not
+    assert ("example" < "examplE").is_false
+    assert ("examplE" > "example").is_false
     @assert = "examplE" <= "example"
     @assert = "example" >= "examplE"
-    @assert = ("example" <= "examplE").not
-    @assert = ("examplE" >= "example").not
+    assert ("example" <= "examplE").is_false
+    assert ("examplE" >= "example").is_false
 
   :it "lexically compares the string with an identical string"
-    @assert = ("example" < "example").not
-    @assert = ("example" > "example").not
+    assert ("example" < "example").is_false
+    assert ("example" > "example").is_false
     @assert = "example" <= "example"
     @assert = "example" >= "example"
 
   :it "lexically compares with a nearly identical string of different length"
     @assert = "example" < "example!"
     @assert = "example!" > "example"
-    @assert = ("example!" < "example").not
-    @assert = ("example" > "example!").not
+    assert ("example!" < "example").is_false
+    assert ("example" > "example!").is_false
     @assert = "example" <= "example!"
     @assert = "example!" >= "example"
-    @assert = ("example!" <= "example").not
-    @assert = ("example" >= "example!").not
+    assert ("example!" <= "example").is_false
+    assert ("example" >= "example!").is_false
 
   :it "parses an integer from the string decimal representation"
     @assert = try ("36".parse_i64!  == 36  | False)

--- a/src/prelude/string.savi
+++ b/src/prelude/string.savi
@@ -432,6 +432,13 @@
       String.new_iso
     )
 
+  :fun non join(others Array(String), separator = "") String'iso
+    res = String.new_iso
+    others.each_with_index -> (other, index |
+      res << other
+      if (index != others.size - 1) (res << separator)
+    )
+    --res
 
 :: Encode the code point into UTF-8. It returns a tuple with the size of the
 :: encoded data and then the data.


### PR DESCRIPTION
Issue: #88 

This is the first full slice of the pie that makes the `assert` macro cake. It only solves the :one: `assert EXPRESSION` case, but it showcases the entire solution, and I updated all the `@assert =` I could find to the new form.

I also took the liberty to change all the `assert ... .not` to `assert ... .is_false` because it felt more readable and because we now have the `!` operator for negation, so I would like to discourage doing the same thing in two different ways across our codebase. In the future, if we add alternatives to verify negative assertions (like `refute EXPRESSION`) we can update them again.

You will also find many `// TODO` comments in the PR, discussing mainly future architectural changes and cleanup to be made once we can remove `@assert =` entirely.

---

Further changes I would like to make, in other PRs, are:
* Print the absolute path of the file where a failure happens.
* Print messages in color.
* When an example ends report `OK`, `SKIP` or `FAIL` depending on the state. Right now it will print `OK` even with failures.