### PR TITLE
Convert some types from class to struct.

### DIFF
--- a/packages/collections/map.savi
+++ b/packages/collections/map.savi
@@ -73,9 +73,9 @@
     value_alias V'aliased = value // TODO: remove the V'aliased explicit type?
     try (
       index = @_search(key)
-      entry = @_array[index]! <<= _KV(K, V).new(--key, --value)
+      old_entry = @_array[index]! <<= _KV(K, V).new(--key, --value)
 
-      case entry <: (
+      case old_entry <: (
       | _MapDeleted |
         @_size += 1
       | _MapEmpty |

--- a/packages/collections/map.savi
+++ b/packages/collections/map.savi
@@ -1,9 +1,9 @@
 :primitive _MapEmpty
 :primitive _MapDeleted
 
-:class _KV(K, V) // TODO: use a value type or tuple literal instead
-  :var key K
-  :var value V
+:struct _KV(K, V)
+  :let key K
+  :let value V
   :new (@key, @value)
 
 :alias MapIs(K, V): Map(K, V, HashIs(K))
@@ -73,18 +73,15 @@
     value_alias V'aliased = value // TODO: remove the V'aliased explicit type?
     try (
       index = @_search(key)
-      entry = @_array[index]!
+      entry = @_array[index]! <<= _KV(K, V).new(--key, --value)
 
       case entry <: (
-      | _KV(K, V) | entry.value = --value
-      |
-        @_array[index]! = _KV(K, V).new(--key, --value)
+      | _MapDeleted |
         @_size += 1
-
-        if (entry <: _MapEmpty) (
-          if (@_size * 4 > @_array.size * 3) (
-            @_resize(@_array.size * 2)
-          )
+      | _MapEmpty |
+        @_size += 1
+        if (@_size * 4 > @_array.size * 3) (
+          @_resize(@_array.size * 2)
         )
       )
     )

--- a/packages/collections/ordered_map.savi
+++ b/packages/collections/ordered_map.savi
@@ -153,11 +153,13 @@
   :fun ref delete(key K)
     try (
       index = @_search(key)
-      entry = @_array[index]!.as!(@->(_KVBA(K, V))) // TODO: fix @-> parentheses
-      @_array[index]! = _MapDeleted // TODO: destructive read/pop instead of read then write
+      entry = @_array[index]! <<= _MapDeleted
+
       @_size -= 1
       @_head = if (@_size == 0) (None | @_head.as!(@->(_KVBA(K, V))).before!) // TODO: fix @-> parentheses
-      @_remove_entry_from_place(entry)
+      @_remove_entry_from_place(
+        entry.as!(@->(_KVBA(K, V))) // TODO: fix @-> parentheses
+      )
     )
     None
 

--- a/spec/savi/prelude/array_spec.savi
+++ b/spec/savi/prelude/array_spec.savi
@@ -80,6 +80,14 @@
     @assert = try (array[3]!, False | True)
     @assert = try (array[3]! = 36, False | True)
 
+  :it "supports element displacing assignment"
+    array Array(U8) = [3, 6, 12]
+    @assert = try ((array[0]! <<= 1) == 3 | False)
+    @assert = try ((array[1]! <<= 2) == 6 | False)
+    @assert = try ((array[2]! <<= 3) == 12 | False)
+    @assert = try (array[3]! <<= 36, False | True)
+    @assert = array == [1, 2, 3]
+
   :it "gives convenient access to the first and last elements, if existent"
     array Array(U8) = [3, 6, 12]
     @assert = try (array.first! == 3 | False)

--- a/src/prelude/array.savi
+++ b/src/prelude/array.savi
@@ -101,6 +101,10 @@
     if (@size <= index) error!
     @_ptr._assign_at(index, --value)
 
+  :fun ref "[]<<=!"(index, value)
+    if (@size <= index) error!
+    @_ptr._displace_at(index, --value)
+
   :fun ref "<<"(value): @push(--value)
   :fun ref push(value)
     @reserve(@_size + 1)

--- a/src/prelude/env.savi
+++ b/src/prelude/env.savi
@@ -27,7 +27,7 @@
   :fun "exit_code="(value)
     LibPony.pony_exitcode(value)
 
-:class val EnvVars
+:struct val EnvVars
   :let _vars Array(EnvVar)
 
   :new val _from_envp(envp CPointer(CPointer(U8)'ref)'ref)
@@ -58,7 +58,7 @@
   :fun "[]!"(needle String) String
     @[needle].as!(String)
 
-:class val EnvVar
+:struct val EnvVar
   :let key String'val
   :let value String'val
 

--- a/src/prelude/string.savi
+++ b/src/prelude/string.savi
@@ -442,8 +442,7 @@
     )
     --res
 
-// TODO: Convert into `:struct`
-:class val StringPair
+:struct val StringPair
   :let first String'val
   :let second String'val
   :new (@first, @second)

--- a/src/savi/compiler/code_gen/gen_func.cr
+++ b/src/savi/compiler/code_gen/gen_func.cr
@@ -162,7 +162,11 @@ class Savi::Compiler::CodeGen
 
       def gen_error_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value, value_expr : AST::Node?)
         tuple = llvm_func_ret_type(g, gfunc).undef
-        tuple = g.builder.insert_value(tuple, value, 0)
+        # Doing insert_value for slot 0 fails here when the normal return value
+        # is a struct but the error value is not a struct.
+        # Or more broadly, whenever the two do not match in size.
+        # For now we do not implement this; we check for it and fail loudly.
+        raise NotImplementedError.new("error value") unless value == g.gen_none
         tuple = g.builder.insert_value(tuple, g.llvm.int1.const_int(1), 1)
         g.builder.ret(tuple)
       end

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -1007,6 +1007,15 @@ class Savi::Compiler::CodeGen::PonyRT
     ])
   end
 
+  def gen_trace_tuple(g : CodeGen, dst, src_type)
+    src_gtype = g.gtype_of(src_type)
+
+    src_gtype.fields.each_with_index { |(name, field_type), index|
+      field = g.builder.extract_value(dst, index)
+      gen_trace(g, field, field, field_type, field_type)
+    }
+  end
+
   def gen_trace_dynamic(g : CodeGen, dst, src_type, dst_type, after_block)
     if src_type.is_union?
       src_type.union_children.each do |child_type|
@@ -1091,7 +1100,7 @@ class Savi::Compiler::CodeGen::PonyRT
       g.builder.br(after_block)
       g.finish_block_and_move_to(after_block)
     when :tuple
-      raise NotImplementedError.new("tuple") # TODO
+      gen_trace_tuple(g, dst, src_type)
     else
       raise NotImplementedError.new(trace_kind)
     end


### PR DESCRIPTION
This PR converts a few types from `:class` to `:struct` and clears up some issues that were encountered while doing so. See individual commit messages for details.

Resolves #79.