### PR TITLE
Remove `@assert =` code

### DIFF
--- a/packages/spec/assert.savi
+++ b/packages/spec/assert.savi
@@ -13,9 +13,9 @@
     success Bool
     pos SourceCodePosition = source_code_position_of_argument spec
   )
-    test = spec.test
-    assert = AssertCondition.new(test.spec, test.example, success, pos)
-    test.specs.enqueue(assert)
+    ctx = spec.ctx
+    assert = AssertCondition.new(ctx.spec, ctx.example, success, pos)
+    ctx.specs.enqueue(assert)
 
   :fun non relation(
     spec Spec
@@ -25,17 +25,17 @@
     success Bool
     pos SourceCodePosition = source_code_position_of_argument spec
   )
-    test = spec.test
+    ctx = spec.ctx
     assert = AssertRelation.new(
-      test.spec
-      test.example
+      ctx.spec
+      ctx.example
       success
       pos
       op
       Inspect[lhs]
       Inspect[rhs]
     )
-    test.specs.enqueue(assert)
+    ctx.specs.enqueue(assert)
 
   :fun non type_relation(
     spec Spec
@@ -45,17 +45,17 @@
     success Bool
     pos SourceCodePosition = source_code_position_of_argument spec
   )
-    test = spec.test
+    ctx = spec.ctx
     assert = AssertTypeRelation.new(
-      test.spec
-      test.example
+      ctx.spec
+      ctx.example
       success
       pos
       op
       Inspect[lhs]
       rhs
     )
-    test.specs.enqueue(assert)
+    ctx.specs.enqueue(assert)
 
   :fun file_and_line String
     line = Inspect[@pos.row + 1]

--- a/packages/spec/spec.savi
+++ b/packages/spec/spec.savi
@@ -1,32 +1,15 @@
 :trait Spec
-  :let test TestHelper
-  :fun env: @test.env
-  :new (@test)
+  :let ctx TestContext
+  :fun env: @ctx.env
+  :new (@ctx)
 
   :: When implementing the Spec trait, include a definition for this constant
   :: indicating what entity the tests are describing the specification for.
   :const describes String
 
-  :fun ref "assert="(
-    success Bool
-    pos SourceCodePosition = source_code_position_of_argument success
-  )
-    @test.assert(success, pos)
-
-:class val TestHelper
+:class val TestContext
   :let env Env
   :let specs Specs
   :let spec String
   :let example String
   :new (@env, @specs, @spec, @example)
-
-  :fun assert(success, pos) // TODO: avoid needing this alias
-    @specs.assert(@spec, @example, success, pos)
-    success
-
-  :fun "assert="(
-    success Bool
-    pos SourceCodePosition = source_code_position_of_argument success
-  )
-    @specs.assert(@spec, @example, success, pos)
-    success

--- a/packages/spec/spec_run.savi
+++ b/packages/spec/spec_run.savi
@@ -8,7 +8,7 @@
 
   // TODO: avoid this indirection
   :fun _new_spec(specs) A
-    A.new(TestHelper.new(@env, specs, A.describes, ""))
+    A.new(TestContext.new(@env, specs, A.describes, ""))
 
   :: Run all spec features for the Spec type indicated by the type argument,
   :: using the given Env to construct an instance of that Spec type.
@@ -31,7 +31,7 @@
   :let example ReflectionFeatureOfType(A)
 
   :new (env, specs, @example)
-    helper = TestHelper.new(env, specs, A.describes, @example.name)
+    helper = TestContext.new(env, specs, A.describes, @example.name)
     spec = A.new(helper)
 
     specs.example_began(A.describes, @example.name)


### PR DESCRIPTION
This PR removes the `@assert =` method code and renames `TestHelper` into `TestContext`. We still want the class to keep all the fields hidden away from the `Spec` trait interface, to avoid any name collisions with user written code.