### PR TITLE
Always use visit_pre in Macros pass - for consistency.

### DIFF
--- a/src/savi/ast.cr
+++ b/src/savi/ast.cr
@@ -913,7 +913,6 @@ module Savi::AST
       dup.tap do |node|
         node.term = new_term
       end
-      self
     end
   end
 end

--- a/src/savi/compiler/macros.cr
+++ b/src/savi/compiler/macros.cr
@@ -82,7 +82,7 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     @func.add_tag(:compiler_intrinsic)
   end
 
-  def visit(ctx, node : AST::Group)
+  def visit_pre(ctx, node : AST::Group)
     # Handle only groups that are whitespace-delimited, as these are the only
     # groups that we may match and interpret as if they are macros.
     return node unless node.style == " "
@@ -170,7 +170,7 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     raise Error.compiler_hole_at(node, exc)
   end
 
-  def visit(ctx, node : AST::Call)
+  def visit_pre(ctx, node : AST::Call)
     case node.ident.value
     when "as!", "not!"
       call_args = node.args
@@ -219,11 +219,6 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
 
   # This clause picks up a special form of case and assert which are inside a Relate node,
   # where the Relate gets reshuffled into the case/assert clauses.
-  #
-  # We need it to be a visit_pre rather than a normal visit, because
-  # if we visited the children first as we normally do, then it would try
-  # to expand the `case`or `assert` macro inside the Relate before running this code,
-  # and fail because the inner Group doesn't have the right terms.
   def visit_pre(ctx, node : AST::Relate)
     lhs = node.lhs
     return node unless \


### PR DESCRIPTION
Unlike some other forms of visitation (which go depth-first),
it turns out that macro expansion is more amenable to breadth-first.
So we change it from using mixed `visit`/`visit_pre` to using all `visit_pre`
for consistency and predictability reasons.

This uncovered a bug in the copy-on-mutate visitation for Jump,
in which it was wrongly returning the original instance instead
of the newly mutated instance when its inner term had been changed via visitation.
This manifested as a bug in which macro expansion inside a return expression was broken.

So this commit also fixes that small bug and adds a test case to prevent regression.