### PR TITLE
Extend `Env` for command line arguments and environment variables

### DIFF
--- a/src/prelude/env.savi
+++ b/src/prelude/env.savi
@@ -1,9 +1,35 @@
 :class val Env
   :let out StdStream
   :let err StdStream
-  :new val _create
+  :let args Array(String'val)
+  :let vars Array(String'val)
+
+  :new val _create(argc I32,
+                   argv CPointer(CPointer(U8)'ref)'ref,
+                   envp CPointer(CPointer(U8)'ref)'ref)
     @out = StdStream._out
     @err = StdStream._err
+
+    @args = []
+    i = USize[0]
+    while (argc > 0) (
+      arg = argv._get_at(i)
+      len = InspectLibC.strlen(arg).usize
+      @args.push(String.val_from_cpointer(arg, len, len))
+      argc -= 1
+      i += 1
+    )
+
+    @vars = []
+    if (envp.is_not_null) (
+      while (True) (
+        arg = envp._get_at(0)
+        break if arg.is_null
+        len = InspectLibC.strlen(arg).usize
+        @vars.push(String.val_from_cpointer(arg, len, len))
+        envp = envp._offset(1)
+      )
+    )
 
   :fun "exit_code="(value)
     LibPony.pony_exitcode(value)

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -554,7 +554,7 @@ class Savi::Compiler::CodeGen::PonyRT
 
     # Call pony_init, letting it optionally consume some of the CLI args,
     # giving us a new value for argc and a mutated argv array.
-    argc = g.builder.call(g.mod.functions["pony_init"], [@i32.const_int(1), argv], "argc")
+    argc = g.builder.call(g.mod.functions["pony_init"], [argc, argv], "argc")
 
     # Get the current alloc_ctx and hold on to it.
     alloc_ctx = gen_alloc_ctx_get(g)
@@ -563,11 +563,8 @@ class Savi::Compiler::CodeGen::PonyRT
     # Create the main actor and become it.
     main_actor = gen_alloc_actor(g, g.gtype_main, nil, "main", become_now: true)
 
-    # TODO: Create the Env from argc, argv, and envp.
     env = gen_alloc(g, g.gtypes["Env"], nil, "env")
-    g.builder.call(g.gtypes["Env"]["_create"].llvm_func, [env])
-    # TODO: g.builder.call(g.gtypes["Env"]["_create"].llvm_func,
-    #   [argc, g.builder.bit_cast(argv, @ptr), g.builder.bitcast(envp, @ptr)])
+    g.builder.call(g.gtypes["Env"]["_create"].llvm_func, [env, argc, argv, envp])
 
     # TODO: Run primitive initialisers using the main actor's heap.
 


### PR DESCRIPTION
Environment variables are in raw KEY=VALUE form. Also, it's probably
better to use getenv(3) to access environment variables.