### PR TITLE
Remove last `@assert =` style assertions

### DIFF
--- a/packages/collections/test/map_spec.savi
+++ b/packages/collections/test/map_spec.savi
@@ -23,7 +23,7 @@
     assert: try (map["example"]! | U64[0]) == 88
     assert: map.has_key("example")
     assert: map.delete("example") <: None
-    @assert = try map["example"]! <: None
+    assert: try map["example"]! <: None
     assert: map.has_key("example").is_false
     assert: map.size == 0
 

--- a/packages/collections/test/ordered_map_spec.savi
+++ b/packages/collections/test/ordered_map_spec.savi
@@ -20,7 +20,7 @@
     assert: try (map["example"]! | U64[0]) == 88
     assert: map.has_key("example")
     assert: map.delete("example") <: None
-    @assert = try map["example"]! <: None
+    assert: try map["example"]! <: None
     assert: map.has_key("example").is_false
     assert: map.size == 0
 


### PR DESCRIPTION
Issue: #88 

We still want to implement `assert try:` and `assert error:` macros for convenience and better error messages, but this PR lets us remove the code for the `@assert` methods.