### PR TITLE
fix to typos in readme and license-pony

### DIFF
--- a/LICENSE-pony
+++ b/LICENSE-pony
@@ -1,6 +1,6 @@
 Parts of this source code are based on code from `ponyc`, whose license is:
 
-Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2016-2017, The Pony Developers
 Copyright (c) 2014-2015, Causality Ltd.
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Background
 
-**Savi** is an actor-oriented programming language using the [Pony](https://www.ponylang.io/) runtime. Like Pony, **Savi** has a unique type system that enforces concurrency-safety and memory-safery properties at compile time.
+**Savi** is an actor-oriented programming language using the [Pony](https://www.ponylang.io/) runtime. Like Pony, **Savi** has a unique type system that enforces concurrency-safety and memory-safety properties at compile time.
 
 Like many other modern compiled languages, **Savi** uses [LLVM](https://llvm.org/) to compile to a wide variety of native targets.
 


### PR DESCRIPTION
Just two little letters typed (perhaps) incorrectly.
Good luck with the project by the way.