### PR TITLE
Add `BinaryReadable` trait, implementations and endianness conversion functions

### DIFF
--- a/packages/bytes/byte_stream_chunked_reader.savi
+++ b/packages/bytes/byte_stream_chunked_reader.savi
@@ -33,6 +33,7 @@
 :: stream using the compact method to drop only chunks that are behind
 :: both the marker and cursor, releasing chunks that cannot be read anymore.
 :class ByteStreamChunkedReader
+  :is BinaryReadable
   :let _chunks Array(Bytes): []
   :var _chunk_index USize: 0
   :var _offset USize: 0
@@ -323,3 +324,41 @@
       )
     )
     @
+
+  :: Starting at `offset`, read the next `num_bytes` from the stream and
+  :: treat them as an unsigned integer in network byte order (big-endian).
+  :fun _read_be_uint!(offset USize, num_bytes USize) U64
+    value U64 = 0
+    pos USize = 0
+    end_offset USize = offset + num_bytes
+
+    @each_token_byte_until -> (byte |
+      if (pos >= offset && pos < end_offset) (
+        value = value.bit_shl(8).bit_or(byte.u64)
+      )
+      pos += 1
+      pos >= end_offset
+    )
+    if (pos == end_offset) (value | error!)
+
+  :fun read_byte!(offset USize) U8
+    @_read_be_uint!(offset, 1).u8
+
+  :fun read_be_u16!(offset USize) U16
+    @_read_be_uint!(offset, 2).u16
+
+  :fun read_be_u32!(offset USize) U32
+    @_read_be_uint!(offset, 4).u32
+
+  :fun read_be_u64!(offset USize) U64
+    @_read_be_uint!(offset, 8)
+
+  :fun read_native_u16!(offset USize) U16
+    @read_be_u16!(offset).be_to_native
+
+  :fun read_native_u32!(offset USize) U32
+    @read_be_u32!(offset).be_to_native
+
+  :fun read_native_u64!(offset USize) U64
+    @read_be_u64!(offset).be_to_native
+

--- a/packages/bytes/byte_stream_reader.savi
+++ b/packages/bytes/byte_stream_reader.savi
@@ -38,6 +38,7 @@
 :: stream using the compact method to drop only bytes that are behind
 :: both the marker and cursor, releasing bytes that cannot be read anymore.
 :class ByteStreamReader
+  :is BinaryReadable
   :let _data Bytes'ref
   :var _offset USize: 0
   :var _mark_offset USize: 0
@@ -243,3 +244,16 @@
     :yields U8 for Bool
     while (yield @_data[@_offset]!) (@_offset += 1)
     @
+
+  :fun read_byte!(offset USize) U8
+    @_data.read_byte!(@_mark_offset + offset)
+
+  :fun read_native_u16!(offset USize) U16
+    @_data.read_native_u16!(@_mark_offset + offset)
+
+  :fun read_native_u32!(offset USize) U32
+    @_data.read_native_u32!(@_mark_offset + offset)
+
+  :fun read_native_u64!(offset USize) U64
+    @_data.read_native_u64!(@_mark_offset + offset)
+

--- a/packages/bytes/test/byte_stream_chunked_reader_spec.savi
+++ b/packages/bytes/test/byte_stream_chunked_reader_spec.savi
@@ -268,3 +268,50 @@
     stream << b":" // only digits (0-9) are valid
     stream.advance_to_end
     @assert = try (stream.token_as_positive_integer!, False | True)
+
+  :it "reads byte at position"
+    stream = ByteStreamChunkedReader.new
+    stream << Bytes.from_array([0x01])
+    stream << Bytes.from_array([0x23, 0x45])
+    stream.advance_to_end
+
+    @assert = try (stream.read_byte!(0) == 0x01 | False)
+    @assert = try (stream.read_byte!(1) == 0x23 | False)
+    @assert = try (stream.read_byte!(2) == 0x45 | False)
+    @assert = try (stream.read_byte!(3), False | True)
+
+  :it "reads integers in native, big and little endianness at specific offsets"
+    stream = ByteStreamChunkedReader.new
+    // break the data up into multiple chunks to test reading integers across chunk boundaries
+    stream << b"garbage"
+    stream << Bytes.from_array([0x01])
+    stream << Bytes.from_array([0x23, 0x45])
+    stream << Bytes.from_array([0x67, 0x89, 0xAB])
+    stream << Bytes.from_array([0xCD])
+    stream << Bytes.from_array([0xEF, 0x01])
+
+    try (stream.advance!(7)) // drop "garbage"
+    stream.mark_here
+    stream.advance_to_end
+
+    @assert = try (stream.read_native_u16!(0) == 0x2301 | False)
+    @assert = try (stream.read_native_u16!(1) == 0x4523 | False)
+    @assert = try (stream.read_native_u32!(0) == 0x67452301 | False)
+    @assert = try (stream.read_native_u32!(1) == 0x89674523 | False)
+    @assert = try (stream.read_native_u64!(0) == 0xEFCDAB8967452301 | False)
+    @assert = try (stream.read_native_u64!(1) == 0x01EFCDAB89674523 | False)
+
+    @assert = try (stream.read_le_u16!(0) == 0x2301 | False)
+    @assert = try (stream.read_le_u16!(1) == 0x4523 | False)
+    @assert = try (stream.read_le_u32!(0) == 0x67452301 | False)
+    @assert = try (stream.read_le_u32!(1) == 0x89674523 | False)
+    @assert = try (stream.read_le_u64!(0) == 0xEFCDAB8967452301 | False)
+    @assert = try (stream.read_le_u64!(1) == 0x01EFCDAB89674523 | False)
+
+    @assert = try (stream.read_be_u16!(0) == 0x0123 | False)
+    @assert = try (stream.read_be_u16!(1) == 0x2345 | False)
+    @assert = try (stream.read_be_u32!(0) == 0x01234567 | False)
+    @assert = try (stream.read_be_u32!(1) == 0x23456789 | False)
+    @assert = try (stream.read_be_u64!(0) == 0x0123456789ABCDEF | False)
+    @assert = try (stream.read_be_u64!(1) == 0x23456789ABCDEF01 | False)
+

--- a/packages/bytes/test/byte_stream_reader_spec.savi
+++ b/packages/bytes/test/byte_stream_reader_spec.savi
@@ -322,6 +322,37 @@
     stream.advance_to_end
     @assert = try (stream.token_as_positive_integer!, False | True)
 
+  :it "reads integers in native, big and little endianness at specific offsets"
+    stream = ByteStreamReader.new
+    write_stream = TestByteStreamSource.new(stream)
+    write_stream << b"garbage"
+    write_stream << Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
+    try (stream.advance!(7)) // drop "garbage"
+    stream.mark_here
+    stream.advance_to_end
+
+    @assert = try (stream.read_native_u16!(0) == 0x2301 | False)
+    @assert = try (stream.read_native_u16!(1) == 0x4523 | False)
+    @assert = try (stream.read_native_u32!(0) == 0x67452301 | False)
+    @assert = try (stream.read_native_u32!(1) == 0x89674523 | False)
+    @assert = try (stream.read_native_u64!(0) == 0xEFCDAB8967452301 | False)
+    @assert = try (stream.read_native_u64!(1) == 0x01EFCDAB89674523 | False)
+
+    @assert = try (stream.read_le_u16!(0) == 0x2301 | False)
+    @assert = try (stream.read_le_u16!(1) == 0x4523 | False)
+    @assert = try (stream.read_le_u32!(0) == 0x67452301 | False)
+    @assert = try (stream.read_le_u32!(1) == 0x89674523 | False)
+    @assert = try (stream.read_le_u64!(0) == 0xEFCDAB8967452301 | False)
+    @assert = try (stream.read_le_u64!(1) == 0x01EFCDAB89674523 | False)
+
+    @assert = try (stream.read_be_u16!(0) == 0x0123 | False)
+    @assert = try (stream.read_be_u16!(1) == 0x2345 | False)
+    @assert = try (stream.read_be_u32!(0) == 0x01234567 | False)
+    @assert = try (stream.read_be_u32!(1) == 0x23456789 | False)
+    @assert = try (stream.read_be_u64!(0) == 0x0123456789ABCDEF | False)
+    @assert = try (stream.read_be_u64!(1) == 0x23456789ABCDEF01 | False)
+
+
 // This is a utility class used here in testing as a way to get chunks
 // inserted into the byte stream of a ByteStreamReader, one chunk at a time.
 :class TestByteStreamSource

--- a/spec/savi/prelude/bytes_spec.savi
+++ b/spec/savi/prelude/bytes_spec.savi
@@ -327,19 +327,7 @@
     @assert = try (data.write_native_u64!(6, 0xfedcba9876543210), False | True)
 
   :it "reads big and little endian integer types at specific offsets"
-    data = Bytes.new
-
-    data.push(0x01)
-    data.push(0x23)
-    data.push(0x45)
-    data.push(0x67)
-
-    data.push(0x89)
-    data.push(0xAB)
-    data.push(0xCD)
-    data.push(0xEF)
-
-    data.push(0x01)
+    data = Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
 
     @assert = try (data.read_be_u16!(0) == 0x0123 | False)
     @assert = try (data.read_be_u16!(1) == 0x2345 | False)

--- a/spec/savi/prelude/bytes_spec.savi
+++ b/spec/savi/prelude/bytes_spec.savi
@@ -326,15 +326,15 @@
     @assert = try (data.write_native_u32!(10, 0x12345678), False | True)
     @assert = try (data.write_native_u64!(6, 0xfedcba9876543210), False | True)
 
-  :it "reads big and little endian integer types at specific offsets"
+  :it "reads integers in native, big and little endianness at specific offsets"
     data = Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
 
-    @assert = try (data.read_be_u16!(0) == 0x0123 | False)
-    @assert = try (data.read_be_u16!(1) == 0x2345 | False)
-    @assert = try (data.read_be_u32!(0) == 0x01234567 | False)
-    @assert = try (data.read_be_u32!(1) == 0x23456789 | False)
-    @assert = try (data.read_be_u64!(0) == 0x0123456789ABCDEF | False)
-    @assert = try (data.read_be_u64!(1) == 0x23456789ABCDEF01 | False)
+    @assert = try (data.read_native_u16!(0) == 0x2301 | False)
+    @assert = try (data.read_native_u16!(1) == 0x4523 | False)
+    @assert = try (data.read_native_u32!(0) == 0x67452301 | False)
+    @assert = try (data.read_native_u32!(1) == 0x89674523 | False)
+    @assert = try (data.read_native_u64!(0) == 0xEFCDAB8967452301 | False)
+    @assert = try (data.read_native_u64!(1) == 0x01EFCDAB89674523 | False)
 
     @assert = try (data.read_le_u16!(0) == 0x2301 | False)
     @assert = try (data.read_le_u16!(1) == 0x4523 | False)
@@ -342,6 +342,13 @@
     @assert = try (data.read_le_u32!(1) == 0x89674523 | False)
     @assert = try (data.read_le_u64!(0) == 0xEFCDAB8967452301 | False)
     @assert = try (data.read_le_u64!(1) == 0x01EFCDAB89674523 | False)
+
+    @assert = try (data.read_be_u16!(0) == 0x0123 | False)
+    @assert = try (data.read_be_u16!(1) == 0x2345 | False)
+    @assert = try (data.read_be_u32!(0) == 0x01234567 | False)
+    @assert = try (data.read_be_u32!(1) == 0x23456789 | False)
+    @assert = try (data.read_be_u64!(0) == 0x0123456789ABCDEF | False)
+    @assert = try (data.read_be_u64!(1) == 0x23456789ABCDEF01 | False)
 
   :it "joins an array of bytes"
     @assert = Bytes.join([

--- a/spec/savi/prelude/numeric_spec.savi
+++ b/spec/savi/prelude/numeric_spec.savi
@@ -359,3 +359,62 @@
     assert F32[-123.456].is_positive.is_false
     assert F64[-123.456].is_negative
     assert F32[-123.456].is_negative
+
+  :it "converts U8 integers from native to big/little endianness and vice versa"
+    u8 = U8[0x12]
+
+    @assert = u8.native_to_be == u8
+    @assert = u8.be_to_native == u8
+    @assert = u8.native_to_le == u8
+    @assert = u8.le_to_native == u8
+
+  :it "converts U16 integers from native to big/little endianness and vice versa"
+    u16 = U16[0x1234]
+    u16_swapped = U16[0x3412]
+
+    if (Platform.little_endian) (
+      @assert = u16.native_to_be == u16_swapped
+      @assert = u16.native_to_le == u16
+      @assert = u16.be_to_native == u16_swapped
+      @assert = u16.le_to_native == u16
+    )
+    if (Platform.big_endian) (
+      @assert = u16.native_to_be == u16
+      @assert = u16.native_to_le == u16_swapped
+      @assert = u16.be_to_native == u16
+      @assert = u16.le_to_native == u16_swapped
+    )
+
+  :it "converts U32 integers from native to big/little endianness and vice versa"
+    u32 = U32[0x1234_5678]
+    u32_swapped = U32[0x7856_3412]
+
+    if (Platform.little_endian) (
+      @assert = u32.native_to_be == u32_swapped
+      @assert = u32.native_to_le == u32
+      @assert = u32.be_to_native == u32_swapped
+      @assert = u32.le_to_native == u32
+    )
+    if (Platform.big_endian) (
+      @assert = u32.native_to_be == u32
+      @assert = u32.native_to_le == u32_swapped
+      @assert = u32.be_to_native == u32
+      @assert = u32.le_to_native == u32_swapped
+    )
+
+  :it "converts U64 integers from native to big/little endianness and vice versa"
+    u64 = U64[0x1234_5678_9ABC_DEF0]
+    u64_swapped = U64[0xF0DE_BC9A_7856_3412]
+
+    if (Platform.little_endian) (
+      @assert = u64.native_to_be == u64_swapped
+      @assert = u64.native_to_le == u64
+      @assert = u64.be_to_native == u64_swapped
+      @assert = u64.le_to_native == u64
+    )
+    if (Platform.big_endian) (
+      @assert = u64.native_to_be == u64
+      @assert = u64.native_to_le == u64_swapped
+      @assert = u64.be_to_native == u64
+      @assert = u64.le_to_native == u64_swapped
+    )

--- a/src/prelude/binary_readable.savi
+++ b/src/prelude/binary_readable.savi
@@ -1,0 +1,36 @@
+:trait BinaryReadable
+  :fun read_byte!(offset USize) U8
+  :fun read_native_u16!(offset USize) U16
+  :fun read_native_u32!(offset USize) U32
+  :fun read_native_u64!(offset USize) U64
+
+  :: Read a U16 from the bytes at the given offset, with big endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
+  :fun read_be_u16!(offset USize) U16
+    @read_native_u16!(offset).native_to_be
+
+  :: Read a U16 from the bytes at the given offset, with little endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
+  :fun read_le_u16!(offset USize) U16
+    @read_native_u16!(offset).native_to_le
+
+  :: Read a U32 from the bytes at the given offset, with big endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U32.
+  :fun read_be_u32!(offset USize) U32
+    @read_native_u32!(offset).native_to_be
+
+  :: Read a U32 from the bytes at the given offset, with little endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U32.
+  :fun read_le_u32!(offset USize) U32
+    @read_native_u32!(offset).native_to_le
+
+  :: Read a U64 from the bytes at the given offset, with big endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U64.
+  :fun read_be_u64!(offset USize) U64
+    @read_native_u64!(offset).native_to_be
+
+  :: Read a U64 from the bytes at the given offset, with little endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U64.
+  :fun read_le_u64!(offset USize) U64
+    @read_native_u64!(offset).native_to_le
+

--- a/src/prelude/bytes.savi
+++ b/src/prelude/bytes.savi
@@ -1,4 +1,5 @@
 :class val Bytes
+  :is BinaryReadable
   :is Comparable(Bytes'box)
   :is Indexable(U8)
 
@@ -438,6 +439,9 @@
     @_space = offset
     --chopped
 
+  :fun read_byte!(offset USize) U8
+    @byte_at!(offset)
+
   :: Read a U16 from the bytes at the given offset, with native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
   :: Raises an error if there aren't enough bytes at that offset to fill a U16.
@@ -445,36 +449,12 @@
     if ((offset + U16.byte_width.usize) > @_size) error!
     CPointer(U16).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
 
-  :: Read a U16 from the bytes at the given offset, with big endian byte order.
-  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
-  :fun read_be_u16!(offset USize) U16
-    number = @read_native_u16!(offset)
-    if (Platform.big_endian) (number | number.swap_bytes)
-
-  :: Read a U16 from the bytes at the given offset, with little endian byte order.
-  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
-  :fun read_le_u16!(offset USize) U16
-    number = @read_native_u16!(offset)
-    if (Platform.little_endian) (number | number.swap_bytes)
-
   :: Read a U32 from the bytes at the given offset, with native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
   :: Raises an error if there aren't enough bytes at that offset to fill a U32.
   :fun read_native_u32!(offset USize) U32
     if ((offset + U32.byte_width.usize) > @_size) error!
     CPointer(U32).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
-
-  :: Read a U32 from the bytes at the given offset, with big endian byte order.
-  :: Raises an error if there aren't enough bytes at that offset to fill a U32.
-  :fun read_be_u32!(offset USize) U32
-    number = @read_native_u32!(offset)
-    if (Platform.big_endian) (number | number.swap_bytes)
-
-  :: Read a U32 from the bytes at the given offset, with little endian byte order.
-  :: Raises an error if there aren't enough bytes at that offset to fill a U32.
-  :fun read_le_u32!(offset USize) U32
-    number = @read_native_u32!(offset)
-    if (Platform.little_endian) (number | number.swap_bytes)
 
   :: Write a U32 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -501,18 +481,6 @@
   :fun read_native_u64!(offset USize) U64
     if ((offset + U64.byte_width.usize) > @_size) error!
     CPointer(U64).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
-
-  :: Read a U64 from the bytes at the given offset, with big endian byte order.
-  :: Raises an error if there aren't enough bytes at that offset to fill a U64.
-  :fun read_be_u64!(offset USize) U64
-    number = @read_native_u64!(offset)
-    if (Platform.big_endian) (number | number.swap_bytes)
-
-  :: Read a U64 from the bytes at the given offset, with little endian byte order.
-  :: Raises an error if there aren't enough bytes at that offset to fill a U64.
-  :fun read_le_u64!(offset USize) U64
-    number = @read_native_u64!(offset)
-    if (Platform.little_endian) (number | number.swap_bytes)
 
   :: Write a U64 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.

--- a/src/prelude/numeric.savi
+++ b/src/prelude/numeric.savi
@@ -74,6 +74,18 @@
   :fun val count_zeros U8: @invert.count_ones
   :fun val next_pow2 @: compiler intrinsic
 
+  :fun val native_to_be @
+    if (Platform.big_endian) (@ | @.swap_bytes)
+
+  :fun val native_to_le @
+    if (Platform.little_endian) (@ | @.swap_bytes)
+
+  :fun val be_to_native @
+    if (Platform.big_endian) (@ | @.swap_bytes)
+
+  :fun val le_to_native @
+    if (Platform.little_endian) (@ | @.swap_bytes)
+
   :fun hash USize
     if (USize.bit_width == 32) (
       x = @usize

--- a/src/prelude/numeric.savi
+++ b/src/prelude/numeric.savi
@@ -75,16 +75,16 @@
   :fun val next_pow2 @: compiler intrinsic
 
   :fun val native_to_be @
-    if (Platform.big_endian) (@ | @.swap_bytes)
+    if (Platform.big_endian) (@ | @swap_bytes)
 
   :fun val native_to_le @
-    if (Platform.little_endian) (@ | @.swap_bytes)
+    if (Platform.little_endian) (@ | @swap_bytes)
 
   :fun val be_to_native @
-    if (Platform.big_endian) (@ | @.swap_bytes)
+    if (Platform.big_endian) (@ | @swap_bytes)
 
   :fun val le_to_native @
-    if (Platform.little_endian) (@ | @.swap_bytes)
+    if (Platform.little_endian) (@ | @swap_bytes)
 
   :fun hash USize
     if (USize.bit_width == 32) (

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -47,7 +47,7 @@ class Savi::Compiler::Binary
     link_args = if target.freebsd?
                   %w{clang
                     -fuse-ld=lld -static -fpic -flto=thin
-                    -lc -pthread -ldl -lexecinfo -lelf
+                    -lc -lm -pthread -ldl -lexecinfo -lelf
                   }
                 else
                   %w{clang


### PR DESCRIPTION
This is a prerequisite for #100.  

@jemc @tonchis Do you think we really need all these `read_{le,be}_u{16,32,64}` functions when we could just use `read_native_u16!(offset).native_to_be` instead? IMHO, the latter can be quite a bit confusing, as you want to read for instance a "big endian u16 from disk" and then convert it into a native integer, but the sequence says "read a native u16 from disk and then convert it to big endian". 