### PR TITLE
Add integration tests for basic manifest-related errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean: PHONY
 	rm -rf $(BUILD) .make-var-cache lib/libsavi_runtime.bc
 
 # Run the full test suite.
-spec.all: PHONY spec.compiler.all spec.language spec.package.all spec.unit.all
+spec.all: PHONY spec.compiler.all spec.language spec.package.all spec.unit.all spec.integration.all
 
 # Run the specs that are written in markdown (mostly compiler pass tests).
 # Run the given compiler-spec target (or all targets).
@@ -29,13 +29,6 @@ spec.compiler: PHONY $(SAVI)
 spec.compiler.all: PHONY $(SAVI)
 	find "spec/compiler" -name '*.savi.spec.md' | sort | xargs -I'{}' sh -c \
 		'echo && $(SAVI) compilerspec {} $(extra_args) || exit 255'
-
-# Run the specs that are written in Crystal (mostly compiler unit tests),
-# narrowing to those with the given name (or all of them).
-spec.unit: PHONY $(SPEC)
-	echo && $(SPEC) -v -e "$(name)"
-spec.unit.all: PHONY $(SPEC)
-	echo && $(SPEC)
 
 # Run the specs for the basic language semantics.
 spec.language: PHONY $(SAVI)
@@ -47,6 +40,17 @@ spec.package: PHONY $(SAVI)
 spec.package.all: PHONY $(SAVI)
 	find packages -name 'test' | cut -d/ -f2 | sort | xargs -I'{}' sh -c \
 		"echo && $(SAVI) run --cd packages "spec-{}" $(extra_args) || exit 255"
+
+# Run the specs that are written in Crystal (mostly compiler unit tests),
+# narrowing to those with the given name (or all of them).
+spec.unit: PHONY $(SPEC)
+	echo && $(SPEC) -v -e "$(name)"
+spec.unit.all: PHONY $(SPEC)
+	echo && $(SPEC)
+
+# Run the integration tests, which invoke the compiler in a real directory.
+spec.integration.all: PHONY $(SAVI)
+	echo && spec/integration/run-all.sh $(SAVI)
 
 # Check formatting of *.savi source files.
 format.check: PHONY $(SAVI)

--- a/main.cr
+++ b/main.cr
@@ -277,7 +277,6 @@ module Savi
         puts
         puts error.message(backtrace)
       }
-      puts
       1 # exit code reflects the fact that compilation errors occurred
     end
   end

--- a/spec/compiler/namespace_spec.cr
+++ b/spec/compiler/namespace_spec.cr
@@ -75,7 +75,7 @@ describe Savi::Compiler::Namespace do
            ^~~~~~
 
     - the built-in type is defined here:
-      from #{Savi.compiler.source_service.core_savi_package_path}/string.savi:1:
+      from ./packages/Savi/string.savi:1:
     :class val String
                ^~~~~~
     MSG

--- a/spec/compiler/verify_spec.cr
+++ b/spec/compiler/verify_spec.cr
@@ -93,7 +93,7 @@ describe Savi::Compiler::Verify do
        ^~~
 
     - it should accept exactly one parameter of type Env:
-      from #{Savi.compiler.source_service.core_savi_package_path}/env.savi:1:
+      from ./packages/Savi/env.savi:1:
     :class val Env
                ^~~
     MSG
@@ -115,7 +115,7 @@ describe Savi::Compiler::Verify do
            ^~~~~~~~~~~~~~~~~~~~
 
     - it should accept exactly one parameter of type Env:
-      from #{Savi.compiler.source_service.core_savi_package_path}/env.savi:1:
+      from ./packages/Savi/env.savi:1:
     :class val Env
                ^~~
     MSG
@@ -137,7 +137,7 @@ describe Savi::Compiler::Verify do
             ^~~~~~~~~~
 
     - it should accept a parameter of type Env:
-      from #{Savi.compiler.source_service.core_savi_package_path}/env.savi:1:
+      from ./packages/Savi/env.savi:1:
     :class val Env
                ^~~
 

--- a/spec/integration/error-manifests-copies-recursive/manifest.savi
+++ b/spec/integration/error-manifests-copies-recursive/manifest.savi
@@ -1,0 +1,27 @@
+:manifest lib Thing1
+  :sources "*.savi"
+  :copies Thing3 // -> 3 -> 2 -> 1 -> ...
+
+:manifest lib Thing2
+  :sources "*.savi"
+  :copies Thing1 // -> 1 -> 3 -> 2 -> ...
+
+:manifest lib Thing3
+  :sources "*.savi"
+  :copies Thing2 // -> 2 -> 1 -> 3 -> ...
+
+:manifest lib Thing4
+  :sources "*.savi"
+  :copies Thing5 // -> 5 -> 6 (no recursion)
+
+:manifest lib Thing5
+  :sources "*.savi"
+  :copies Thing6 // -> 6 (no recursion)
+
+:manifest lib Thing6
+  :sources "*.savi"
+
+:manifest "spec"
+  :sources "*.savi"
+  :copies Thing3 // -> 3 -> 2 -> 1 -> 3 -> ...
+  :copies Thing4 // -> 4 -> 5 -> 6 (no recursion)

--- a/spec/integration/error-manifests-copies-recursive/savi.errors.txt
+++ b/spec/integration/error-manifests-copies-recursive/savi.errors.txt
@@ -1,0 +1,24 @@
+
+Compilation Error:
+
+---
+
+A copies declaration cannot be self-recursive:
+from ./manifest.savi:3:
+  :copies Thing3 // -> 3 -> 2 -> 1 -> ...
+          ^~~~~~
+
+- it recursed from here:
+  from ./manifest.savi:26:
+  :copies Thing3 // -> 3 -> 2 -> 1 -> 3 -> ...
+          ^~~~~~
+
+- it recursed from here:
+  from ./manifest.savi:11:
+  :copies Thing2 // -> 2 -> 1 -> 3 -> ...
+          ^~~~~~
+
+- it recursed from here:
+  from ./manifest.savi:7:
+  :copies Thing1 // -> 1 -> 3 -> 2 -> ...
+          ^~~~~~

--- a/spec/integration/error-manifests-copies-wrong-name/manifest.savi
+++ b/spec/integration/error-manifests-copies-wrong-name/manifest.savi
@@ -1,0 +1,20 @@
+:manifest lib Foo
+  :sources "*.savi"
+
+:manifest lib Bar
+  :sources "*.savi"
+  :copies Food // mispelled `Foo`
+
+:manifest lib Baz
+  :sources "*.savi"
+  :copies TotallyBogusName // no similar name exists
+
+:manifest lib Speccy
+  :sources "*.savi"
+  :copies Spec // can't copy from foreign manifests - even standard library
+
+:manifest "main"
+  :copies Foo
+  :copies Bar
+  :copies Baz
+  :copies Speccy

--- a/spec/integration/error-manifests-copies-wrong-name/savi.errors.txt
+++ b/spec/integration/error-manifests-copies-wrong-name/savi.errors.txt
@@ -1,0 +1,28 @@
+
+Compilation Errors:
+
+---
+
+There's no manifest named `Food` in this directory:
+from ./manifest.savi:6:
+  :copies Food // mispelled `Foo`
+          ^~~~
+
+- maybe you meant `Foo`:
+  from ./manifest.savi:1:
+:manifest lib Foo
+              ^~~
+
+---
+
+There's no manifest named `TotallyBogusName` in this directory:
+from ./manifest.savi:10:
+  :copies TotallyBogusName // no similar name exists
+          ^~~~~~~~~~~~~~~~
+
+---
+
+There's no manifest named `Spec` in this directory:
+from ./manifest.savi:14:
+  :copies Spec // can't copy from foreign manifests - even standard library
+          ^~~~

--- a/spec/integration/error-manifests-many-but-no-main/another.manifest.savi
+++ b/spec/integration/error-manifests-many-but-no-main/another.manifest.savi
@@ -1,0 +1,5 @@
+:manifest lib "package-e"
+  :sources "*.savi"
+
+:manifest bin "package-f"
+  :sources "*.savi"

--- a/spec/integration/error-manifests-many-but-no-main/manifest.savi
+++ b/spec/integration/error-manifests-many-but-no-main/manifest.savi
@@ -1,0 +1,11 @@
+:manifest lib "package-a"
+  :sources "*.savi"
+
+:manifest bin "package-b"
+  :sources "*.savi"
+
+:manifest lib "package-c"
+  :sources "*.savi"
+
+:manifest bin "package-d"
+  :sources "*.savi"

--- a/spec/integration/error-manifests-many-but-no-main/savi.errors.txt
+++ b/spec/integration/error-manifests-many-but-no-main/savi.errors.txt
@@ -1,0 +1,36 @@
+
+Compilation Error:
+
+---
+
+There is more than one manifest and it isn't clear which to use; please specify one explicitly by name
+
+- this is an available manifest:
+  from ./another.manifest.savi:1:
+:manifest lib "package-e"
+              ^~~~~~~~~~~
+
+- this is an available manifest:
+  from ./another.manifest.savi:4:
+:manifest bin "package-f"
+              ^~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:1:
+:manifest lib "package-a"
+              ^~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:4:
+:manifest bin "package-b"
+              ^~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:7:
+:manifest lib "package-c"
+              ^~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:10:
+:manifest bin "package-d"
+              ^~~~~~~~~~~

--- a/spec/integration/error-manifests-many-main/another.manifest.savi
+++ b/spec/integration/error-manifests-many-main/another.manifest.savi
@@ -1,5 +1,8 @@
 :manifest "package-g"
+  :sources "*.savi"
 
 :manifest lib "package-h"
+  :sources "*.savi"
 
 :manifest bin "package-i"
+  :sources "*.savi"

--- a/spec/integration/error-manifests-many-main/another.manifest.savi
+++ b/spec/integration/error-manifests-many-main/another.manifest.savi
@@ -1,0 +1,5 @@
+:manifest "package-g"
+
+:manifest lib "package-h"
+
+:manifest bin "package-i"

--- a/spec/integration/error-manifests-many-main/manifest.savi
+++ b/spec/integration/error-manifests-many-main/manifest.savi
@@ -1,11 +1,17 @@
 :manifest "package-a"
+  :sources "*.savi"
 
 :manifest lib "package-b"
+  :sources "*.savi"
 
 :manifest bin "package-c"
+  :sources "*.savi"
 
 :manifest "package-d"
+  :sources "*.savi"
 
 :manifest lib "package-e"
+  :sources "*.savi"
 
 :manifest bin "package-f"
+  :sources "*.savi"

--- a/spec/integration/error-manifests-many-main/manifest.savi
+++ b/spec/integration/error-manifests-many-main/manifest.savi
@@ -1,0 +1,11 @@
+:manifest "package-a"
+
+:manifest lib "package-b"
+
+:manifest bin "package-c"
+
+:manifest "package-d"
+
+:manifest lib "package-e"
+
+:manifest bin "package-f"

--- a/spec/integration/error-manifests-many-main/savi.errors.txt
+++ b/spec/integration/error-manifests-many-main/savi.errors.txt
@@ -16,6 +16,6 @@ There can't be more than one main manifest in this directory; please mark some o
           ^~~~~~~~~~~
 
 - this is a main manifest:
-  from ./manifest.savi:7:
+  from ./manifest.savi:10:
 :manifest "package-d"
           ^~~~~~~~~~~

--- a/spec/integration/error-manifests-many-main/savi.errors.txt
+++ b/spec/integration/error-manifests-many-main/savi.errors.txt
@@ -1,0 +1,21 @@
+
+Compilation Error:
+
+---
+
+There can't be more than one main manifest in this directory; please mark some of these as `:manifest lib` or `:manifest bin`
+
+- this is a main manifest:
+  from ./another.manifest.savi:1:
+:manifest "package-g"
+          ^~~~~~~~~~~
+
+- this is a main manifest:
+  from ./manifest.savi:1:
+:manifest "package-a"
+          ^~~~~~~~~~~
+
+- this is a main manifest:
+  from ./manifest.savi:7:
+:manifest "package-d"
+          ^~~~~~~~~~~

--- a/spec/integration/error-manifests-no-sources/manifest.savi
+++ b/spec/integration/error-manifests-no-sources/manifest.savi
@@ -1,0 +1,9 @@
+:manifest lib ExampleNoSources
+
+:manifest bin "example-no-sources"
+
+:manifest lib ExampleWithSources
+  :sources "*.savi"
+
+:manifest bin "example-with-sources"
+  :sources "*.savi"

--- a/spec/integration/error-manifests-no-sources/savi.errors.txt
+++ b/spec/integration/error-manifests-no-sources/savi.errors.txt
@@ -1,0 +1,26 @@
+
+Compilation Error:
+
+---
+
+There is more than one manifest and it isn't clear which to use; please specify one explicitly by name
+
+- this is an available manifest:
+  from ./manifest.savi:1:
+:manifest lib ExampleNoSources
+              ^~~~~~~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:3:
+:manifest bin "example-no-sources"
+              ^~~~~~~~~~~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:5:
+:manifest lib ExampleWithSources
+              ^~~~~~~~~~~~~~~~~~
+
+- this is an available manifest:
+  from ./manifest.savi:8:
+:manifest bin "example-with-sources"
+              ^~~~~~~~~~~~~~~~~~~~~~

--- a/spec/integration/error-manifests-non-unique-names/manifest.savi
+++ b/spec/integration/error-manifests-non-unique-names/manifest.savi
@@ -1,0 +1,21 @@
+:manifest lib Thing1
+  :sources "*.savi"
+
+:manifest lib Thing2
+  :sources "*.savi"
+
+:manifest lib Thing3
+  :sources "*.savi"
+
+// DEJA VU
+
+:manifest lib Thing2
+  :sources "*.savi"
+
+:manifest lib Thing3
+  :sources "*.savi"
+
+// DEJA VU ALL OVER AGAIN
+
+:manifest lib Thing3
+  :sources "*.savi"

--- a/spec/integration/error-manifests-non-unique-names/savi.errors.txt
+++ b/spec/integration/error-manifests-non-unique-names/savi.errors.txt
@@ -1,0 +1,31 @@
+
+Compilation Errors:
+
+---
+
+This manifest needs a unique name:
+from ./manifest.savi:12:
+:manifest lib Thing2
+              ^~~~~~
+
+- a conflicting one is here:
+  from ./manifest.savi:4:
+:manifest lib Thing2
+              ^~~~~~
+
+---
+
+This manifest needs a unique name:
+from ./manifest.savi:20:
+:manifest lib Thing3
+              ^~~~~~
+
+- a conflicting one is here:
+  from ./manifest.savi:7:
+:manifest lib Thing3
+              ^~~~~~
+
+- a conflicting one is here:
+  from ./manifest.savi:15:
+:manifest lib Thing3
+              ^~~~~~

--- a/spec/integration/error-manifests-none/manifest.savi
+++ b/spec/integration/error-manifests-none/manifest.savi
@@ -1,0 +1,3 @@
+// This file is named as a manifest file, but it doesn't contain a manifest.
+// It only contains a class, which will be ignored during manifest probe.
+:class NotAManifest

--- a/spec/integration/error-manifests-none/not-a-manifest.savi
+++ b/spec/integration/error-manifests-none/not-a-manifest.savi
@@ -1,0 +1,3 @@
+// This is a real manifest, but the filename isn't matching the pattern
+// "*.manifest.savi" or "manifest.savi", so it won't be found as a manifest.
+:manifest "not-in-a-manifest-dot-savi-file"

--- a/spec/integration/error-manifests-none/not-a-manifest.savi
+++ b/spec/integration/error-manifests-none/not-a-manifest.savi
@@ -1,3 +1,4 @@
 // This is a real manifest, but the filename isn't matching the pattern
 // "*.manifest.savi" or "manifest.savi", so it won't be found as a manifest.
 :manifest "not-in-a-manifest-dot-savi-file"
+  :sources "*.savi"

--- a/spec/integration/error-manifests-none/savi.errors.txt
+++ b/spec/integration/error-manifests-none/savi.errors.txt
@@ -1,0 +1,6 @@
+
+Compilation Error:
+
+---
+
+No manifests found in the 'manifest.savi' files in this directory

--- a/spec/integration/error-manifests-reserved-names/manifest.savi
+++ b/spec/integration/error-manifests-reserved-names/manifest.savi
@@ -1,0 +1,11 @@
+:manifest bin Savi // NOT OKAY
+  :sources "*.savi"
+
+:manifest bin Savi.Thing // NOT OKAY
+  :sources "*.savi"
+
+:manifest bin Saviour // okay
+  :sources "*.savi"
+
+:manifest "savi" // okay
+  :sources "*.savi"

--- a/spec/integration/error-manifests-reserved-names/manifest.savi
+++ b/spec/integration/error-manifests-reserved-names/manifest.savi
@@ -1,11 +1,14 @@
-:manifest bin Savi // NOT OKAY
+:manifest lib Savi // NOT OKAY
   :sources "*.savi"
 
-:manifest bin Savi.Thing // NOT OKAY
+:manifest lib Savi.Thing // NOT OKAY
   :sources "*.savi"
 
-:manifest bin Saviour // okay
+:manifest lib Saviour // okay - no dot after `Savi`
   :sources "*.savi"
 
-:manifest "savi" // okay
+:manifest lib Thing.Savi // okay - `Savi` is not first
+  :sources "*.savi"
+
+:manifest "savi" // okay - `savi` is lowercase
   :sources "*.savi"

--- a/spec/integration/error-manifests-reserved-names/savi.errors.txt
+++ b/spec/integration/error-manifests-reserved-names/savi.errors.txt
@@ -5,12 +5,12 @@ Compilation Errors:
 
 This name is reserved for core Savi packages:
 from ./manifest.savi:1:
-:manifest bin Savi // NOT OKAY
+:manifest lib Savi // NOT OKAY
               ^~~~
 
 ---
 
 This name is reserved for core Savi packages:
 from ./manifest.savi:4:
-:manifest bin Savi.Thing // NOT OKAY
+:manifest lib Savi.Thing // NOT OKAY
               ^~~~~~~~~~

--- a/spec/integration/error-manifests-reserved-names/savi.errors.txt
+++ b/spec/integration/error-manifests-reserved-names/savi.errors.txt
@@ -1,0 +1,16 @@
+
+Compilation Errors:
+
+---
+
+This name is reserved for core Savi packages:
+from ./manifest.savi:1:
+:manifest bin Savi // NOT OKAY
+              ^~~~
+
+---
+
+This name is reserved for core Savi packages:
+from ./manifest.savi:4:
+:manifest bin Savi.Thing // NOT OKAY
+              ^~~~~~~~~~

--- a/spec/integration/run-all.sh
+++ b/spec/integration/run-all.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+
+set -e
+
+# Set up path to the Savi compiler to use, based on the path provided via arg.
+SAVI=$(CDPATH= cd -- "$(dirname -- "${1:-build/savi-debug}")" && pwd)/$(basename "${1:-build/savi-debug}")
+
+# Change directory to the directory where this script is located.
+cd -- "$(dirname -- "$0")"
+
+
+# Start running integation tests.
+echo "Running integration tests..."
+echo
+for subdir in $(find ./ -maxdepth 1 -mindepth 1 -type d); do
+  # If this subdirectory has an expected errors file, use that test approach.
+  if [ -f "$subdir/savi.errors.txt" ]; then
+    actual=$(cd $subdir && "$SAVI" --backtrace 2>&1 || true)
+    expected=$(cat $subdir/savi.errors.txt)
+    if [ "$actual" = "$expected" ]; then
+      echo "✓    $subdir"
+    else
+      did_fail="X"
+      echo "---"
+      echo "---"
+      echo
+      echo "FAIL $subdir"
+      echo
+      echo "---"
+      echo
+      echo "EXPECTED $expected"
+      echo
+      echo "---"
+      echo
+      echo "ACTUAL $actual"
+      echo
+      echo "---"
+      echo "---"
+    fi
+
+  # Otherwise, we have no test approaches left that can be tried.
+  else
+    did_fail="X"
+    echo "FAIL $subdir"
+    echo "     (missing files needed for integration testing)"
+    echo "     (please add a savi.errors.txt file to that directory)"
+  fi
+  echo
+done
+
+# If any test failed, report overall failure here.
+if [ -n "$did_fail" ]; then
+  echo "INTEGRATION TESTS FAILED"
+  exit 1
+fi

--- a/spec/integration/run-all.sh
+++ b/spec/integration/run-all.sh
@@ -12,7 +12,7 @@ cd -- "$(dirname -- "$0")"
 # Start running integation tests.
 echo "Running integration tests..."
 echo
-for subdir in $(find ./ -maxdepth 1 -mindepth 1 -type d); do
+for subdir in $(find ./ -maxdepth 1 -mindepth 1 -type d | sort --ignore-case); do
   # If this subdirectory has an expected errors file, use that test approach.
   if [ -f "$subdir/savi.errors.txt" ]; then
     actual=$(cd $subdir && "$SAVI" --backtrace 2>&1 || true)

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -224,7 +224,14 @@ class Savi::Compiler
   end
 
   def compile(dirname : String, target : Symbol = :eval, options = Compiler::Options.new)
-    compile(source_service.get_directory_sources(dirname), target, options)
+    sources =
+      if options.skip_manifest
+        source_service.get_directory_sources(dirname)
+      else
+        source_service.get_manifest_sources_at_or_above(dirname)
+      end
+
+    compile(sources, target, options)
   end
 
   @prev_ctx : Context?

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -197,9 +197,7 @@ class Savi::Compiler::CodeGen
     main_gtype = @gtypes["Main"]?
 
     unless main_gtype
-      root_source_package = ctx.root_package.source_package
-      Error.at Source::Pos.show_package_path(root_source_package),
-        "This is the root directory being compiled, but it has no Main actor"
+      Error.at Source::Pos.none, "This package has no Main actor"
     end
 
     main_gtype.not_nil!

--- a/src/savi/compiler/context.cr
+++ b/src/savi/compiler/context.cr
@@ -84,23 +84,12 @@ class Savi::Compiler::Context
     compile_package(source_package, docs)
   end
 
-  def compile_package_at_path(path)
-    # First, try to find an already loaded package that has this same path.
-    package = @program.packages.find(&.source_package.path.==(path))
-    return package if package
-
-    # Otherwise go ahead and load the package.
-    sources = compiler.source_service.get_directory_sources(path)
-    docs = sources.map { |source| Parser.parse(source) }
-    compile_package(sources.first.package, docs)
-  end
-
   def compile_manifests_at_path(path)
     # Skip if we've already compiled at least one manifest at this same path.
     return if @program.manifests.any?(&.name.pos.source.package.path.==(path))
 
     # Otherwise go ahead and load the manifests.
-    sources = compiler.source_service.get_directory_sources(path)
+    sources = compiler.source_service.get_manifest_sources_at_or_above(path)
     docs = sources.map { |source| Parser.parse(source) }
     compile_package(sources.first.package, docs)
   end

--- a/src/savi/compiler/manifests.cr
+++ b/src/savi/compiler/manifests.cr
@@ -140,8 +140,10 @@ class Savi::Compiler::Manifests
     return true if names.uniq.size == names.size
 
     manifests.group_by(&.name.value).each { |name, dups|
-      m = dups.pop
-      ctx.error_at m.name, "This manifest needs a unique name",
+      last = dups.pop
+      next unless dups.any?
+
+      ctx.error_at last.name, "This manifest needs a unique name",
         dups.map { |other| {other.name.pos, "a conflicting one is here"} }
     }
     return false

--- a/src/savi/compiler/manifests.cr
+++ b/src/savi/compiler/manifests.cr
@@ -54,7 +54,7 @@ class Savi::Compiler::Manifests
     # There must be at least one manifest.
     manifests = ctx.program.manifests
     if manifests.empty?
-      ctx.error_at Source::Pos.show_package_path(ctx.root_package.source_package),
+      ctx.error_at Source::Pos.none,
         "No manifests found in the 'manifest.savi' files in this directory"
       return
     end
@@ -75,7 +75,7 @@ class Savi::Compiler::Manifests
 
     # If there is more than one main manifest, complain.
     if mains.size > 1
-      ctx.error_at Source::Pos.show_package_path(ctx.root_package.source_package),
+      ctx.error_at Source::Pos.none,
         "There can't be more than one main manifest in this directory; " \
         "please mark some of these as `:manifest lib` or `:manifest bin`",
         mains.map { |m| {m.name.pos, "this is a main manifest"} }
@@ -87,7 +87,7 @@ class Savi::Compiler::Manifests
     return libs.first if libs.size == 1
 
     # We have no more ways to select an appropriate root manifest; complain.
-    ctx.error_at Source::Pos.show_package_path(ctx.root_package.source_package),
+    ctx.error_at Source::Pos.none,
       "There is more than one manifest and it isn't clear which to use; " \
       "please specify one explicitly by name",
       manifests.map { |m| {m.name.pos, "this is an available manifest"} }
@@ -157,7 +157,7 @@ class Savi::Compiler::Manifests
     return manifest if manifest
 
     name_pos = manifest_name.is_a?(String) \
-      ? Source::Pos.show_package_path(ctx.root_package.source_package) \
+      ? Source::Pos.none \
       : manifest_name.pos
 
     # If we didn't find it, complain.

--- a/src/savi/compiler/source_service.cr
+++ b/src/savi/compiler/source_service.cr
@@ -219,23 +219,6 @@ class Savi::Compiler::SourceService
     }
   end
 
-  # Given a package name, optionally anchored to a given "from source",
-  # try to resolve a directory that matches the package name.
-  #
-  # First a relative location will be attempted starting from the "from source".
-  # Then a standard package location will be attempted.
-  # If both attempts fail, there is no hope of resolving the package.
-  def resolve_package_dirname(libname : String, from_source : Source)
-    standard_dirname = File.expand_path(libname, standard_package_path)
-    relative_dirname = File.expand_path(libname, from_source.dirname)
-
-    if relative_dirname && dir_exists?(relative_dirname)
-      relative_dirname
-    elsif dir_exists?(standard_dirname)
-      standard_dirname
-    end
-  end
-
   # Given a directory name, load source objects for all the source files in it.
   def get_directory_sources(dirname, package : Source::Package? = nil)
     package ||= Source::Package.new(dirname)

--- a/src/savi/compiler/source_service.cr
+++ b/src/savi/compiler/source_service.cr
@@ -245,8 +245,8 @@ class Savi::Compiler::SourceService
       sources << Source.new(dirname, name, content, package)
     }
 
-    Error.at Source::Pos.show_package_path(package),
-      "No '.savi' source files found in this directory" \
+    Error.at Source::Pos.none,
+      "No '.savi' source files found in this directory:\n#{dirname}" \
         if sources.empty?
 
     # Sort the sources by case-insensitive name, so that they always get loaded
@@ -272,8 +272,8 @@ class Savi::Compiler::SourceService
       break unless try_dirname.starts_with?(Dir.current)
     end
 
-    Error.at Source::Pos.show_package_path(Source::Package.new(dirname)),
-      "No 'manifest.savi' source files found at or above this directory" \
+    Error.at Source::Pos.none,
+      "No 'manifest.savi' source files found at or above this directory:\n#{dirname}" \
         if sources.empty?
 
     # Sort the sources by case-insensitive name, so that they always get loaded
@@ -327,8 +327,9 @@ class Savi::Compiler::SourceService
         << Source.new(dirname, name, content, package)
     }
 
-    Error.at Source::Pos.show_package_path(Source::Package.new(root_dirname)),
-      "No '.savi' source files found recursively within this root" \
+    Error.at Source::Pos.none,
+      "No '.savi' source files found recursively within this directory: " \
+      "#{root_dirname}" \
         if sources.empty?
 
     # Sort the sources by case-insensitive name, so that they always get loaded

--- a/src/savi/error.cr
+++ b/src/savi/error.cr
@@ -21,7 +21,12 @@ class Savi::Error < Exception
   end
 
   def message(show_compiler_hole_details = false)
-    strings = ["#{headline}:\n#{pos.show}\n"]
+    strings =
+      if pos == Source::Pos.none
+        ["#{headline}\n"]
+      else
+        ["#{headline}:\n#{pos.show}\n"]
+      end
     info.each do |info_pos, info_msg|
       if info_pos == Source::Pos.none
         strings << "- #{info_msg}"

--- a/src/savi/ext/lib_gc.cr
+++ b/src/savi/ext/lib_gc.cr
@@ -1,0 +1,11 @@
+# Set the "warning proc" of the native Boehm GC library to a no-op,
+# so that it won't print warnings it would otherwise print, looking like:
+#
+#   GC Warning: Repeated allocation of very large block (appr. size 528384):
+#	      May lead to memory leak and poor performance
+#
+# For more info,
+# - see https://forum.crystal-lang.org/t/gc-warning-repeated-allocation-of-very-large-block/928/11?u=jemc
+# - see https://github.com/crystal-lang/crystal/issues/2104#issuecomment-180471871
+
+LibGC.set_warn_proc ->(msg, word) {}

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -105,16 +105,6 @@ struct Savi::Source::Pos
     )
   end
 
-  def self.show_source_path(source : Source)
-    source = Source.new(package.path, "", package.path, package, :path)
-    new(source, 0, package.path.bytesize, 0, package.path.bytesize, 0, 0)
-  end
-
-  def self.show_package_path(package : Package)
-    source = Source.new(package.path, "", package.path, package, :path)
-    new(source, 0, package.path.bytesize, 0, package.path.bytesize, 0, 0)
-  end
-
   def initialize(
     @source, @start, @finish, @line_start, @line_finish, @row, @col
   )
@@ -325,8 +315,10 @@ struct Savi::Source::Pos
       tail = "···"
     end
 
+    relative_path = source.path.sub(Dir.current, ".")
+
     [
-      "from #{source.path}:#{row + 1}:",
+      "from #{relative_path}:#{row + 1}:",
       source.content.byte_slice(line_start, line_finish - line_start),
       (" " * col) + "^" + ("~" * twiddle_width) + tail,
     ].join("\n")


### PR DESCRIPTION
This is part of the work to implement a package manager (#44).

In the previous PR (#174) I added quite a bit of basic functionality related to packages and package manifests, but not all of it was well-tested.

This PR adds a lot more test coverage by introducing a new kind of spec - the `spec/integration` directory which hosts example source file trees with some files that have meta-information about how to test them.

For example, the tests added in this PR all use a new convention of having a `savi.errors.txt` file in the directory which has the verbatim error messages that are expected from compiling the manifests in that directory.

In order to make that work well, this PR also reworks error printing a bit to try to use relative paths (when possible) instead of absolute ones - otherwise, it would be hard to test the verbatim output because absolute paths are dependent on where the Savi git repository is checked out on the host machine.