### PR TITLE
Add formatting support to LSP Server

### DIFF
--- a/lib/.shards.info
+++ b/lib/.shards.info
@@ -6,7 +6,7 @@ shards:
     version: 0.2.1+git.commit.601363cb2ce9c57ccc70967eb270005950f2f7b0
   lsp:
     git: https://github.com/jemc/crystal-lsp.git
-    version: 0.1.0+git.commit.69157ae18f0be65c27974e16037f59c0cf290c94
+    version: 0.1.0+git.commit.fbe009ea8dfc61457ed2acf0354b8a368bb2597a
   clim:
     git: https://github.com/at-grandpa/clim.git
     version: 0.13.0

--- a/lib/.shards.info
+++ b/lib/.shards.info
@@ -6,7 +6,7 @@ shards:
     version: 0.2.1+git.commit.601363cb2ce9c57ccc70967eb270005950f2f7b0
   lsp:
     git: https://github.com/jemc/crystal-lsp.git
-    version: 0.1.0+git.commit.fbe009ea8dfc61457ed2acf0354b8a368bb2597a
+    version: 0.1.0+git.commit.3dee3e0a8596aa647860c3df191310843520b984
   clim:
     git: https://github.com/at-grandpa/clim.git
     version: 0.13.0

--- a/lib/lsp/src/lsp/data/formatting_options.cr
+++ b/lib/lsp/src/lsp/data/formatting_options.cr
@@ -1,0 +1,50 @@
+require "json"
+
+module LSP::Data
+  struct FormattingOptions
+    include JSON::Serializable
+    include JSON::Serializable::Unmapped
+
+    # Size of a tab in spaces.
+    @[JSON::Field(key: "tabSize")]
+    property tab_size : Int64 = 2
+
+    # Prefer spaces over tabs.
+    @[JSON::Field(key: "insertSpaces")]
+    property insert_spaces : Bool = true
+
+    # Trim trailing whitespace on a line.
+    @[JSON::Field(key: "trimTrailingWhitespace")]
+    property trim_trailing_whitespace : Bool?
+
+    # Insert a newline character at the end of the file if one does not exist.
+    @[JSON::Field(key: "insertFinalNewline")]
+    property insert_final_newline : Bool?
+
+    # Trim all newlines after the final newline at the end of the file.
+    @[JSON::Field(key: "trimFinalNewlines")]
+    property trim_final_newlines : Bool?
+
+    # Signature for further properties.
+    # [key: string]: boolean | integer | string;
+    def [](key : String)
+      @json_unmapped[key].raw.as(Bool | Int64 | String)
+    end
+    def []?(key : String)
+      @json_unmapped[key]?.try(&.raw.as(Bool | Int64 | String))
+    end
+    def []=(key : String, value : Bool | Int64 | String)
+      @json_unmapped[key] = JSON::Any.new(value)
+    end
+
+    def initialize(
+      @tab_size = 2_i64,
+      @insert_spaces = true,
+      @trim_trailing_whitespace = nil,
+      @insert_final_newline = nil,
+      @trim_final_newlines = nil,
+      @json_unmapped = {} of String => JSON::Any
+    )
+    end
+  end
+end

--- a/lib/lsp/src/lsp/data/server_capabilities.cr
+++ b/lib/lsp/src/lsp/data/server_capabilities.cr
@@ -69,7 +69,7 @@ module LSP::Data
 
     # The server provides document range formatting.
     @[JSON::Field(key: "documentRangeFormattingProvider")]
-    property document_range_formatting_provider : Bool = false
+    property document_range_formatting_provider : Bool | WorkDoneProgressOptions = false
 
     # The server provides document formatting on typing.
     @[JSON::Field(key: "documentOnTypeFormattingProvider")]

--- a/lib/lsp/src/lsp/data/server_capabilities.cr
+++ b/lib/lsp/src/lsp/data/server_capabilities.cr
@@ -65,7 +65,7 @@ module LSP::Data
 
     # The server provides document formatting.
     @[JSON::Field(key: "documentFormattingProvider")]
-    property document_formatting_provider : Bool = false
+    property document_formatting_provider : Bool | WorkDoneProgressOptions = false
 
     # The server provides document range formatting.
     @[JSON::Field(key: "documentRangeFormattingProvider")]
@@ -149,6 +149,17 @@ module LSP::Data
         @resolve_provider = false,
         @trigger_characters = [] of String
       )
+      end
+    end
+
+    struct WorkDoneProgressOptions
+      include JSON::Serializable
+
+      # The server provides support for workDoneProgress notifications.
+      @[JSON::Field(key: "workDoneProgress")]
+      property work_done_progress : Bool = false
+
+      def initialize(@work_done_progress = false)
       end
     end
 

--- a/lib/lsp/src/lsp/data/text_edit.cr
+++ b/lib/lsp/src/lsp/data/text_edit.cr
@@ -6,7 +6,7 @@ module LSP::Data
     include JSON::Serializable
 
     # The range of the text document to be manipulated.
-    # To insert text into a document create a range where start === end.
+    # To insert netext into a document create a range where start === end.
     property range : Range
 
     # The string to be inserted.

--- a/lib/lsp/src/lsp/message.cr
+++ b/lib/lsp/src/lsp/message.cr
@@ -181,7 +181,9 @@ module LSP::Message
                        CompletionItemResolve |
                        Hover |
                        SignatureHelp |
-                       Formatting
+                       Formatting |
+                       RangeFormatting |
+                       OnTypeFormatting
 
   alias AnyInResponse = GenericResponse |
                         ShowMessageRequest::Response
@@ -200,7 +202,9 @@ module LSP::Message
                          CompletionItemResolve::Response |
                          Hover::Response |
                          SignatureHelp::Response |
-                         Formatting::Response
+                         Formatting::Response |
+                         RangeFormatting::Response |
+                         OnTypeFormatting::Response
 
   alias AnyOutErrorResponse = GenericErrorResponse |
                               Initialize::ErrorResponse |
@@ -209,7 +213,9 @@ module LSP::Message
                               CompletionItemResolve::ErrorResponse |
                               Hover::ErrorResponse |
                               SignatureHelp::ErrorResponse |
-                              Formatting::ErrorResponse
+                              Formatting::ErrorResponse |
+                              RangeFormatting::ErrorResponse |
+                              OnTypeFormatting::ErrorResponse
 
   alias AnyOutRequest = ShowMessageRequest
 
@@ -1016,11 +1022,69 @@ module LSP::Message
 
   # The document range formatting request is sent from the client to the server
   # to format a given range in a document.
-  # TODO: struct RangeFormatting
+  struct RangeFormatting
+    Message.def_request("textDocument/rangeFormatting")
+
+    struct Params
+      include JSON::Serializable
+
+      # The document to format.
+      @[JSON::Field(key: "textDocument")]
+      property text_document : Data::TextDocumentIdentifier
+
+      # The range to format.
+      property range : Data::Range
+
+      # The format options.
+      property options : Data::FormattingOptions
+
+      def initialize(
+        @text_document = Data::TextDocumentIdentifier.new,
+        @range = Data::Range.new,
+        @options = Data::FormattingOptions.new
+      )
+      end
+    end
+
+    alias Result = Array(Data::TextEdit)
+
+    alias ErrorData = Nil
+  end
 
   # The document on type formatting request is sent from the client to the
   # server to format parts of the document during typing.
-  # TODO: struct OnTypeFormatting
+  struct OnTypeFormatting
+    Message.def_request("textDocument/onTypeFormatting")
+
+    struct Params
+      include JSON::Serializable
+
+      # The text document.
+      @[JSON::Field(key: "textDocument")]
+      property text_document : Data::TextDocumentIdentifier
+
+      # The position inside the text document.
+      property position : Data::Position
+
+      # The character that has been typed.
+      property ch : String
+
+      # The format options.
+      property options : Data::FormattingOptions
+
+      def initialize(
+        @text_document = Data::TextDocumentIdentifier.new,
+        @position = Data::Position.new,
+        @ch = "",
+        @options = Data::FormattingOptions.new
+      )
+      end
+    end
+
+    alias Result = Array(Data::TextEdit)
+
+    alias ErrorData = Nil
+  end
 
   # The rename request is sent from the client to the server to perform a
   # workspace-wide rename of a symbol.

--- a/lib/lsp/src/lsp/message.cr
+++ b/lib/lsp/src/lsp/message.cr
@@ -180,7 +180,8 @@ module LSP::Message
                        Completion |
                        CompletionItemResolve |
                        Hover |
-                       SignatureHelp
+                       SignatureHelp |
+                       Formatting
 
   alias AnyInResponse = GenericResponse |
                         ShowMessageRequest::Response
@@ -198,7 +199,8 @@ module LSP::Message
                          Completion::Response |
                          CompletionItemResolve::Response |
                          Hover::Response |
-                         SignatureHelp::Response
+                         SignatureHelp::Response |
+                         Formatting::Response
 
   alias AnyOutErrorResponse = GenericErrorResponse |
                               Initialize::ErrorResponse |
@@ -206,7 +208,8 @@ module LSP::Message
                               Completion::ErrorResponse |
                               CompletionItemResolve::ErrorResponse |
                               Hover::ErrorResponse |
-                              SignatureHelp::ErrorResponse
+                              SignatureHelp::ErrorResponse |
+                              Formatting::ErrorResponse
 
   alias AnyOutRequest = ShowMessageRequest
 
@@ -986,7 +989,30 @@ module LSP::Message
 
   # The document formatting request is sent from the client to the server to
   # format a whole document.
-  # TODO: struct Formatting
+  struct Formatting
+    Message.def_request("textDocument/formatting")
+
+    struct Params
+      include JSON::Serializable
+
+      # The document to format.
+      @[JSON::Field(key: "textDocument")]
+      property text_document : Data::TextDocumentIdentifier
+
+      # The format options.
+      property options : Data::FormattingOptions
+
+      def initialize(
+        @text_document = Data::TextDocumentIdentifier.new,
+        @options = Data::FormattingOptions.new
+      )
+      end
+    end
+
+    alias Result = Array(Data::TextEdit)
+
+    alias ErrorData = Nil
+  end
 
   # The document range formatting request is sent from the client to the server
   # to format a given range in a document.

--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   lsp:
     git: https://github.com/jemc/crystal-lsp.git
-    version: 0.1.0+git.commit.fbe009ea8dfc61457ed2acf0354b8a368bb2597a
+    version: 0.1.0+git.commit.3dee3e0a8596aa647860c3df191310843520b984
 
   pegmatite:
     git: https://github.com/jemc/crystal-pegmatite.git

--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   lsp:
     git: https://github.com/jemc/crystal-lsp.git
-    version: 0.1.0+git.commit.69157ae18f0be65c27974e16037f59c0cf290c94
+    version: 0.1.0+git.commit.fbe009ea8dfc61457ed2acf0354b8a368bb2597a
 
   pegmatite:
     git: https://github.com/jemc/crystal-pegmatite.git

--- a/src/savi/error.cr
+++ b/src/savi/error.cr
@@ -1,3 +1,5 @@
+require "lsp" # only for conversion to/from LSP data types
+
 # This exception class is used to represent errors to be presented to the user,
 # with each error being associated to a particular SourcePos that caused it.
 class Savi::Error < Exception
@@ -39,6 +41,19 @@ class Savi::Error < Exception
       end
     }
     strings.join("\n").strip
+  end
+
+  def to_lsp_diagnostic
+    LSP::Data::Diagnostic.new(
+      range: pos.to_lsp_range,
+      message: message, # TODO: should this use the headline instead?
+      related_information: info.map { |info_pos, info_message|
+        LSP::Data::Diagnostic::RelatedInformation.new(
+          info_pos.to_lsp_location,
+          info_message,
+        )
+      }
+    )
   end
 
   # Raise an error built with the given information.

--- a/src/savi/server.cr
+++ b/src/savi/server.cr
@@ -67,6 +67,10 @@ class Savi::Server
       msg.result.capabilities.completion_provider =
         LSP::Data::ServerCapabilities::CompletionOptions.new(false, [":"])
       msg.result.capabilities.document_formatting_provider = true
+      msg.result.capabilities.document_on_type_formatting_provider =
+        LSP::Data::ServerCapabilities::DocumentOnTypeFormattingOptions.new(
+          "\n", ")", "]"
+        )
       msg
     end
   end
@@ -161,6 +165,38 @@ class Savi::Server
   end
 
   def handle(req : LSP::Message::Formatting)
+    filename = req.params.text_document.uri.path.not_nil!
+    dirname = File.dirname(filename)
+    sources = Savi.compiler.source_service.get_library_sources(dirname)
+
+    ctx = Savi.compiler.compile(sources, :import)
+    doc = ctx.root_docs.find(&.pos.source.path.==(filename)).not_nil!
+
+    edits = AST::Format.run(ctx, ctx.root_library_link, [doc]).flat_map(&.last)
+
+    @wire.respond(req) { |msg|
+      msg.result = edits.map { |edit|
+        LSP::Data::TextEdit.new(
+          LSP::Data::Range.new(
+            LSP::Data::Position.new(
+              edit.pos.row.to_i64,
+              edit.pos.col.to_i64,
+            ),
+            LSP::Data::Position.new(
+              edit.pos.row.to_i64,
+              edit.pos.col.to_i64 + (
+                edit.pos.finish - edit.pos.start
+              ),
+            ),
+          ),
+          new_text: edit.replacement,
+        )
+      }
+      msg
+    }
+  end
+
+  def handle(req : LSP::Message::OnTypeFormatting)
     filename = req.params.text_document.uri.path.not_nil!
     dirname = File.dirname(filename)
     sources = Savi.compiler.source_service.get_library_sources(dirname)

--- a/src/savi/server.cr
+++ b/src/savi/server.cr
@@ -66,6 +66,7 @@ class Savi::Server
       msg.result.capabilities.definition_provider = true
       msg.result.capabilities.completion_provider =
         LSP::Data::ServerCapabilities::CompletionOptions.new(false, [":"])
+      msg.result.capabilities.document_formatting_provider = true
       msg
     end
   end
@@ -157,6 +158,38 @@ class Savi::Server
       end
       msg
     end
+  end
+
+  def handle(req : LSP::Message::Formatting)
+    filename = req.params.text_document.uri.path.not_nil!
+    dirname = File.dirname(filename)
+    sources = Savi.compiler.source_service.get_library_sources(dirname)
+
+    ctx = Savi.compiler.compile(sources, :import)
+    doc = ctx.root_docs.find(&.pos.source.path.==(filename)).not_nil!
+
+    edits = AST::Format.run(ctx, ctx.root_library_link, [doc]).flat_map(&.last)
+
+    @wire.respond(req) { |msg|
+      msg.result = edits.map { |edit|
+        LSP::Data::TextEdit.new(
+          LSP::Data::Range.new(
+            LSP::Data::Position.new(
+              edit.pos.row.to_i64,
+              edit.pos.col.to_i64,
+            ),
+            LSP::Data::Position.new(
+              edit.pos.row.to_i64,
+              edit.pos.col.to_i64 + (
+                edit.pos.finish - edit.pos.start
+              ),
+            ),
+          ),
+          new_text: edit.replacement,
+        )
+      }
+      msg
+    }
   end
 
   # TODO: Proper completion support.

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -336,4 +336,16 @@ struct Savi::Source::Pos
       start.row, start.col
     )
   end
+
+  def to_lsp_range
+    # TODO: we actually need to convert the byte offsets to character offsets
+    LSP::Data::Range.new(
+      LSP::Data::Position.new(row.to_i64, col.to_i64),
+      LSP::Data::Position.new(row.to_i64, (col + size).to_i64), # TODO: account for spilling over into a new row
+    )
+  end
+
+  def to_lsp_location
+    LSP::Data::Location.new(URI.new(path: source.path), to_lsp_range)
+  end
 end

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -1,3 +1,5 @@
+require "lsp" # only for conversion to/from LSP data types
+
 struct Savi::Source
   property dirname : String
   property filename : String
@@ -317,5 +319,21 @@ struct Savi::Source::Pos
       source.content.byte_slice(line_start, line_finish - line_start),
       (" " * col) + "^" + ("~" * twiddle_width) + tail,
     ].join("\n")
+  end
+
+  def self.from_lsp_position(source, position : LSP::Data::Position)
+    # TODO: we actually need to convert the character offset to a byte offset
+    point(source, position.line.to_i32, position.character.to_i32)
+  end
+
+  def self.from_lsp_range(source, range : LSP::Data::Range)
+    start = from_lsp_position(source, range.start)
+    finish = from_lsp_position(source, range.finish)
+
+    new(
+      source, start.start, finish.start,
+      start.line_start, start.line_finish,
+      start.row, start.col
+    )
   end
 end


### PR DESCRIPTION
Now it is possible run formatting commands in VSCode (or another LSP-compatible editor) and have the Savi LSP Server carry them out.

For example, in VSCode, users can now configure "format on save" to always format Savi files when saving them. Explicitly requesting to format, formatting "on type", and formatting a selected range are also supported.