### PR TITLE
Rename `:primitive` as `:module`.

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 ### Features from Pony (and other basic language features)
 
 - [x] - FFI function calling
-- [x] - Stateless, non-allocated primitives with pure functions
+- [x] - Stateless, non-allocated modules with pure functions
 - [x] - Numeric machine word types
 - [x] - Stateful, allocated classes with constructors and methods
 - [x] - Properties (fields hidden behind getters/setters)

--- a/docs/intro-vs-pony.md
+++ b/docs/intro-vs-pony.md
@@ -46,14 +46,13 @@ Unlike in Pony, the documentation comments for a type of function appear *above*
 
 ```savi
 :: This comment is stored as documentation for the Example type.
-:primitive Example
+:module Example
   :: This comment is stored as documentation for the greeting function.
   :: Note that documentation comments can span multiple lines this way,
   :: and by convention they often include code examples like this:
   ::
   :: $ Example.greeting
   :: > "Hello, World!"
-
   :fun greeting
     "Hello, World!" // this is a line comment, discarded by the parser
 ```
@@ -250,7 +249,7 @@ Let's look at the same code sample from the `if` section above, rewritten to use
 Now let's look at an example of `case` used with the subtype check operator:
 
 ```savi
-:primitive Example
+:module Example
   :fun thing_to_number(thing Any'box) I64
     case (
     | thing <: Numeric | thing.i64
@@ -263,7 +262,7 @@ Now let's look at an example of `case` used with the subtype check operator:
 An alternative syntax for `case` is available when the left-side expression and operator are the same in every conditional part:
 
 ```savi
-:primitive Example
+:module Example
   :fun thing_to_number(thing Any'box) I64
     case thing <: (
     | Numeric | thing.i64
@@ -359,7 +358,7 @@ If you want to create such a function, you can use the :yields declaration to de
 Note that the block is not a value that can be carried around - yielding cannot be asynchronous and must take place within the normal execution of the yielding function. However this restriction on the yielder gives benefits to the caller because it is efficient and it can be used to modify local variables in the scope of the caller, without many of the reference capability pitfalls that lambdas in Pony have. Savi will also have Pony-like lambdas, but these yield blocks are to be preferred for synchronous and immediate callbacks / inversion of control.
 
 ```savi
-:primitive Blabber
+:module Blabber
   :const sentences Array(String)'val: [
     "Hello, nice to meet you!"
     "Are you enjoying this lovely day?"
@@ -628,9 +627,9 @@ Probably the most notable semantics change from Pony is the addition of a new re
   - is sendable
   - appropriate for cases where you want to define and call functions on a type without allocating an instance of it at runtime (i.e. stateless "singleton" types, or stateless "class methods" defined on a stateful type)
 
-As you might expect from the description, primitives in Savi have a capability of `non` (rather than `val`, as they do in Pony). As a result, even stateful types can be used "like a primitive" by defining `non` functions on them - such functions can be called without an allocated instance of the type. This replaces the common pattern in Pony of defining a "utility primitive" alongside a stateful type (e.g. `primitive Promises` alongside `actor Promise` from the Pony standard libarary) - in Savi, all these functions can be within the same type without any inconvenience. Moreover, all types become first-class values, just like primitives.
+As you might expect from the description, modules in Savi have a capability of `non` rather than `val`, as they do in Pony, where they are named "primitives. As a result, even stateful types can be used "like a module" by defining `non` functions on them - such functions can be called without an allocated instance of the type. This replaces the common pattern in Pony of defining a "utility primitive" alongside a stateful type (e.g. `primitive Promises` alongside `actor Promise` from the Pony standard libarary) - in Savi, all these functions can be within the same type without any inconvenience. Moreover, all types become first-class values, just like modules.
 
-However, because it is safe, we allow typechecking of primitives capabilities to ignore capabilities, which smooths over certain issues with migrating Pony code where you were depending on primitives to be a subtype of `val` or `box`, as well as new patterns, such as dependency-injecting a primitive where a mutable type is expected. A primitive can have no field-accessing methods, so this is all safe and allowable.
+However, because it is safe, we allow typechecking of modules capabilities to ignore capabilities, which smooths over certain issues with migrating Pony code where you were depending on modules to be a subtype of `val` or `box`, as well as new patterns, such as dependency-injecting a module where a mutable type is expected. A module can have no field-accessing methods, so this is all safe and allowable.
 
 ### [TODO: More Semantics Info...]
 

--- a/examples/adventofcode/2018/day_1.savi
+++ b/examples/adventofcode/2018/day_1.savi
@@ -1,7 +1,7 @@
 :import "spec"
 :import "collections"
 
-:primitive Day1
+:module Day1
   :fun a(env Env, input String)
     total I64 = 0
     input.each_split('\n') -> (line |

--- a/examples/adventofcode/2018/day_2.savi
+++ b/examples/adventofcode/2018/day_2.savi
@@ -1,7 +1,7 @@
 :import "spec"
 :import "collections"
 
-:primitive Day2
+:module Day2
   :fun has_duo(line): @has_target_count(line, 2)
   :fun has_trio(line): @has_target_count(line, 3)
   :fun has_target_count(line String, target_count I64)

--- a/examples/adventofcode/2018/day_3.savi
+++ b/examples/adventofcode/2018/day_3.savi
@@ -22,7 +22,7 @@
       dimensions[1]!             .parse_i64!.usize
     )
 
-:primitive Day3
+:module Day3
   :fun input_to_claims(env Env, input String)
     claims Array(Day3Claim) = [] // TODO: use split.map or map_split instead?
     input.each_split('\n') -> (line |

--- a/examples/adventofcode/2018/day_4.savi
+++ b/examples/adventofcode/2018/day_4.savi
@@ -52,7 +52,7 @@
 
     @new(guard, event, time)
 
-:primitive Day4
+:module Day4
   :fun sleeps_data_from(env Env, input String)
     // Parse the lines of the input, keeping the current guard id in memory
     // so that we can assign it wherever it was omitted from the journal entry.

--- a/examples/adventofcode/2018/day_5.savi
+++ b/examples/adventofcode/2018/day_5.savi
@@ -73,7 +73,7 @@
     )
     @
 
-:primitive Day5
+:module Day5
   :fun a(input)
     Day5Polymer.new(input).reduce.size
 

--- a/packages/collections/count.savi
+++ b/packages/collections/count.savi
@@ -1,4 +1,4 @@
-:primitive Count
+:module Count
   :: Yield each successive integer that is less than the given limit.
   :: For example, Count.to(3) will yield 0, 1, and 2.
   :fun to(limit USize)

--- a/packages/collections/hash.savi
+++ b/packages/collections/hash.savi
@@ -8,12 +8,12 @@
 
 :: A hashing strategy that hashes based on structural equality of the value,
 :: as implemented by the `hash` and `==` functions of the type.
-:primitive HashEq(Q Hashable(Q)'read)
+:module HashEq(Q Hashable(Q)'read)
   :fun hash(x box->(Q'aliased)) USize: x.hash
   :fun equal(x box->(Q'aliased), y box->(Q'aliased)) Bool: x == y
 
 :: A hashing strategy that hashes only the identity of the value,
 :: considering two values to be equal only if they have the same identity.
-:primitive HashIs(Q)
+:module HashIs(Q)
   :fun hash(x tag->Q) USize: (identity_digest_of x).hash
   :fun equal(x tag->Q, y tag->Q) Bool: x === y

--- a/packages/collections/map.savi
+++ b/packages/collections/map.savi
@@ -1,5 +1,5 @@
-:primitive _MapEmpty
-:primitive _MapDeleted
+:module _MapEmpty
+:module _MapDeleted
 
 :class _KV(K, V) // TODO: use a value type or tuple literal instead
   :var key K

--- a/packages/http2/protocol/protocol.savi
+++ b/packages/http2/protocol/protocol.savi
@@ -37,7 +37,7 @@
   :member SettingsTypeMaxFrameSize:         0x5
   :member SettingsTypeMaxHeaderListSize:    0x6
 
-:primitive ProtocolLimits
+:module ProtocolLimits
   :const max_stream_id USize:   0x7FFFFFFF
   :const max_window_size USize: 0x7FFFFFFF
   :const max_frame_size USize:  0x00FFFFFF

--- a/packages/io/lib.savi
+++ b/packages/io/lib.savi
@@ -17,7 +17,7 @@
   :fun pony_os_recv!(event CPointer(AsioEvent), buffer CPointer(U8), count USize) USize
   :fun pony_os_errno OSError
 
-:primitive _PonyOs
+:module _PonyOs
   :fun level_socket  I32: LibPonyOs.pony_os_sockopt_level(4138)
   :fun option_error  I32: LibPonyOs.pony_os_sockopt_option(827)
 

--- a/packages/json/json_token.savi
+++ b/packages/json/json_token.savi
@@ -15,17 +15,17 @@
   | JsonTokenArrayEnd
   )
 
-:primitive JsonTokenNull
-:primitive JsonTokenTrue
-:primitive JsonTokenFalse
-:primitive JsonTokenNumberPre
-:primitive JsonTokenNumber
-:primitive JsonTokenStringPre
-:primitive JsonTokenString
-:primitive JsonTokenKeyPre
-:primitive JsonTokenKey
-:primitive JsonTokenPairPost
-:primitive JsonTokenObjectStart
-:primitive JsonTokenObjectEnd
-:primitive JsonTokenArrayStart
-:primitive JsonTokenArrayEnd
+:module JsonTokenNull
+:module JsonTokenTrue
+:module JsonTokenFalse
+:module JsonTokenNumberPre
+:module JsonTokenNumber
+:module JsonTokenStringPre
+:module JsonTokenString
+:module JsonTokenKeyPre
+:module JsonTokenKey
+:module JsonTokenPairPost
+:module JsonTokenObjectStart
+:module JsonTokenObjectEnd
+:module JsonTokenArrayStart
+:module JsonTokenArrayEnd

--- a/packages/regex/_parser.savi
+++ b/packages/regex/_parser.savi
@@ -1,6 +1,6 @@
 :import "./pattern"
 
-:primitive _Parser
+:module _Parser
   :fun parse(input String) Pattern
     choice = PatternChoice.new
     pattern Pattern = PatternNone.new

--- a/spec/compiler/declarator.interpreter.savi.spec.md
+++ b/spec/compiler/declarator.interpreter.savi.spec.md
@@ -37,7 +37,7 @@ There is no declarator named `inpork` known within this file scope:
 It complains when the declarator is not in the right context.
 
 ```savi
-:primitive Example
+:module Example
   :yields String for U64
 ```
 ```error
@@ -75,7 +75,7 @@ This declaration didn't match any known declarator:
 It complains when the declaration's terms are not accepted by the declarators.
 
 ```savi
-:primitive Example
+:module Example
   :fun call(message String) U64
     :yields "bogus"
 ```

--- a/spec/compiler/eval_spec.cr
+++ b/spec/compiler/eval_spec.cr
@@ -1,7 +1,7 @@
 describe Savi::Compiler::Eval do
   it "complains if there is no Main actor defined in the root library" do
     content = <<-SOURCE
-    :primitive Example
+    :module Example
     SOURCE
 
     source = Savi::Source.new(

--- a/spec/compiler/macros/break_spec.cr
+++ b/spec/compiler/macros/break_spec.cr
@@ -2,7 +2,7 @@ describe Savi::Compiler::Macros do
   describe "break" do
     it "is transformed into a jump" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example
           while True (
             break
@@ -24,7 +24,7 @@ describe Savi::Compiler::Macros do
 
     it "can have an explicit value" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example
           while True (
             break "value"
@@ -47,7 +47,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond_1, cond_2)
           while True (
             break if cond_1
@@ -85,7 +85,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `if` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break if cond what now
@@ -120,7 +120,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break "value" if cond what now
@@ -160,7 +160,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break if
@@ -185,7 +185,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is a value but no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break "value" if
@@ -215,7 +215,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break unless cond
@@ -253,7 +253,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `unless` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break unless cond what now
@@ -288,7 +288,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break "value" unless cond what now
@@ -328,7 +328,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break unless
@@ -353,7 +353,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is a value but no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Breaks
+      :module Breaks
         :fun example(cond)
           while True (
             break "value" unless

--- a/spec/compiler/macros/error_spec.cr
+++ b/spec/compiler/macros/error_spec.cr
@@ -2,7 +2,7 @@ describe Savi::Compiler::Macros do
   describe "error!" do
     it "is transformed into a jump" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!
           error!
       SOURCE
@@ -17,7 +17,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!(cond)
           error! if cond
       SOURCE
@@ -36,7 +36,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `if` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!(cond)
           error! if cond what now
       SOURCE
@@ -69,7 +69,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!(cond)
           error! if
       SOURCE
@@ -92,7 +92,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!(cond)
           error! unless cond
       SOURCE
@@ -111,7 +111,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `unless` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!(cond)
           error! unless cond what now
       SOURCE
@@ -144,7 +144,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Errors
+      :module Errors
         :fun example!(cond)
           error! unless
       SOURCE

--- a/spec/compiler/macros/next_spec.cr
+++ b/spec/compiler/macros/next_spec.cr
@@ -2,7 +2,7 @@ describe Savi::Compiler::Macros do
   describe "next" do
     it "is transformed into a jump" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example
           while True (
             next
@@ -24,7 +24,7 @@ describe Savi::Compiler::Macros do
 
     it "can have an explicit value" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example
           while True (
             next "value"
@@ -47,7 +47,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond_1, cond_2)
           while True (
             next if cond_1
@@ -85,7 +85,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `if` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next if cond what now
@@ -120,7 +120,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next "value" if cond what now
@@ -160,7 +160,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next if
@@ -185,7 +185,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is a value but no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next "value" if
@@ -215,7 +215,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next unless cond
@@ -253,7 +253,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `unless` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next unless cond what now
@@ -288,7 +288,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next "value" unless cond what now
@@ -328,7 +328,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next unless
@@ -353,7 +353,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is a value but no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Nexts
+      :module Nexts
         :fun example(cond)
           while True (
             next "value" unless

--- a/spec/compiler/macros/return_spec.cr
+++ b/spec/compiler/macros/return_spec.cr
@@ -2,7 +2,7 @@ describe Savi::Compiler::Macros do
   describe "return" do
     it "is transformed into a jump" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example
           return
       SOURCE
@@ -17,7 +17,7 @@ describe Savi::Compiler::Macros do
 
     it "it can be nested, as silly as that is" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example
           @
           return (
@@ -47,7 +47,7 @@ describe Savi::Compiler::Macros do
 
     it "can have an explicit value" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example
           return "value"
       SOURCE
@@ -63,7 +63,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond_1, cond_2)
           return if cond_1
           return "value" if cond_2
@@ -89,7 +89,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `if` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return if cond what now
       SOURCE
@@ -122,7 +122,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return "value" if cond what now
       SOURCE
@@ -160,7 +160,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return if
       SOURCE
@@ -183,7 +183,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is a value but no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return "value" if
       SOURCE
@@ -211,7 +211,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return unless cond
           return "value" unless cond
@@ -237,7 +237,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the `unless` condition" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return unless cond what now
       SOURCE
@@ -270,7 +270,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `unless`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return "value" unless cond what now
       SOURCE
@@ -308,7 +308,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return unless
       SOURCE
@@ -331,7 +331,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is a value but no `unless` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Returns
+      :module Returns
         :fun example(cond)
           return "value" unless
       SOURCE

--- a/spec/compiler/macros/yield_spec.cr
+++ b/spec/compiler/macros/yield_spec.cr
@@ -2,7 +2,7 @@ describe Savi::Compiler::Macros do
   describe "yield" do
     it "is transformed into a yield" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Yields
+      :module Yields
         :fun example
           yield "value"
       SOURCE
@@ -20,7 +20,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are more terms after the value" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Yields
+      :module Yields
         :fun example
           yield "value" what now
       SOURCE
@@ -53,7 +53,7 @@ describe Savi::Compiler::Macros do
 
     it "can be conditional with `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Yields
+      :module Yields
         :fun example(cond)
           yield "value" if cond
       SOURCE
@@ -72,7 +72,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there are extra terms after the value and `if`" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Yields
+      :module Yields
         :fun example(cond)
           yield "value" if cond what now
       SOURCE
@@ -110,7 +110,7 @@ describe Savi::Compiler::Macros do
 
     it "complains if there is no `if` condition term" do
       source = Savi::Source.new_example <<-SOURCE
-      :primitive Yields
+      :module Yields
         :fun example(cond)
           yield "value" if
       SOURCE

--- a/spec/compiler/refer_spec.cr
+++ b/spec/compiler/refer_spec.cr
@@ -1,7 +1,7 @@
 describe Savi::Compiler::Refer do
   it "returns the same output state when compiled again with same sources" do
     source = Savi::Source.new_example <<-SOURCE
-    :primitive Greeting
+    :module Greeting
       :fun greet(env Env):
         env.out.print("Hello, World")
 

--- a/spec/compiler/refer_type_spec.cr
+++ b/spec/compiler/refer_type_spec.cr
@@ -1,7 +1,7 @@
 describe Savi::Compiler::ReferType do
   it "returns the same output state when compiled again with same sources" do
     source = Savi::Source.new_example <<-SOURCE
-    :primitive Greeting
+    :module Greeting
       :fun greet(env Env):
         env.out.print("Hello, World")
 

--- a/spec/compiler/type_check.calls.savi.spec.md
+++ b/spec/compiler/type_check.calls.savi.spec.md
@@ -23,7 +23,7 @@ It complains when calling on types without that function:
 :class Barable
   :fun bar: "bar"
 
-:primitive Bazable
+:module Bazable
   :fun baz: "baz"
 ```
 ```savi
@@ -41,7 +41,7 @@ It complains when calling on types without that function:
 //            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // - Bazable has no 'bar' function:
-// :primitive Bazable
+// :module Bazable
 //            ^~~~~~~
 
 // - maybe you meant to call the 'baz' function:
@@ -62,8 +62,8 @@ The 'bar' function can't be called on this receiver:
            ^~~
 
 - Bazable has no 'bar' function:
-:primitive Bazable
-           ^~~~~~~
+:module Bazable
+        ^~~~~~~
 
 - maybe you meant to call the 'baz' function:
   :fun baz: "baz"
@@ -75,7 +75,7 @@ The 'bar' function can't be called on this receiver:
 It suggests a similarly named function when found:
 
 ```savi
-:primitive SomeHFunctions
+:module SomeHFunctions
   :fun hey
   :fun hell
   :fun hello_world
@@ -89,8 +89,8 @@ The 'hello' function can't be called on this receiver:
                    ^~~~~
 
 - SomeHFunctions has no 'hello' function:
-:primitive SomeHFunctions
-           ^~~~~~~~~~~~~~
+:module SomeHFunctions
+        ^~~~~~~~~~~~~~
 
 - maybe you meant to call the 'hell' function:
   :fun hell
@@ -102,7 +102,7 @@ The 'hello' function can't be called on this receiver:
 It suggests a similarly named function (without '!') when found:
 
 ```savi
-:primitive HelloNotPartial
+:module HelloNotPartial
   :fun hello
 ```
 ```savi
@@ -114,8 +114,8 @@ The 'hello!' function can't be called on this receiver:
                     ^~~~~~
 
 - HelloNotPartial has no 'hello!' function:
-:primitive HelloNotPartial
-           ^~~~~~~~~~~~~~~
+:module HelloNotPartial
+        ^~~~~~~~~~~~~~~
 
 - maybe you meant to call 'hello' (without '!'):
   :fun hello
@@ -127,7 +127,7 @@ The 'hello!' function can't be called on this receiver:
 It suggests a similarly named function (with '!') when found:
 
 ```savi
-:primitive HelloPartial
+:module HelloPartial
   :fun hello!
 ```
 ```savi
@@ -139,8 +139,8 @@ The 'hello' function can't be called on this receiver:
                  ^~~~~
 
 - HelloPartial has no 'hello' function:
-:primitive HelloPartial
-           ^~~~~~~~~~~~
+:module HelloPartial
+        ^~~~~~~~~~~~
 
 - maybe you meant to call 'hello!' (with a '!'):
   :fun hello!

--- a/spec/compiler/type_check.completeness.savi.spec.md
+++ b/spec/compiler/type_check.completeness.savi.spec.md
@@ -14,7 +14,7 @@ It complains when access to the self is shared while still incomplete:
   :var y U64
   :var z U64
 
-:primitive AccessWhileIncomplete
+:module AccessWhileIncomplete
   :fun data(any Any'box)
     any
 ```
@@ -51,11 +51,11 @@ It allows opaque sharing of the self while still incomplete and non-opaque shari
   :var y U64
   :var z U64
 
-:primitive AccessAfterComplete
+:module AccessAfterComplete
   :fun data(any Any'box)
     any
 
-:primitive TouchWhileIncomplete
+:module TouchWhileIncomplete
   :fun data(any Any'tag)
     any
 ```

--- a/spec/compiler/type_check.generics.savi.spec.md
+++ b/spec/compiler/type_check.generics.savi.spec.md
@@ -148,22 +148,22 @@ It can supply a default type argument based on one of the other ones:
 :trait non ToStringFunction(A)
   :fun non to_string(a A) String
 
-:primitive ToStringDefault(A)
+:module ToStringDefault(A)
   :fun non to_string(a A): "(unknown)"
 
-:primitive GenericWithDefault(A share, B share, S ToStringFunction(A) = ToStringDefault(A))
-:primitive GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
+:module GenericWithDefault(A share, B share, S ToStringFunction(A) = ToStringDefault(A))
+:module GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
 ```
 ```error
 This type argument won't satisfy the type parameter bound:
-:primitive GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
-                                                                           ^~~~
+:module GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
+                                                                        ^~~~
 
 - the type parameter bound is ToStringFunction(U64):
-:primitive GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
-                                                     ^~~~~~~~~~~~~~~~~~~
+:module GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
+                                                  ^~~~~~~~~~~~~~~~~~~
 
 - the type argument is None:
-:primitive GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
-                                                                           ^~~~
+:module GenericWithBadDefault(A share, B share, S ToStringFunction(A) = None)
+                                                                        ^~~~
 ```

--- a/spec/compiler/type_check.subtyping.savi.spec.md
+++ b/spec/compiler/type_check.subtyping.savi.spec.md
@@ -120,7 +120,7 @@ It requires a sub-func to have the same number of params:
   :fun example2(a U64, b U64, c U64) None
   :fun example3(a U64, b U64, c U64) None
 
-:primitive ConcreteNot3Params
+:module ConcreteNot3Params
   :is Trait3Params
   :fun example1 None
   :fun example2(a U64, b U64) None
@@ -227,7 +227,7 @@ It requires a sub-func to have covariant return and contravariant params:
   :fun example3(a U64, b U64, c U64) None
   :fun example4(a Numeric, b Numeric, c Numeric) None
 
-:primitive ConcreteParamsReturn
+:module ConcreteParamsReturn
   :is TraitParamsReturn
   :fun example1 U64: 0
   :fun example2 Numeric: U64[0]
@@ -272,7 +272,7 @@ It won't show assignment errors if (even erroneously) asserted as a subtype:
 :trait non TraitExampleNone
   :fun example None
 
-:primitive ConcreteWithoutExampleNone
+:module ConcreteWithoutExampleNone
   :is TraitExampleNone
 ```
 ```savi

--- a/spec/compiler/type_check.yields.savi.spec.md
+++ b/spec/compiler/type_check.yields.savi.spec.md
@@ -5,7 +5,7 @@ pass: type_check
 This type will be used throughout the following examples to demonstrate calling with yield blocks:
 
 ```savi
-:primitive Numbers
+:module Numbers
   :fun will_not_yield: None
 
   :fun yield_99

--- a/spec/compiler/types.savi.spec.md
+++ b/spec/compiler/types.savi.spec.md
@@ -8,7 +8,7 @@ It analyzes a simple system of types.
 :trait box _Describable
   :fun describe String
 
-:primitive Example1(A _Describable)
+:module Example1(A _Describable)
   :fun example(a A, cond Bool)
     x String = a.describe
     y = if cond ("string" | b"bytes")
@@ -16,8 +16,8 @@ It analyzes a simple system of types.
 ```types.type_variables_list Example1.example
 T'A'^1
   <: (_Describable & box)
-  :primitive Example1(A _Describable)
-                        ^~~~~~~~~~~~
+  :module Example1(A _Describable)
+                     ^~~~~~~~~~~~
 ~~~
 T'return'2
   :> T'y'7'aliased
@@ -136,7 +136,7 @@ T'value'3
 It analyzes an array literal, its elements, and its antecedent.
 
 ```savi
-:primitive ArrayExample
+:module ArrayExample
   :fun example
     a Array(F64)'val = [1, 2.3]
 ```

--- a/spec/compiler/verify_spec.cr
+++ b/spec/compiler/verify_spec.cr
@@ -1,7 +1,7 @@
 describe Savi::Compiler::Verify do
   it "does not impose checks on the Main actor if it doesn't exist" do
     source = Savi::Source.new_example <<-SOURCE
-    :primitive Example
+    :module Example
     SOURCE
 
     Savi.compiler.compile([source], :verify).errors.should be_empty

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -228,7 +228,7 @@ describe Savi::Parser do
 
   it "correctly parses a negative integer literal in a single-line decl" do
     source = Savi::Source.new_example <<-SOURCE
-    :primitive Example
+    :module Example
       :const x U64: 1
       :const y U64: -1
     SOURCE
@@ -238,7 +238,7 @@ describe Savi::Parser do
     # Can't use array literals here because Crystal is too slow to compile them.
     ast.to_a.pretty_inspect(74).should eq <<-AST
     [:doc,
-     [:declare, [[:ident, "primitive"], [:ident, "Example"]], [:group, ":"]],
+     [:declare, [[:ident, "module"], [:ident, "Example"]], [:group, ":"]],
      [:declare,
       [[:ident, "const"], [:ident, "x"], [:ident, "U64"]],
       [:group, ":", [:integer, 1]]],
@@ -250,7 +250,7 @@ describe Savi::Parser do
 
   it "returns the same AST when called again with the same source content" do
     content = <<-SOURCE
-    :primitive Example
+    :module Example
       :const greeting String: "Hello, World!"
     SOURCE
 

--- a/spec/savi/prelude/inspect_spec.savi
+++ b/spec/savi/prelude/inspect_spec.savi
@@ -1,6 +1,6 @@
 :import "spec"
 
-:primitive ArbitraryTestPrimitive
+:module ArbitraryTestModule
 
 :class InspectSpec
   :is Spec
@@ -45,9 +45,9 @@
   :it "inspects the number zero"
     @assert = Inspect[U8[0]] == "0"
 
-  :it "inspects a primitive with its type name"
+  :it "inspects a module with its type name"
     @assert = Inspect[None] == "None"
-    @assert = Inspect[ArbitraryTestPrimitive] == "ArbitraryTestPrimitive"
+    @assert = Inspect[ArbitraryTestModule] == "ArbitraryTestModule"
 
   :it "inspects strings"
     @assert = Inspect["example"] == "\"example\""

--- a/spec/savi/semantics/displacing_assignment_spec.savi
+++ b/spec/savi/semantics/displacing_assignment_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive DisplacingAssignmentSpec
+:module DisplacingAssignmentSpec
   :fun run(test MicroTest)
     displacable = "original"
     displaced = displacable <<= "new"

--- a/spec/savi/semantics/identity_spec.savi
+++ b/spec/savi/semantics/identity_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive IdentitySpec
+:module IdentitySpec
   :fun run(test MicroTest)
     test["identity_digest_of string literal =="].pass =
       identity_digest_of "example" ==

--- a/spec/savi/semantics/reflection_spec.savi
+++ b/spec/savi/semantics/reflection_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive ReflectionSpec
+:module ReflectionSpec
   :fun run(test MicroTest)
     test["reflection_of_type.string String"].pass =
       (reflection_of_type "example").string == "String"

--- a/spec/savi/semantics/return_spec.savi
+++ b/spec/savi/semantics/return_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive _EarlyReturn
+:module _EarlyReturn
   :fun non conditional(early Bool) U64
     if early (
       return 33
@@ -9,7 +9,7 @@
     )
     11
 
-:primitive ReturnSpec
+:module ReturnSpec
   :fun run(test MicroTest)
     test["return; with early return value"].pass =
       U64[33] == _EarlyReturn.conditional(True)

--- a/spec/savi/semantics/source_code_spec.savi
+++ b/spec/savi/semantics/source_code_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive SourceCodeSpec
+:module SourceCodeSpec
   :fun run(test MicroTest)
     zero = U64[0]
 

--- a/spec/savi/semantics/trait_non.savi
+++ b/spec/savi/semantics/trait_non.savi
@@ -3,20 +3,20 @@
 :trait non TraitNon
   :fun non example: "value"
 
-:primitive TraitNonDefault
+:module TraitNonDefault
   :is TraitNon
 
-:primitive TraitNonOverride
+:module TraitNonOverride
   :is TraitNon
   :fun non example: "other value"
 
-:primitive TraitNonSpec
+:module TraitNonSpec
   :fun run(test MicroTest)
     test["fun non call on trait singleton"].pass =
       TraitNon.example == "value"
 
-    test["trait-inherited fun non call on primitive"].pass =
+    test["trait-inherited fun non call on module"].pass =
       TraitNonDefault.example == "value"
 
-    test["overriden fun non call on primitive"].pass =
+    test["overriden fun non call on module"].pass =
       TraitNonOverride.example == "other value"

--- a/spec/savi/semantics/try_spec.savi
+++ b/spec/savi/semantics/try_spec.savi
@@ -1,11 +1,11 @@
 :import "../micro_test" (MicroTest)
 
-:primitive _Err
+:module _Err
   :fun non not_really!: None
   :fun non now!: @inner!
   :fun non inner!: error!
 
-:primitive TrySpec
+:module TrySpec
   :fun run(test MicroTest)
     zero = U64[0]
 

--- a/spec/savi/semantics/while_spec.savi
+++ b/spec/savi/semantics/while_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive WhileSpec
+:module WhileSpec
   :fun run(test MicroTest)
     zero = U64[0]
 

--- a/spec/savi/semantics/yielding_call_spec.savi
+++ b/spec/savi/semantics/yielding_call_spec.savi
@@ -1,6 +1,6 @@
 :import "../micro_test" (MicroTest)
 
-:primitive Yielding
+:module Yielding
   :fun call(count_remaining U64, array Array(String)) U64
   :yields U64 for String
     while (count_remaining > 0) (
@@ -10,7 +10,7 @@
     array << "."
     count_remaining
 
-:primitive YieldingCallSpec
+:module YieldingCallSpec
   :fun run(test MicroTest)
     array Array(String) = []
     total U64 = 0

--- a/src/prelude/asio_event.savi
+++ b/src/prelude/asio_event.savi
@@ -1,7 +1,7 @@
 :trait tag AsioEventNotify
   :be _event_notify(event CPointer(AsioEvent), flags U32, arg U32)
 
-:primitive AsioEvent
+:module AsioEvent
   :fun none: CPointer(AsioEvent).null
 
   :const dispose            U32: 0

--- a/src/prelude/declarators/declarators.savi
+++ b/src/prelude/declarators/declarators.savi
@@ -102,7 +102,7 @@
   :term name_and_params NameMaybeWithParams
 
 // TODO: Document this.
-:declarator primitive
+:declarator module
   :intrinsic
   :begins type
   :begins type_singleton

--- a/src/prelude/inspect.savi
+++ b/src/prelude/inspect.savi
@@ -17,7 +17,7 @@
 
 // TODO: Move this out of prelude maybe? Does that make sense?
 // TODO: Make this into a trait with "implement for"/typeclass style polymorphism
-:primitive Inspect
+:module Inspect
   :fun "[]"(input Any'box) String'val // TODO: use `box` instead of `Any'box`
     @into(String.new_iso, input)
 

--- a/src/prelude/none.savi
+++ b/src/prelude/none.savi
@@ -1,1 +1,1 @@
-:primitive None
+:module None

--- a/src/prelude/platform.savi
+++ b/src/prelude/platform.savi
@@ -1,4 +1,4 @@
-:primitive Platform
+:module Platform
   :const ilp32 Bool: compiler intrinsic
   :const lp64 Bool: compiler intrinsic
   :const llp64 Bool: False // TODO: this is 65-but windows, instead of lp64

--- a/src/prelude/string.savi
+++ b/src/prelude/string.savi
@@ -450,7 +450,7 @@
 
 :: Encode the code point into UTF-8. It returns a tuple with the size of the
 :: encoded data and then the data.
-:primitive _UTF8Encoder
+:module _UTF8Encoder
   :fun encode(value U32)
     :yields (USize, U8, U8, U8, U8)
     case value < (

--- a/src/prelude/utf8_decoding.savi
+++ b/src/prelude/utf8_decoding.savi
@@ -22,10 +22,10 @@
 // TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
 // OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-:: This primitive can be used collaboratively with the caller to decode UTF-8.
+:: This module can be used collaboratively with the caller to decode UTF-8.
 ::
 :: It uses a DFA (deterministic finite automaton) state machine, with the
-:: caller maintaining state on the calling side, so that the primitive itself
+:: caller maintaining state on the calling side, so that the module itself
 :: can be stateless, avoiding the need for it to be allocated.
 ::
 :: The general-purpose usage looks like this:
@@ -45,7 +45,7 @@
 ::
 :: See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details on the DFA.
 ::
-:primitive UTF8Decoding // TODO: make this private or rename the file
+:module UTF8Decoding // TODO: make this private or rename the file
   // See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
   :const _type_table_data Array(U8)'val: [
     0,   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 00..0f

--- a/src/savi/ast.cr
+++ b/src/savi/ast.cr
@@ -752,7 +752,7 @@ module Savi::AST
   # the result of evaluating the `else_body` Term; otherwise, the result
   # of the final execution of the `body` Term will be used as the result value.
   # In simple cases, the `repeat_cond` is the same as the `initial_cond` and
-  # the `else_body` just returns a simple value of the `None` primitive.
+  # the `else_body` just returns a simple value of the `None` module.
   #
   # This is an internal AST type which has no corresponding source code syntax,
   # because such a construct is only created inside macro expansions.

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -2895,7 +2895,7 @@ class Savi::Compiler::CodeGen
     type_name_string_opaque =
       @builder.bit_cast(gen_string(mutator_gtype.type_def.llvm_name), @ptr)
 
-    # Generate a type descriptor, so this can masquerade as a real primitive.
+    # Generate a type descriptor, so this can masquerade as a real module.
     raise NotImplementedError.new("gen_reflection_mutator_of_type in Verona") \
       if @runtime.is_a?(VeronaRT)
     desc = gen_global_for_const(mutator_gtype.desc_type.const_struct [
@@ -3488,7 +3488,7 @@ class Savi::Compiler::CodeGen
   # This defines the global singleton stateless value associated with this type.
   # This value is invoked whenever you reference the type with as a `non`,
   # acting as a runtime representation of a type itself rather than an instance.
-  # For primitives, this is the only value you'll ever see.
+  # For modules, this is the only value you'll ever see.
   def gen_singleton(gtype)
     global = @mod.globals.add(gtype.struct_type, gtype.type_def.llvm_name)
     global.linkage = LLVM::Linkage::LinkerPrivate

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -566,7 +566,7 @@ class Savi::Compiler::CodeGen::PonyRT
     env = gen_alloc(g, g.gtypes["Env"], nil, "env")
     g.builder.call(g.gtypes["Env"]["_create"].llvm_func, [env, argc, argv, envp])
 
-    # TODO: Run primitive initialisers using the main actor's heap.
+    # TODO: Run module initialisers using the main actor's heap.
 
     # Send the env in a message to the main actor's constructor
     g.builder.call(g.gtype_main.default_constructor.send_llvm_func, [main_actor, env])
@@ -593,7 +593,7 @@ class Savi::Compiler::CodeGen::PonyRT
     # On success (or after running the failure block), do the following:
     g.finish_block_and_move_to(post_block)
 
-    # TODO: Run primitive finalizers.
+    # TODO: Run module finalizers.
 
     # Become nothing (stop being the main actor).
     g.builder.call(g.mod.functions["pony_become"], [

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -52,7 +52,7 @@ module Savi::Program::Intrinsic
           declare.body.not_nil!.terms.first,
         )
       when "actor", "class", "struct", "trait",
-           "numeric", "enum", "primitive", "ffi"
+           "numeric", "enum", "module", "ffi"
         name, params =
           AST::Extract.name_and_params(terms["name_and_params"].not_nil!)
 
@@ -89,7 +89,7 @@ module Savi::Program::Intrinsic
           type.add_tag(:simple_value)
           type.add_tag(:numeric)
           type.add_tag(:enum)
-        when "primitive"
+        when "module"
           type.add_tag(:singleton)
           type.add_tag(:ignores_cap)
         when "ffi"
@@ -420,7 +420,7 @@ module Savi::Program::Intrinsic
     when "fun", "be", "new"
       scope.current_type.functions << scope.current_function
       scope.current_function = nil
-    when "actor", "class", "struct", "primitive"
+    when "actor", "class", "struct", "module"
       scope.current_library.types << scope.current_type
       scope.current_type = nil
     when "numeric"


### PR DESCRIPTION
As [discussed in Zulip](https://savi.zulipchat.com/#narrow/stream/294905-language/topic/.3Aprimitive.20rename.20to.20.3Amodule), we think this will make the intent of the concept more clear to newcomers that don't already know Pony concepts.