### PR TITLE
Fix uses of `.exit_status` to prefer `.exit_code`.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -71,11 +71,11 @@ class Savi::Compiler::Binary
     link_args << "-o" << ctx.options.binary_name
 
     res = Process.run("/usr/bin/env", link_args, output: STDOUT, error: STDERR)
-    raise "linker failed" unless res.exit_status == 0
+    raise "linker failed" unless res.exit_code == 0
 
     if ctx.options.release
       res = Process.run("/usr/bin/env", ["strip", ctx.options.binary_name], output: STDOUT, error: STDERR)
-      raise "strip failed" unless res.exit_status == 0
+      raise "strip failed" unless res.exit_code == 0
     end
   ensure
     File.delete(obj_filename) if obj_filename

--- a/src/savi/compiler/binary_verona.cr
+++ b/src/savi/compiler/binary_verona.cr
@@ -54,11 +54,11 @@ class Savi::Compiler::BinaryVerona
     link_args << "-o" << ctx.options.binary_name
 
     res = Process.run("/usr/bin/env", link_args, output: STDOUT, error: STDERR)
-    raise "linker failed" unless res.exit_status == 0
+    raise "linker failed" unless res.exit_code == 0
 
     if ctx.options.release
       res = Process.run("/usr/bin/env", ["strip", ctx.options.binary_name], output: STDOUT, error: STDERR)
-      raise "strip failed" unless res.exit_status == 0
+      raise "strip failed" unless res.exit_code == 0
     end
   ensure
     File.delete(obj_filename) if obj_filename
@@ -66,6 +66,6 @@ class Savi::Compiler::BinaryVerona
 
   def self.run_last_compiled_program
     res = Process.run("/usr/bin/env", ["./" + Compiler::CompilerOptions::DEFAULT_BINARY_NAME], output: STDOUT, error: STDERR)
-    res.exit_status
+    res.exit_code
   end
 end

--- a/src/savi/compiler/eval.cr
+++ b/src/savi/compiler/eval.cr
@@ -17,6 +17,6 @@ class Savi::Compiler::Eval
     binary_path = "./#{ctx.options.binary_name}"
 
     res = Process.run("/usr/bin/env", [binary_path], output: STDOUT, error: STDERR)
-    @exitcode = res.exit_status
+    @exitcode = res.exit_code
   end
 end


### PR DESCRIPTION
It turns out that `.exit_status` is not correct. We want `.exit_code`.
See discussion here: https://github.com/crystal-lang/crystal/issues/8381