### PR TITLE
Add generic `Pair` type.

### DIFF
--- a/packages/collections/map.savi
+++ b/packages/collections/map.savi
@@ -1,17 +1,12 @@
 :module _MapEmpty
 :module _MapDeleted
 
-:struct _KV(K, V)
-  :let key K
-  :let value V
-  :new (@key, @value)
-
 :alias MapIs(K, V): Map(K, V, HashIs(K))
 
 :class Map(K, V, H HashFunction(K) = HashEq(K))
   :is MapReadable(K, V)
   :var _size USize: 0
-  :var _array Array((_KV(K, V) | _MapEmpty | _MapDeleted))
+  :var _array Array((Pair(K, V) | _MapEmpty | _MapDeleted))
 
   :fun size: @_size
 
@@ -19,7 +14,7 @@
     @_init_array(((prealloc * 4) / 3).max(8).next_pow2)
 
   :fun ref _init_array(space USize)
-    @_array = Array((_KV(K, V) | _MapEmpty | _MapDeleted)).new(space)
+    @_array = Array((Pair(K, V) | _MapEmpty | _MapDeleted)).new(space)
     Count.to(space) -> (@_array << _MapEmpty)
 
   :fun ref _resize(space USize)
@@ -30,7 +25,7 @@
     @_init_array(space)
 
     old_array.each -> (entry |
-      if (entry <: _KV(K, V)) (
+      if (entry <: Pair(K, V)) (
         try (@_array[@_search(entry.key)]! = entry)
       )
     )
@@ -58,7 +53,7 @@
   :: > error! // this key no longer has an assigned value
   ::
   :fun "[]!"(key K)
-    @_array[@_search(key)]!.as!(@->(_KV(K, V))).value
+    @_array[@_search(key)]!.as!(@->(Pair(K, V))).value
 
   :: Assign the given value to the given key in the map.
   :: The previous value will be overwritten and discarded if present.
@@ -73,7 +68,7 @@
     value_alias V'aliased = value // TODO: remove the V'aliased explicit type?
     try (
       index = @_search(key)
-      old_entry = @_array[index]! <<= _KV(K, V).new(--key, --value)
+      old_entry = @_array[index]! <<= Pair(K, V).new(--key, --value)
 
       case old_entry <: (
       | _MapDeleted |
@@ -119,7 +114,7 @@
         entry = @_array[idx]!
 
         case entry <: (
-        | @->(_KV(K, V)) |
+        | @->(Pair(K, V)) |
           if H.equal(key, entry.key) (
             result_idx = idx
             found = True
@@ -148,7 +143,7 @@
   :: Yield each key and value in the map.
   :fun each
     @_array.each -> (entry |
-      if (entry <: @->(_KV(K, V))) (
+      if (entry <: @->(Pair(K, V))) (
         yield (entry.key, entry.value)
       )
     )
@@ -159,7 +154,7 @@
   :fun each_until
     :yields for Bool
     @_array.each_until -> (entry |
-      if (entry <: @->(_KV(K, V))) (
+      if (entry <: @->(Pair(K, V))) (
         yield (entry.key, entry.value)
       |
         False

--- a/src/prelude/env.savi
+++ b/src/prelude/env.savi
@@ -28,7 +28,7 @@
     LibPony.pony_exitcode(value)
 
 :struct val EnvVars
-  :let _vars Array(EnvVar)
+  :let _vars Array(Pair(String))
 
   :new val _from_envp(envp CPointer(CPointer(U8)'ref)'ref)
     @_vars = []
@@ -37,7 +37,11 @@
         arg = envp._get_at(0)
         break if arg.is_null
 
-        try @_vars.push(EnvVar._from_cstring!(arg))
+        try (
+          len = InspectLibC.strlen(arg).usize
+          pair = String.val_from_cpointer(arg, len, len).split2!('=')
+          @_vars.push(pair)
+        )
 
         envp = envp._offset(1)
       )
@@ -57,16 +61,6 @@
 
   :fun "[]!"(needle String) String
     @[needle].as!(String)
-
-:struct val EnvVar
-  :let key String'val
-  :let value String'val
-
-  :new val _from_cstring!(cstring CPointer(U8)'ref)
-    len = InspectLibC.strlen(cstring).usize
-    pair = String.val_from_cpointer(cstring, len, len).split2!('=')
-    @key = pair.first
-    @value = pair.second
 
 :actor StdStream
   :let _stream CPointer(None)'ref

--- a/src/prelude/pair.savi
+++ b/src/prelude/pair.savi
@@ -1,0 +1,8 @@
+:struct Pair(A, B = A)
+  :let first A
+  :let second B
+  :new (@first, @second)
+
+  // Convenience aliases for when this is used as a key/value pair.
+  :fun key: @first
+  :fun value: @second

--- a/src/prelude/string.savi
+++ b/src/prelude/string.savi
@@ -354,9 +354,9 @@
     )
     @
 
-  :fun val split2!(split_byte U8) StringPair
+  :fun val split2!(split_byte U8) Pair(String)
     pos = @_index_of!(split_byte)
-    StringPair.new(@_slice(0, pos), @_slice(pos + 1, @_size))
+    Pair(String).new(@_slice(0, pos), @_slice(pos + 1, @_size))
 
   :: Returns the integer index of the first occurence of the given character `char`.
   :fun val _index_of!(char U8, offset USize = 0) USize
@@ -441,11 +441,6 @@
       if (index != others.size - 1) (res << separator)
     )
     --res
-
-:struct val StringPair
-  :let first String'val
-  :let second String'val
-  :new (@first, @second)
 
 :: Encode the code point into UTF-8. It returns a tuple with the size of the
 :: encoded data and then the data.


### PR DESCRIPTION
With one type argument, it uses the same type for both elements.
With two type arguments, it uses different types for the elements.

This type is intended to be used anywhere a pair of values is needed,
where there is no need for additional methods more specific to the type.