### PR TITLE
Add `assert EXP1 <op> EXP2` macro

### DIFF
--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -4,32 +4,83 @@
   :let success Bool
   :let pos SourceCodePosition
 
-  :new val (@spec, @example, @success, @pos)
-
-  :: The report function will print a specific failure message \
+  :: The print_failure function will print a specific failure message \
   :: for the different kinds of assertions.
-  :fun report_failure(env Env) None
+  :fun print_failure(env Env) None
 
   :fun non condition(
     spec Spec
     success Bool
-    pos SourceCodePosition = source_code_position_of_argument success
+    pos SourceCodePosition = source_code_position_of_argument spec
   )
     test = spec.test
     assert = AssertCondition.new(test.spec, test.example, success, pos)
     test.specs.enqueue(assert)
 
+  :fun non relation(
+    spec Spec
+    op String
+    lhs Any'box
+    rhs Any'box
+    success Bool
+    pos SourceCodePosition = source_code_position_of_argument spec
+  )
+    test = spec.test
+    assert = AssertRelation.new(
+      test.spec
+      test.example
+      success
+      pos
+      op
+      Inspect[lhs]
+      Inspect[rhs]
+    )
+    test.specs.enqueue(assert)
+
+  :fun file_and_line String
+    line = Inspect[@pos.row + 1]
+    @indent(4, String.join(["# ", @pos.filename, ":", line]))
+
+  :fun indent(times USize, msg String) String
+    String.join([" " * times, msg])
+
 :class val AssertCondition
   :is Assert
+  
+  :new val (@spec, @example, @success, @pos)
 
-  :fun report_failure(env Env) None
-    line = Inspect[@pos.row + 1]
-
-    env.err.write("\n")
+  :fun print_failure(env Env) None
     env.err.print(String.join([
-      "    Expected the following to be True:"
-      String.join(["    ", @pos.string, "\n"])
-      String.join(["    # ", @pos.filename, ":", line])
+      ""
+      @indent(4, String.join(["FAIL:", @pos.string], " "))
+      ""
+      @indent(4, "Expected to be True")
+      ""
+      @file_and_line
+    ], "\n"))
+
+    None
+
+:class val AssertRelation
+  :is Assert
+
+  :let op String
+  :let lhs String
+  :let rhs String
+
+  :new val (@spec, @example, @success, @pos, @op, @lhs, @rhs)
+
+  :fun print_failure(env Env) None
+    env.err.print(String.join([
+      ""
+      @indent(4, String.join(["FAIL:", @pos.string], " "))
+      ""
+      @indent(4, "Expected")
+      @indent(6, @lhs)
+      @indent(4, String.join(["to ", @op]))
+      @indent(6, @rhs)
+      ""
+      @file_and_line
     ], "\n"))
 
     None

--- a/packages/spec/spec_reporter.savi
+++ b/packages/spec/spec_reporter.savi
@@ -52,7 +52,7 @@
       @env.err.write(".")
     |
       try (
-        event.assert.as!(Assert).report_failure(@env)
+        event.assert.as!(Assert).print_failure(@env)
       |
         @env.err.write("\n")
         @env.err.write(Inspect[event.pos.row + 1])

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -18,3 +18,12 @@
     assert Foo.with_yield -> (false |
       assert !false
     )
+
+  :it "conforms to the `assert EXP1 <op> EXP2` macro"
+    assert True == True
+    assert Foo.true == True
+    assert True == Foo.true
+    assert True \
+      == True
+    assert Foo.with_yield -> (false |
+      assert !false) == Foo.true

--- a/spec/compiler/macros/assertion_spec.cr
+++ b/spec/compiler/macros/assertion_spec.cr
@@ -1,5 +1,5 @@
 describe Savi::Compiler::Macros do
-  describe "assert" do
+  describe "assert EXPR" do
     it "is transformed into Assert.condition" do
       source = Savi::Source.new_example <<-SOURCE
       :actor Main
@@ -19,6 +19,40 @@ describe Savi::Compiler::Macros do
           [:ident, "True"],
         ]
       ]]
+    end
+  end
+
+  describe "assert EXP1 <op> EXP2" do
+    it "is transformed into Assert.relation" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new
+          foo = "foo"
+          assert SideEffects.call != foo
+      SOURCE
+
+      ctx = Savi.compiler.compile([source], :macros)
+      ctx.errors.should be_empty
+
+      func = ctx.namespace.find_func!(ctx, source, "Main", "new")
+      func.body.not_nil!.terms[1].to_a.should eq [:group, "(",
+        [:relate,
+          [:ident, "hygienic_macros_local.1"],
+          [:op, "="],
+          [:call, [:ident, "SideEffects"], [:ident, "call"]],
+        ],
+        [:call,
+          [:ident, "Assert"],
+          [:ident, "relation"],
+          [:group, "(", 
+            [:ident, "@"],
+            [:string, "!=", nil],
+            [:ident, "hygienic_macros_local.1"],
+            [:ident, "foo"],
+            [:relate, [:ident, "hygienic_macros_local.1"], [:op, "!="], [:ident, "foo"]]
+          ]
+        ]
+      ]
     end
   end
 end


### PR DESCRIPTION
Issue: #88 

Apologies for the single big commit. I got in the zone and forgot to commit incrementally xD

The gist of the changes goes as follows:
* Refactored `visit_pre` to take the `assert Foo ==` Relate node into account as well.
* That function calls `visit_assert(Relate)`, which converts the loosely binding operation into the `Assert.relation` call
  * It uses hygienic variables to store the `EXP1` and `EXP2` expressions and avoid evaluating them twice.
* Created the `Assert.relation` method to generate a `AssertRelation` object holding all the values we'll need to report an error.
  * As suggested per our chat offline, I'm Inspecting `EXP1` and `EXP2` before creating the `AssertRelation` object to make sure I can keep it `val`, without references to non-sendable `box`es.
*  I renamed and refactored the `report_failure` function to `print_failure`, and implemented them for both kinds of assertions.
  * I'm pointing `pos` to the source code position of argument for`@`, and I'm giving that the `node`'s position to print the entire `assert ...` line in the failure.
  * I added a couple helper functions to generate the message: `file_and_line` and `indent`.

This is the output this PR will generate when a failure occurs, using two of my specs as examples

<img width="790" alt="image" src="https://user-images.githubusercontent.com/106882/126856207-5bf3ace5-5b78-4fd7-99f6-e5ac225ee749.png">

Out of scope for this PR but still on my sights:
* Replace all `@assert = EXP1 <op> EXP2` with the new macro.
* Print `F` when reporting a single failure, and then print *all* failures (with the `print_failure` function) when calling `@reporter.spec_ended`, after everything runs.
* Clean up `spec.savi` and `specs.savi` from code we don't need anymore.