### PR TITLE
Add `Assert.type_relation` for `<:` and `!<:` expressions in `assert:` macro

### DIFF
--- a/packages/collections/test/map_spec.savi
+++ b/packages/collections/test/map_spec.savi
@@ -22,7 +22,7 @@
     assert: map.size == 1
     assert: try (map["example"]! | U64[0]) == 88
     assert: map.has_key("example")
-    @assert = map.delete("example") <: None
+    assert: map.delete("example") <: None
     @assert = try map["example"]! <: None
     assert: map.has_key("example").is_false
     assert: map.size == 0

--- a/packages/collections/test/ordered_map_spec.savi
+++ b/packages/collections/test/ordered_map_spec.savi
@@ -19,7 +19,7 @@
     assert: map.size == 1
     assert: try (map["example"]! | U64[0]) == 88
     assert: map.has_key("example")
-    @assert = map.delete("example") <: None
+    assert: map.delete("example") <: None
     @assert = try map["example"]! <: None
     assert: map.has_key("example").is_false
     assert: map.size == 0

--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -113,7 +113,7 @@
   :let rhs String
 
   :new val (@spec, @example, @success, @pos, @op, @lhs, @rhs)
-  
+
   :fun print_failure(env Env) None
     expectation = if (@op == "<:") ("to be a subtype of" | "not to be a subtype of")
 

--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -37,6 +37,26 @@
     )
     test.specs.enqueue(assert)
 
+  :fun non type_relation(
+    spec Spec
+    op String
+    lhs Any'box
+    rhs String
+    success Bool
+    pos SourceCodePosition = source_code_position_of_argument spec
+  )
+    test = spec.test
+    assert = AssertTypeRelation.new(
+      test.spec
+      test.example
+      success
+      pos
+      op
+      Inspect[lhs]
+      rhs
+    )
+    test.specs.enqueue(assert)
+
   :fun file_and_line String
     line = Inspect[@pos.row + 1]
     @indent(4, String.join(["# ", @pos.filename, ":", line]))
@@ -79,6 +99,34 @@
       @indent(6, @lhs)
       @indent(4, String.join(["to ", @op]))
       @indent(6, @rhs)
+      ""
+      @file_and_line
+    ], "\n"))
+
+    None
+
+:class val AssertTypeRelation
+  :is Assert
+
+  :let op String
+  :let lhs String
+  :let rhs String
+
+  :new val (@spec, @example, @success, @pos, @op, @lhs, @rhs)
+  
+  :fun print_failure(env Env) None
+    expectation = if (@op == "<:") ("to be a subtype of" | "not to be a subtype of")
+
+    env.err.print(String.join([
+      ""
+      @indent(4, String.join(["FAIL:", @pos.string], " "))
+      ""
+      @indent(4, String.join([
+        "Expected"
+        @lhs
+        expectation
+        @rhs
+      ], " "))
       ""
       @file_and_line
     ], "\n"))

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -24,7 +24,7 @@
     assert: Foo.true == True
     assert: True == Foo.true
     assert: True \
-    == True
+      == True
     assert: Foo.with_yield -> (false |
       assert: !false) == Foo.true
 
@@ -34,8 +34,8 @@
     assert: @maybe_string1 !<: String
     assert: @maybe_string2 <: String
     assert: [@maybe_string1] <: Array((String | None))
-    // TODO: we need to implement <: for union types
-    // assert: True <: (String | Bool)
+  // TODO: we need to implement <: for union types
+  // assert: True <: (String | Bool)
 
   :it "honors iso"
     assert: "" == String.new_iso

--- a/packages/spec/test/assert_spec.savi
+++ b/packages/spec/test/assert_spec.savi
@@ -20,13 +20,22 @@
     )
 
   :it "conforms to the `assert: EXP1 <op> EXP2` macro"
-    assert True == True
-    assert Foo.true == True
-    assert True == Foo.true
-    assert True \
+    assert: True == True
+    assert: Foo.true == True
+    assert: True == Foo.true
+    assert: True \
     == True
-    assert Foo.with_yield -> (false |
-      assert !false) == Foo.true
+    assert: Foo.with_yield -> (false |
+      assert: !false) == Foo.true
+
+  :fun maybe_string1 (String | None): None
+  :fun maybe_string2 (String | None): String.new_iso
+  :it "conforms to the `assert: EXP1 <: EXP2` and `assert: EXP1 !<: EXP2` cases"
+    assert: @maybe_string1 !<: String
+    assert: @maybe_string2 <: String
+    assert: [@maybe_string1] <: Array((String | None))
+    // TODO: we need to implement <: for union types
+    // assert: True <: (String | Bool)
 
   :it "honors iso"
     assert: "" == String.new_iso

--- a/spec/compiler/macros/assertion_spec.cr
+++ b/spec/compiler/macros/assertion_spec.cr
@@ -67,5 +67,74 @@ describe Savi::Compiler::Macros do
         ]
       ]
     end
+
+    it "is transformed into Assert.type_relation for <: and !<:" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new
+          assert: "foo" <: String
+          assert: True !<: String
+      SOURCE
+
+      ctx = Savi.compiler.compile([source], :macros)
+      ctx.errors.should be_empty
+
+      func = ctx.namespace.find_func!(ctx, source, "Main", "new")
+      terms = func.body.not_nil!.terms 
+
+      terms[0].to_a.should eq [:group, "(",
+        [:relate,
+          [:ident, "hygienic_macros_local.1"],
+          [:op, "="],
+          [:string, "foo", nil]],
+        [:relate,
+          [:ident, "hygienic_macros_local.2"],
+          [:op, "="],
+          [:relate,
+            [:ident, "hygienic_macros_local.1"],
+            [:op, "<:"],
+            [:ident, "String"],
+          ],
+        ],
+        [:call,
+          [:ident, "Assert"],
+          [:ident, "type_relation"],
+          [:group, "(",
+            [:ident, "@"],
+            [:string, "<:", nil],
+            [:prefix, [:op, "--"], [:ident, "hygienic_macros_local.1"]],
+            [:string, "String", nil],
+            [:ident, "hygienic_macros_local.2"],
+          ]
+        ]
+      ]
+
+      terms[1].to_a.should eq [:group, "(",
+        [:relate,
+          [:ident, "hygienic_macros_local.3"],
+          [:op, "="],
+          [:ident, "True"]],
+        [:relate,
+          [:ident, "hygienic_macros_local.4"],
+          [:op, "="],
+          [:relate,
+            [:ident, "hygienic_macros_local.3"],
+            [:op, "!<:"],
+            [:ident, "String"],
+          ],
+        ],
+        [:call,
+          [:ident, "Assert"],
+          [:ident, "type_relation"],
+          [:group, "(",
+            [:ident, "@"],
+            [:string, "!<:", nil],
+            [:prefix, [:op, "--"], [:ident, "hygienic_macros_local.3"]],
+            [:string, "String", nil],
+            [:ident, "hygienic_macros_local.4"],
+          ]
+        ]
+      ]
+    end
   end
 end

--- a/src/savi/compiler/macros.cr
+++ b/src/savi/compiler/macros.cr
@@ -576,6 +576,9 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
   # assert: True == True
   # assert: foo || bar && baz
   #
+  # When the relation uses the `<:` and `!<:` operator the assert is compiled into a special
+  # `Assert.type_relation` method.
+  #
   # When the expression is any other kind of node it will compile into a `Assert.condition`.
   #
   # assert: True
@@ -586,6 +589,11 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     lhs = expr.lhs
     op = expr.op
     rhs = expr.rhs
+    
+    # For the case where `rhs` is not a value expression, but rather a type expression:
+    # `String`, `Array(String)` or `(String | None)`, we will compile into the
+    # `Assert.type_relation` call.
+    return visit_assert_type_relation(node, expr) if op.value == "<:" || op.value == "!<:"
 
     # Use a hygienic local to explicitly hold the expressions as box.
     # This also helps to refer to them multiple times without evaluating them again.
@@ -634,6 +642,54 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     AST::Group.new("(", [
       local_lhs_assign,
       local_rhs_assign,
+      call,
+    ] of AST::Term).from(node)
+  end
+
+  def visit_assert_type_relation(node : AST::Relate, expr : AST::Relate)
+    orig = node.lhs.as(AST::Identifier)
+    lhs = expr.lhs
+    op = expr.op
+    rhs = expr.rhs
+    
+    # Use a hygienic local to explicitly hold the expressions as box.
+    # This also helps to refer to them multiple times without evaluating them again.
+    local_lhs_name = AST::Identifier.new(next_local_name).from(lhs) 
+    local_lhs = AST::Relate.new(
+      local_lhs_name,
+      AST::Operator.new("=").from(lhs),
+      lhs,
+    ).from(lhs)
+
+    local_relate_name = AST::Identifier.new(next_local_name).from(expr)
+    local_relate = AST::Relate.new(
+      local_relate_name,
+      AST::Operator.new("=").from(expr),
+      AST::Relate.new(
+        local_lhs_name,
+        op,
+        rhs,
+      ).from(expr)
+    ).from(expr)
+
+    call = AST::Call.new(
+      AST::Identifier.new("Assert").from(orig),
+      AST::Identifier.new("type_relation").from(orig),
+      AST::Group.new("(", [
+        AST::Identifier.new("@").from(node),
+        AST::LiteralString.new(op.value).from(op),
+        AST::Prefix.new(
+          AST::Operator.new("--").from(expr),
+          local_lhs_name
+        ).from(lhs),
+        AST::LiteralString.new(rhs.pos.content).from(rhs),
+        local_relate_name,
+      ] of AST::Term).from(expr)
+    ).from(orig)
+
+    AST::Group.new("(", [
+      local_lhs,
+      local_relate,
       call,
     ] of AST::Term).from(node)
   end

--- a/src/savi/compiler/macros.cr
+++ b/src/savi/compiler/macros.cr
@@ -652,8 +652,7 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     op = expr.op
     rhs = expr.rhs
     
-    # Use a hygienic local to explicitly hold the expressions as box.
-    # This also helps to refer to them multiple times without evaluating them again.
+    # Use a hygienic local to refer to it multiple times without evaluating again.
     local_lhs_name = AST::Identifier.new(next_local_name).from(lhs) 
     local_lhs = AST::Relate.new(
       local_lhs_name,

--- a/src/savi/compiler/type_check.cr
+++ b/src/savi/compiler/type_check.cr
@@ -530,7 +530,9 @@ class Savi::Compiler::TypeCheck
     end
     def type_check_pre(ctx : Context, info : Infer::TypeConditionForLocal, mt : MetaType) : Bool
       lhs_info = @pre_infer[info.refine]
-      lhs_info = lhs_info.info if lhs_info.is_a?(Infer::LocalRef)
+      while lhs_info.is_a?(Infer::LocalRef)
+        lhs_info = lhs_info.info
+      end
       rhs_info = info.refine_type
       lhs_mt = resolve(ctx, lhs_info)
       rhs_mt = resolve(ctx, rhs_info)


### PR DESCRIPTION
Issue: #88 

This PR addresses creates a special case `Assert.type_relation` function for the `assert: foo <: Some` (and `!<:`) operators because the right-hand side is a type expression, not a value expression, so we can't treat it the same as other operators in the language.

Error messages for this macro look like this:
![image](https://user-images.githubusercontent.com/106882/131912811-45265381-f73b-4a01-ae9f-efa0eefe34e3.png)
