### PR TITLE
Fix `assert EXP1 <op> EXP2` macro for iso variables

### DIFF
--- a/packages/http/server/test/response_builder_spec.savi
+++ b/packages/http/server/test/response_builder_spec.savi
@@ -5,7 +5,7 @@
   :const describes: "ResponseBuilder"
 
   :it "builds 1xx responses"
-    @assert = @build -> (builder |
+    assert @build -> (builder |
       builder.status_continue
     ) == Bytes.join([
       b"HTTP/1.1 100 Continue"
@@ -13,7 +13,7 @@
       b""
     ], b"\r\n")
 
-    @assert = @build -> (builder |
+    assert @build -> (builder |
       builder.status_switching_protocols
     ) == Bytes.join([
       b"HTTP/1.1 101 Switching Protocols"
@@ -28,7 +28,7 @@
   :it "builds 5xx responses"
 
   :it "can add headers"
-    @assert = @build -> (builder |
+    assert @build -> (builder |
       builder
         .status_ok
         .header("Content-Length", "0")
@@ -40,7 +40,7 @@
     ], b"\r\n")
 
   :it "can write a body"
-    @assert = @build -> (builder |
+    assert @build -> (builder |
       builder
         .status_ok
         .header("Content-Type", "text/plain; charset=utf-8")

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -27,3 +27,9 @@
       == True
     assert Foo.with_yield -> (false |
       assert !false) == Foo.true
+
+  :it "honors iso"
+    assert "" == String.new_iso
+
+    foo = String.new_iso, foo << "foo"
+    assert "foo" == --foo

--- a/spec/compiler/macros/assertion_spec.cr
+++ b/spec/compiler/macros/assertion_spec.cr
@@ -14,7 +14,7 @@ describe Savi::Compiler::Macros do
       func.body.not_nil!.terms.first.to_a.should eq [:group, "(", [:call,
         [:ident, "Assert"],
         [:ident, "condition"],
-        [:group, "(", 
+        [:group, "(",
           [:ident, "@"],
           [:ident, "True"],
         ]
@@ -27,29 +27,42 @@ describe Savi::Compiler::Macros do
       source = Savi::Source.new_example <<-SOURCE
       :actor Main
         :new
-          foo = "foo"
-          assert SideEffects.call != foo
+          assert SideEffects.call != "foo"
       SOURCE
 
       ctx = Savi.compiler.compile([source], :macros)
       ctx.errors.should be_empty
 
       func = ctx.namespace.find_func!(ctx, source, "Main", "new")
-      func.body.not_nil!.terms[1].to_a.should eq [:group, "(",
+      func.body.not_nil!.terms.first.to_a.should eq [:group, "(",
         [:relate,
-          [:ident, "hygienic_macros_local.1"],
+          [:relate,
+            [:ident, "hygienic_macros_local.1"],
+            [:op, "EXPLICITTYPE"],
+            [:ident, "box"]],
           [:op, "="],
           [:call, [:ident, "SideEffects"], [:ident, "call"]],
+        ],
+        [:relate,
+          [:relate,
+            [:ident, "hygienic_macros_local.2"],
+            [:op, "EXPLICITTYPE"],
+            [:ident, "box"]],
+          [:op, "="],
+          [:string, "foo", nil],
         ],
         [:call,
           [:ident, "Assert"],
           [:ident, "relation"],
-          [:group, "(", 
+          [:group, "(",
             [:ident, "@"],
             [:string, "!=", nil],
             [:ident, "hygienic_macros_local.1"],
-            [:ident, "foo"],
-            [:relate, [:ident, "hygienic_macros_local.1"], [:op, "!="], [:ident, "foo"]]
+            [:ident, "hygienic_macros_local.2"],
+            [:relate,
+              [:ident, "hygienic_macros_local.1"],
+              [:op, "!="],
+              [:ident, "hygienic_macros_local.2"]]
           ]
         ]
       ]


### PR DESCRIPTION
Issue: #88 

In the implementation of the `assert EXP1 <op> EXP2` macro we store the EXP1 and EXP2 expressions in hygienic variables, but when one of the operands is an iso that aliasing breaks capability rules.

To address this we forcefully type the hygienic as `box`, so passing it into `Assert.relate` doesn't make the compiler cry.