### PR TITLE
Add initial Random and DeterministicRandom packages.

### DIFF
--- a/packages/DeterministicRandom.manifest.savi
+++ b/packages/DeterministicRandom.manifest.savi
@@ -1,0 +1,11 @@
+:manifest lib DeterministicRandom
+  :sources "DeterministicRandom/*.savi"
+
+  :dependency Random "TODO: specify version"
+
+:manifest bin "spec-DeterministicRandom"
+  :copies DeterministicRandom
+  :sources "DeterministicRandom/test/*.savi"
+
+  :dependency Spec "TODO: specify version"
+  :transitive dependency Map "TODO: specify version"

--- a/packages/DeterministicRandom/Default.savi
+++ b/packages/DeterministicRandom/Default.savi
@@ -1,0 +1,7 @@
+:: A type alias to the current best all-purpose purpose PRNG in this package.
+:: Currently this points to the xoroshiro128++ implementation.
+::
+:: Like all generators in this library, it should NOT be used for cryptographic
+:: purposes, or any other purpose where predictability can cause security flaws.
+:: Prefer using the SecureRandom package for those use cases.
+:alias DeterministicRandom.Default: DeterministicRandom.Xoroshiro128

--- a/packages/DeterministicRandom/DeterministicRandom.savi
+++ b/packages/DeterministicRandom/DeterministicRandom.savi
@@ -1,0 +1,19 @@
+:: A deterministic (non-cryptographic) pseudo-random number generator (PRNG).
+::
+:: This trait defines the common interface that deterministic PRNGs should
+:: adhere to, including the standard common interface for Random in general.
+:trait DeterministicRandom
+  :is Random
+
+  // TODO: this should not be necessary - unimplemented methods should be copied
+  :fun ref u64 U64
+
+  :new (seed): @seed_64(seed)
+  :new new_64(seed U64): @seed_64(seed)
+  :new new_128(seed_a U64, seed_b U64): @seed_128(seed_a, seed_b)
+
+  :fun ref seed(seed U64): @seed_64(seed)
+  :fun ref seed_64(seed U64) @
+  :fun ref seed_128(seed_a U64, seed_b U64) @
+
+// TODO: Add signatures for "jump functions" used to jump N steps forward.

--- a/packages/DeterministicRandom/SplitMix64.savi
+++ b/packages/DeterministicRandom/SplitMix64.savi
@@ -1,0 +1,42 @@
+// TODO: Document.
+:class DeterministicRandom.SplitMix64
+  :is Random // TODO: this should not be necessary - copies should be transitive
+  :is DeterministicRandom // TODO: this should not be necessary - copies should be transitive
+  :is _State64
+
+  :: Each step of the generator, the state steps forward by a constant amount.
+  :const _step U64: 0x9e3779b97f4a7c15
+
+  // Written in 2015 by Sebastiano Vigna (vigna@acm.org)
+  // See <https://prng.di.unimi.it/splitmix64.c>.
+  //
+  // To the extent possible under law, the author has dedicated all copyright
+  // and related and neighboring rights to this software to the public domain
+  // worldwide. This software is distributed without any warranty.
+  //
+  // See <http://creativecommons.org/publicdomain/zero/1.0/>.
+  :fun ref u64
+    z = @_state += @_step
+    z = z.bit_xor(z.bit_shr(30)) * 0xbf58476d1ce4e5b9
+    z = z.bit_xor(z.bit_shr(27)) * 0x94d049bb133111eb
+    z.bit_xor(z.bit_shr(31))
+
+  // Override the default implementation of the U32 so that we get slightly
+  // better performance than just using the high bits of the U64.
+  //
+  // These values are the Mix04 variant taken from a David Stafford blog post.
+  // See <http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html>.
+  //
+  // This blog post appears to be the source cited for the SplitMix64 paper,
+  // which used the Mix13 variant from that post for best 64-bit quality.
+  //
+  // However, the Mix04 variant is of comparable quality and can be used
+  // more efficiently for 32-bit purposes, because it has an exactly 32-bit
+  // shift at the end, so we can skip the final xor operation and the later
+  // 32-bit shift that would normally happen, since the low 32 bits we will use
+  // are already of a high statistical quality when we finish here.
+  :fun ref u32
+    z = @_state += @_step
+    z = z.bit_xor(z.bit_shr(33)) * 0x62a9d9ed799705f5
+    z = z.bit_xor(z.bit_shr(28)) * 0xcb24d0a5c88c35b3
+    z.bit_shr(32).u32

--- a/packages/DeterministicRandom/Xoroshiro128.savi
+++ b/packages/DeterministicRandom/Xoroshiro128.savi
@@ -1,0 +1,86 @@
+:: This is xoroshiro128++, an all-purpose small-state PRNG.
+:: It is very fast and it passes all major statistical quality tests.
+::
+:: See <https://prng.di.unimi.it/> for more information.
+::
+:: Like all generators in this library, it should NOT be used for cryptographic
+:: purposes, or any other purpose where predictability can cause security flaws.
+:: Prefer using the SecureRandom package for those use cases.
+::
+:: Its state space is large enough only for mild parallelism, so if
+:: vast parallelism without state overlap is needed, use 256-bit variants.
+::
+:: For generating floating point numbers (which need only 53 significant bits),
+:: and/or generating other narrow-width types like U32, U16, U8, Bool, prefer to
+:: use Xoroshiro128.Narrow instead, which implements the xoroshiro128+ variant,
+:: being optimized for high performance across that smaller number of bits (53).
+:class DeterministicRandom.Xoroshiro128
+  :is Random // TODO: this should not be necessary - copies should be transitive
+  :is DeterministicRandom // TODO: this should not be necessary - copies should be transitive
+  :is _State128
+
+  // Written in 2019 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+  // See <https://prng.di.unimi.it/xoroshiro128plusplus.c>.
+  //
+  // To the extent possible under law, the author has dedicated all copyright
+  // and related and neighboring rights to this software to the public domain
+  // worldwide. This software is distributed without any warranty.
+  //
+  // See <http://creativecommons.org/publicdomain/zero/1.0/>.
+  :fun ref u64
+    sa = @_state_a
+    sb = @_state_b
+
+    result = (sa + sb).bit_rotl(17) + sa
+
+    sb = sb.bit_xor(sa)
+    @_state_a = sa.bit_rotl(49).bit_xor(sb).bit_xor(sb.bit_shl(21))
+    @_state_b = sb.bit_rotl(28)
+
+    result
+
+:: This is xoroshiro128+, a variant of xoroshiro128++ optimized for F64 values,
+:: which need good statistical quality across only 53 significant bits instead
+:: of across the entire 64 bits that xoroshiro128++ is optimized for.
+::
+:: Other lower bit width data types like U32, U16, U8, Bool, etc can also be
+:: expected to be of high quality, since they will be extracted from within the
+:: 53 high-quality upper bits that are targeted for F64 quality.
+::
+:: It is faster than xoroshiro128++, but has a "mild Hamming-weight dependency"
+:: causing it to fail some linear complexity tests after about 5TB of data.
+::
+:: See <https://prng.di.unimi.it/> for more information.
+::
+:: Like all generators in this library, it should NOT be used for cryptographic
+:: purposes, or any other purpose where predictability can cause security flaws.
+:: Prefer using the SecureRandom package for those use cases.
+::
+:: Its state space is large enough only for mild parallelism, so if
+:: vast parallelism without state overlap is needed, use 256-bit variants.
+::
+:: For all-purpose 64-bit generation, use the main Xoroshiro128 type instead.
+:class DeterministicRandom.Xoroshiro128.Narrow
+  :is Random // TODO: this should not be necessary - copies should be transitive
+  :is DeterministicRandom // TODO: this should not be necessary - copies should be transitive
+  :is _State128
+
+  // Written in 2016-2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+  // See <https://prng.di.unimi.it/xoroshiro128plus.c>.
+  //
+  // To the extent possible under law, the author has dedicated all copyright
+  // and related and neighboring rights to this software to the public domain
+  // worldwide. This software is distributed without any warranty.
+  //
+  // See <http://creativecommons.org/publicdomain/zero/1.0/>.
+  :fun ref u64
+    sa = @_state_a
+    sb = @_state_b
+
+    result = sa + sb
+
+    sb = sb.bit_xor(sa)
+    @_state_a = sa.bit_rotl(24).bit_xor(sb).bit_xor(sb.bit_shl(16))
+    @_state_b = sb.bit_rotl(37)
+
+    result

--- a/packages/DeterministicRandom/_State128.savi
+++ b/packages/DeterministicRandom/_State128.savi
@@ -1,0 +1,31 @@
+:: A deterministic pseudo-random number generator with 128 bits of state.
+:trait _State128
+  :is DeterministicRandom
+  :is Random // TODO: this should not be necessary - copies should be transitive
+
+  // TODO: this should not be necessary - unimplemented methods should be copied
+  :fun ref u64 U64
+
+  :var _state_a U64
+  :var _state_b U64
+
+  :fun ref seed_128(seed_a, seed_b)
+    // Otherwise, use the given seed as normal.
+    @_state_a = seed_a
+    @_state_b = seed_b
+
+    // If a low-quality seed was given, use the seed_64 approach to
+    // spice it up with some scrambled bits, to getter a better seed.
+    case (
+    | seed_a == 0 | @seed_64(seed_b)
+    | seed_b == 0 | @seed_64(seed_a)
+    )
+
+    @
+
+  // When a 64-bit seed is provided to a 128-bit generator,
+  // use SplitMix64 to produce a full seed from the given half-seed.
+  :fun ref seed_64(seed)
+    seeder = DeterministicRandom.SplitMix64.new_64(seed)
+    @seed_128(seeder.u64, seeder.u64)
+    @

--- a/packages/DeterministicRandom/_State64.savi
+++ b/packages/DeterministicRandom/_State64.savi
@@ -1,0 +1,21 @@
+:: A deterministic pseudo-random number generator with 64 bits of state.
+::
+:: It is expected to be seeded with a 64-bit seed, but alternatively,
+:: a 128-bit seed can be used, resulting in the bits being XOR-combined.
+:trait _State64
+  :is DeterministicRandom
+  :is Random // TODO: this should not be necessary - copies should be transitive
+
+  // TODO: this should not be necessary - unimplemented methods should be copied
+  :fun ref u64 U64
+
+  :var _state U64
+
+  :fun ref seed_64(seed)
+    @_state = seed
+    @
+
+  :fun ref seed_128(seed_a U64, seed_b U64)
+    @_state = seed_a.bit_xor(seed_b)
+    @
+

--- a/packages/DeterministicRandom/test/default_spec.savi
+++ b/packages/DeterministicRandom/test/default_spec.savi
@@ -1,0 +1,7 @@
+:class DefaultSpec
+  :is Spec
+  :const describes: "DeterministicRandom.Default"
+
+  :it "is xoroshiro128++"
+    random = DeterministicRandom.Default.new(0)
+    assert: random <: DeterministicRandom.Xoroshiro128

--- a/packages/DeterministicRandom/test/main.savi
+++ b/packages/DeterministicRandom/test/main.savi
@@ -1,0 +1,7 @@
+:actor Main
+  :new (env)
+    Spec.Process.run(env, [
+      Spec.Run(SplitMix64Spec).new(env)
+      Spec.Run(Xoroshiro128Spec).new(env)
+      Spec.Run(Xoroshiro128NarrowSpec).new(env)
+    ])

--- a/packages/DeterministicRandom/test/main.savi
+++ b/packages/DeterministicRandom/test/main.savi
@@ -1,6 +1,7 @@
 :actor Main
   :new (env)
     Spec.Process.run(env, [
+      Spec.Run(DefaultSpec).new(env)
       Spec.Run(SplitMix64Spec).new(env)
       Spec.Run(Xoroshiro128Spec).new(env)
       Spec.Run(Xoroshiro128NarrowSpec).new(env)

--- a/packages/DeterministicRandom/test/split_mix_64_spec.savi
+++ b/packages/DeterministicRandom/test/split_mix_64_spec.savi
@@ -1,0 +1,74 @@
+:class SplitMix64Spec
+  :is Spec
+  :const describes: "DeterministicRandom.SplitMix64"
+
+  :it "generates deterministic 64-bit values, given a specific seed"
+    random = DeterministicRandom.SplitMix64.new(0x14821d7fa0a048bd)
+    assert: random.u64 == 0x1b8cfae92bc829e2
+    assert: random.u64 == 0x295883a20d7e72f3
+    assert: random.u64 == 0xbb823b1f6575a666
+    assert: random.u64 == 0x75cca1d6ff12fb6b
+    assert: random.u64 == 0xd222424fdbfb2a67
+    assert: random.u64 == 0xed37247313d27ae7
+    assert: random.u64 == 0xe3734ceb6a213c07
+    assert: random.u64 == 0xb6df3de5ca769094
+    assert: random.u64 == 0x967669b9ee16dbb4
+    assert: random.u64 == 0xed3d03f1e062a6b2
+    assert: random.u64 == 0x2e4e109e9d8690dc
+    assert: random.u64 == 0x8650a0c62e7b9f80
+    assert: random.u64 == 0x9a344a11932e236b
+    assert: random.u64 == 0x6d6341825fbdb66a
+    assert: random.u64 == 0x4f3b46397517114d
+    assert: random.u64 == 0x6c3e095edaa0384a
+
+  :it "can be re-seeded to cut over to another location in the state space"
+    random = DeterministicRandom.SplitMix64.new(0)
+    assert: random.u64 == 0xe220a8397b1dcdaf
+
+    // Re-seed with the same seed that was used for the previous test,
+    // and show that the same sequence of 16 values is produced.
+    random.seed(0x14821d7fa0a048bd)
+    assert: random.u64 == 0x1b8cfae92bc829e2
+    assert: random.u64 == 0x295883a20d7e72f3
+    assert: random.u64 == 0xbb823b1f6575a666
+    assert: random.u64 == 0x75cca1d6ff12fb6b
+    assert: random.u64 == 0xd222424fdbfb2a67
+    assert: random.u64 == 0xed37247313d27ae7
+    assert: random.u64 == 0xe3734ceb6a213c07
+    assert: random.u64 == 0xb6df3de5ca769094
+    assert: random.u64 == 0x967669b9ee16dbb4
+    assert: random.u64 == 0xed3d03f1e062a6b2
+    assert: random.u64 == 0x2e4e109e9d8690dc
+    assert: random.u64 == 0x8650a0c62e7b9f80
+    assert: random.u64 == 0x9a344a11932e236b
+    assert: random.u64 == 0x6d6341825fbdb66a
+    assert: random.u64 == 0x4f3b46397517114d
+    assert: random.u64 == 0x6c3e095edaa0384a
+
+  :it "generates deterministic 32-bit values, given a specific seed"
+    // Note that these are not the same as the 64-bit numbers produced,
+    // because we did override the default implementation of `u32` with a
+    // more efficient implementation that has comparable statistical properties,
+    // but different values used for the bitwise operations.
+    random = DeterministicRandom.SplitMix64.new(0x14821d7fa0a048bd)
+    assert: random.u32 == 0xea8d51ee
+    assert: random.u32 == 0x822d8e5f
+    assert: random.u32 == 0x65d86e30
+    assert: random.u32 == 0x19b87778
+    assert: random.u32 == 0x4494a4f6
+    assert: random.u32 == 0x237d2cd9
+    assert: random.u32 == 0xc17d6171
+    assert: random.u32 == 0x93df09c0
+
+    // However, if we switch back to 64-bit, the remaining numbers will be
+    // the same as if we had taken that number of steps using `u64`.
+    // That is, the following numbers are the same as the 2nd half of
+    // the numbers in the prior tests that used 64-bit generated values.
+    assert: random.u64 == 0x967669b9ee16dbb4
+    assert: random.u64 == 0xed3d03f1e062a6b2
+    assert: random.u64 == 0x2e4e109e9d8690dc
+    assert: random.u64 == 0x8650a0c62e7b9f80
+    assert: random.u64 == 0x9a344a11932e236b
+    assert: random.u64 == 0x6d6341825fbdb66a
+    assert: random.u64 == 0x4f3b46397517114d
+    assert: random.u64 == 0x6c3e095edaa0384a

--- a/packages/DeterministicRandom/test/xoroshiro_128_narrow_spec.savi
+++ b/packages/DeterministicRandom/test/xoroshiro_128_narrow_spec.savi
@@ -1,0 +1,60 @@
+
+:class Xoroshiro128NarrowSpec
+  :is Spec
+  :const describes: "DeterministicRandom.Xoroshiro128.Narrow"
+
+  :it "generates deterministic 64-bit values, given a specific seed"
+    random = DeterministicRandom.Xoroshiro128.Narrow.new_128(
+      0x1b8cfae92bc829e2
+      0x295883a20d7e72f3
+    )
+    assert: random.u64 == 0x44e57e8b39469cd5
+    assert: random.u64 == 0x797ff9fafa4c014f
+    assert: random.u64 == 0xfb925e05601d0870
+    assert: random.u64 == 0xb463a47121a1a5d7
+    assert: random.u64 == 0x4e6ff8dcd693a676
+    assert: random.u64 == 0x44ab0e5cbc821597
+    assert: random.u64 == 0x19d948f09796b555
+    assert: random.u64 == 0x686a361bdc33dd39
+    assert: random.u64 == 0x369276a2848d9fa4
+    assert: random.u64 == 0x355b3d4aa6e54d1d
+    assert: random.u64 == 0x55e909dcf23f89e6
+    assert: random.u64 == 0xa4bff809572ab095
+    assert: random.u64 == 0x6c24699a4578ebf8
+    assert: random.u64 == 0xc55c6b51e98339af
+    assert: random.u64 == 0x10a4a40b081c8b7f
+    assert: random.u64 == 0xaf6b86593b10aead
+
+  :it "can be re-seeded to cut over to another location in the state space"
+    random = DeterministicRandom.Xoroshiro128.Narrow.new_128(1, 2)
+    assert: random.u64 == 0x0000000000000003
+
+    // Re-seed with the same seed that was used for the previous test,
+    // and show that the same sequence of 16 values is produced.
+    random.seed_128(
+      0x1b8cfae92bc829e2
+      0x295883a20d7e72f3
+    )
+    assert: random.u64 == 0x44e57e8b39469cd5
+    assert: random.u64 == 0x797ff9fafa4c014f
+    assert: random.u64 == 0xfb925e05601d0870
+    assert: random.u64 == 0xb463a47121a1a5d7
+    assert: random.u64 == 0x4e6ff8dcd693a676
+    assert: random.u64 == 0x44ab0e5cbc821597
+    assert: random.u64 == 0x19d948f09796b555
+    assert: random.u64 == 0x686a361bdc33dd39
+    assert: random.u64 == 0x369276a2848d9fa4
+    assert: random.u64 == 0x355b3d4aa6e54d1d
+    assert: random.u64 == 0x55e909dcf23f89e6
+    assert: random.u64 == 0xa4bff809572ab095
+    assert: random.u64 == 0x6c24699a4578ebf8
+    assert: random.u64 == 0xc55c6b51e98339af
+    assert: random.u64 == 0x10a4a40b081c8b7f
+    assert: random.u64 == 0xaf6b86593b10aead
+
+  :it "prevents the mistake of seeding with an all-zero seed"
+    random = DeterministicRandom.Xoroshiro128.Narrow.new_128(0, 0)
+    // Without special action to prevent, this would produce all zeroes.
+    assert: random.u64 == 0x509946a41cd733a3
+    assert: random.u64 == 0xd805fcac6824536e
+    assert: random.u64 == 0xdadc02f3e3cf7be3

--- a/packages/DeterministicRandom/test/xoroshiro_128_spec.savi
+++ b/packages/DeterministicRandom/test/xoroshiro_128_spec.savi
@@ -1,0 +1,59 @@
+:class Xoroshiro128Spec
+  :is Spec
+  :const describes: "DeterministicRandom.Xoroshiro128"
+
+  :it "generates deterministic 64-bit values, given a specific seed"
+    random = DeterministicRandom.Xoroshiro128.new_128(
+      0x1b8cfae92bc829e2
+      0x295883a20d7e72f3
+    )
+    assert: random.u64 == 0x18a36d766572b3ac
+    assert: random.u64 == 0x450a217c59700240
+    assert: random.u64 == 0xb13dc42144d9c9fc
+    assert: random.u64 == 0x754d398b886b93c8
+    assert: random.u64 == 0xaf03cafb91299b8f
+    assert: random.u64 == 0x9fe2f3b72dce67c6
+    assert: random.u64 == 0x723154da022be1ed
+    assert: random.u64 == 0x86111eedc159a09f
+    assert: random.u64 == 0x9b5e3455466b6b78
+    assert: random.u64 == 0x214580c7e541f79b
+    assert: random.u64 == 0x63dc4aa3efed499e
+    assert: random.u64 == 0xf3da89aca0e115e6
+    assert: random.u64 == 0x7c832eee0d90cc9d
+    assert: random.u64 == 0x6c1198ed285d2002
+    assert: random.u64 == 0x7489127f8c390cce
+    assert: random.u64 == 0xacc5fa85532a442c
+
+  :it "can be re-seeded to cut over to another location in the state space"
+    random = DeterministicRandom.Xoroshiro128.new_128(1, 2)
+    assert: random.u64 == 0x0000000000060001
+
+    // Re-seed with the same seed that was used for the previous test,
+    // and show that the same sequence of 16 values is produced.
+    random.seed_128(
+      0x1b8cfae92bc829e2
+      0x295883a20d7e72f3
+    )
+    assert: random.u64 == 0x18a36d766572b3ac
+    assert: random.u64 == 0x450a217c59700240
+    assert: random.u64 == 0xb13dc42144d9c9fc
+    assert: random.u64 == 0x754d398b886b93c8
+    assert: random.u64 == 0xaf03cafb91299b8f
+    assert: random.u64 == 0x9fe2f3b72dce67c6
+    assert: random.u64 == 0x723154da022be1ed
+    assert: random.u64 == 0x86111eedc159a09f
+    assert: random.u64 == 0x9b5e3455466b6b78
+    assert: random.u64 == 0x214580c7e541f79b
+    assert: random.u64 == 0x63dc4aa3efed499e
+    assert: random.u64 == 0xf3da89aca0e115e6
+    assert: random.u64 == 0x7c832eee0d90cc9d
+    assert: random.u64 == 0x6c1198ed285d2002
+    assert: random.u64 == 0x7489127f8c390cce
+    assert: random.u64 == 0xacc5fa85532a442c
+
+  :it "prevents the mistake of seeding with an all-zero seed"
+    random = DeterministicRandom.Xoroshiro128.new_128(0, 0)
+    // Without special action to prevent, this would produce all zeroes.
+    assert: random.u64 == 0x6f68e1e7e2646ee1
+    assert: random.u64 == 0xbf971b7f454094ad
+    assert: random.u64 == 0x48f2de556f30de38

--- a/packages/Random.manifest.savi
+++ b/packages/Random.manifest.savi
@@ -1,0 +1,9 @@
+:manifest lib Random
+  :sources "Random/*.savi"
+
+:manifest bin "spec-Random"
+  :copies Random
+  :sources "Random/test/*.savi"
+
+  :dependency Spec "TODO: specify version"
+  :transitive dependency Map "TODO: specify version"

--- a/packages/Random/Random.savi
+++ b/packages/Random/Random.savi
@@ -1,0 +1,31 @@
+// TODO: Document.
+:trait Random
+  // Each random generator is expected to supply an implementation to generate
+  // a pseudo-random 64-bit number, and other value types are derived from this.
+  :fun ref u64 U64
+
+  // Unsigned integers are derived by bit-shifting down from the original U64.
+  // However, some implementations may override these with different approaches.
+  //
+  // We intentionally cascade each method into the next, so that if for example,
+  // the `u32` method is overridden with another approach, then all
+  // smaller-width values will derive from `u32` instead of `u64`.
+  //
+  // In the normal case, with no overrides, we trust LLVM to inline and combine
+  // the bit shift operations to remove unnecessary bit shift instructions.
+  :fun ref u32 U32: @u64.bit_shr(32).u32
+  :fun ref u16 U16: @u32.bit_shr(16).u16
+  :fun ref u8 U8: @u16.bit_shr(8).u8
+
+  // Signed integers are derived by generating as unsigned, then converting.
+  :fun ref i64 I64: @u64.i64
+  :fun ref i32 I32: @u32.i32
+  :fun ref i16 I16: @u16.i16
+  :fun ref i8 I8: @u8.i8
+
+  // Floating-point numbers are similarly derived by converting unsigned ones.
+  :fun ref f64 F64: F64.from_bits(@u64)
+  :fun ref f32 F32: F32.from_bits(@u32)
+
+  // Boolean values are derived from the most significant bit of the value.
+  :fun ref bool Bool: @u8 >= 0x80

--- a/packages/Random/test/main.savi
+++ b/packages/Random/test/main.savi
@@ -1,0 +1,5 @@
+:actor Main
+  :new (env)
+    Spec.Process.run(env, [
+      Spec.Run(RandomSpec).new(env)
+    ])

--- a/packages/Random/test/random_spec.savi
+++ b/packages/Random/test/random_spec.savi
@@ -1,0 +1,45 @@
+// A fake random implementation that always returns the same 64-bit value,
+// so that the variety of different derived functions can be easily tested.
+:class _FakeRandom64
+  :is Random
+  :fun ref u64 U64: 0x0123456789abcdef
+
+// A fake random implementation that always returns the same 64-bit value,
+// but overrides the 32-bit function to return a differently derived value,
+// to test that smaller values will prefer deriving from the 32-bit value.
+:class _FakeRandom6432
+  :is Random
+  :fun ref u64 U64: 0x0123456789abcdef
+  :fun ref u32 U32: 0xf7e6d5c4
+
+:class RandomSpec
+  :is Spec
+  :const describes: "Random"
+
+  :it "derives other values from the high side of the 64-bit value"
+    random = _FakeRandom64.new
+    assert: random.u64 == 0x0123456789abcdef
+    assert: random.u32 == 0x01234567
+    assert: random.u16 == 0x0123
+    assert: random.u8  == 0x01
+    assert: random.i64 == 0x0123456789abcdef
+    assert: random.i32 == 0x01234567
+    assert: random.i16 == 0x0123
+    assert: random.i8  == 0x01
+    assert: random.f64 == F64.from_bits(0x0123456789abcdef)
+    assert: random.f32 == F32.from_bits(0x01234567)
+    assert: random.bool == False
+
+  :it "derives smaller values from the high side of the 32-bit value if present"
+    random = _FakeRandom6432.new
+    assert: random.u64 == 0x0123456789abcdef
+    assert: random.u32 == 0xf7e6d5c4
+    assert: random.u16 == 0xf7e6
+    assert: random.u8  == 0xf7
+    assert: random.i64 == 0x0123456789abcdef
+    assert: random.i32 == 0xf7e6d5c4
+    assert: random.i16 == 0xf7e6
+    assert: random.i8  == 0xf7
+    assert: random.f64 == F64.from_bits(0x0123456789abcdef)
+    assert: random.f32 == F32.from_bits(0xf7e6d5c4)
+    assert: random.bool == True

--- a/packages/Savi/numeric.savi
+++ b/packages/Savi/numeric.savi
@@ -74,6 +74,20 @@
   :fun val count_zeros U8: @invert.count_ones
   :fun val next_pow2 @: compiler intrinsic
 
+  :: Rotate the given number of bits to the "left" (toward most significant).
+  :: Bits that are shifted off the left side are copied to the right side.
+  :fun val bit_rotl(bits U8) @
+    @bit_shl(bits).bit_or(
+      @bit_shr(@bit_width - bits)
+    )
+
+  :: Rotate the given number of bits to the "right" (toward least significant).
+  :: Bits that are shifted off the right side are copied to the left side.
+  :fun val bit_rotr(bits U8) @
+    @bit_shr(bits).bit_or(
+      @bit_shl(@bit_width - bits)
+    )
+
   :fun val native_to_be @
     if (Platform.big_endian) (@ | @swap_bytes)
 

--- a/packages/Savi/test/numeric_spec.savi
+++ b/packages/Savi/test/numeric_spec.savi
@@ -265,6 +265,10 @@
     assert: U8[127].next_pow2     == 128
     assert: U8[128].next_pow2     == 128
     assert: U8[129].next_pow2     == 0
+    assert: U16[0b1110010110001010].bit_shl(5)  == 0b1011000101000000
+    assert: U16[0b1110010110001010].bit_rotl(5) == 0b1011000101011100
+    assert: U16[0b1110010110001010].bit_shr(5)  == 0b0000011100101100
+    assert: U16[0b1110010110001010].bit_rotr(5) == 0b0101011100101100
 
   :it "implements logarithms and exponents for floating points"
     assert: F64[1].log == 0

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -2310,6 +2310,8 @@ class Savi::Compiler::CodeGen
         else
           gtype_of(expr).singleton
         end
+      elsif ref.is_a?(Refer::TypeAlias)
+        gtype_of(expr).singleton
       elsif ref.is_a?(Refer::Self)
         raise "#{ref.inspect} isn't a constant value" if const_only
         func_frame.receiver_value


### PR DESCRIPTION
Resolves #172.

- `Random` is the new common interface to be used for all PRNGs,
  which also has convenience methods for getting various value types.
- `DeterministicRandom`, the package, contains a collection of
  deterministic (and thus non-cryptographic PRNGS).
- `DeterministicRandom`, the trait, is a common interface for
  PRNGs that require/allow a seed for determinism - a subtype of `Random`.
- in the future, a `SecureRandom` package will host a non-deterministic,
  cryptographically secure PRNG (i.e. CSPRNG) - see #171. This will be another subtype of `Random`,

Note that to do this I first added `bit_rotl` and `bit_rotr` methods to `IntegerMethods`,
since it was missing these basic bitwise utilities.
