### PR TITLE
Fix upward type inference via a local with only a cap as its explicit type.

### DIFF
--- a/spec/compiler/type_check.constraints.savi.spec.md
+++ b/spec/compiler/type_check.constraints.savi.spec.md
@@ -193,7 +193,7 @@ The type of this expression doesn't meet the constraints imposed on it:
 It complains when assigning with an insufficient right-hand capability:
 
 ```savi
-    s_ref ref = String.new
+    s_ref ref = String.new_iso
     s_iso String'iso = s_ref
 ```
 ```error
@@ -206,7 +206,7 @@ The type of this expression doesn't meet the constraints imposed on it:
           ^~~~~~~~~~
 
 - but the type of the local variable was String'ref:
-    s_ref ref = String.new
+    s_ref ref = String.new_iso
           ^~~
 ```
 ```error
@@ -219,7 +219,7 @@ The type of this expression doesn't meet the constraints imposed on it:
           ^~~~~~~~~~
 
 - but the type of the local variable was String'ref:
-    s_ref ref = String.new
+    s_ref ref = String.new_iso
           ^~~
 ```
 
@@ -239,7 +239,7 @@ This aliasing violates uniqueness (did you forget to consume the variable?):
     s_val     = s_iso          // not okay
                 ^~~~~
 
-- it is required here to be a subtype of val:
+- it is required here to be a subtype of String:
     s_val val = String.new_iso // okay
           ^~~
 
@@ -303,7 +303,7 @@ This aliasing violates uniqueness (did you forget to consume the variable?):
     s2 iso = s // not okay
              ^
 
-- it is required here to be a subtype of iso:
+- it is required here to be a subtype of String'iso:
     s2 iso = s // not okay
        ^~~
 
@@ -316,7 +316,7 @@ This aliasing violates uniqueness (did you forget to consume the variable?):
     s3 iso = s // not okay
              ^
 
-- it is required here to be a subtype of iso:
+- it is required here to be a subtype of String'iso:
     s3 iso = s // not okay
        ^~~
 

--- a/spec/compiler/type_check.inference.savi.spec.md
+++ b/spec/compiler/type_check.inference.savi.spec.md
@@ -139,6 +139,24 @@ It infers an integer literal within the else body of an if statement:
 
 ---
 
+It infers an integer through a variable with no explicit type:
+
+```savi
+    x = 99 ::type=> U64
+    U64[99] == x
+```
+
+---
+
+It infers an integer through a variable with only a cap as its explicit type:
+
+```savi
+    x box = 99 ::type=> U64
+    U64[99] == x
+```
+
+---
+
 It complains when a literal couldn't be resolved to a single type:
 
 ```savi
@@ -294,7 +312,7 @@ The type of this expression doesn't meet the constraints imposed on it:
     array_val val = [x_ref] // not okay
                     ^~~~~~~
 
-- it is required here to be a subtype of val:
+- it is required here to be a subtype of Array(String'ref)'val:
     array_val val = [x_ref] // not okay
               ^~~
 


### PR DESCRIPTION
This issue was encountered by @tonchis while he was working on removing the old style of assert macro.