### PR TITLE
Compile to binary named after the manifest, instead of always `./main`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-main
+bin
 /.make-var-cache
 /build
 /build-in-docker

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SPEC=$(BUILD)/savi-spec
 ci: PHONY
 	make format.check
 	make spec.all extra_args="--backtrace $(extra_args)"
-	make example-run dir="examples/adventofcode/2018" extra_args="--backtrace $(extra_args)"
+	make example dir="examples/adventofcode/2018" extra_args="--backtrace $(extra_args)"
 
 # Remove temporary/generated files.
 clean: PHONY
@@ -40,6 +40,11 @@ spec.package: PHONY $(SAVI)
 spec.package.all: PHONY $(SAVI)
 	find packages/spec -mindepth 1 -maxdepth 1 | cut -d/ -f3 | sort | xargs -I'{}' sh -c \
 		"echo && $(SAVI) run --cd packages "spec-{}" $(extra_args) || exit 255"
+
+# Run the specs for the given package in lldb for debugging.
+spec.package.lldb: PHONY $(SAVI)
+	echo && $(SAVI) build --cd packages "spec-$(name)" $(extra_args) && \
+		lldb -o run -- "packages/bin/spec-$(name)"
 
 # Run the specs that are written in Crystal (mostly compiler unit tests),
 # narrowing to those with the given name (or all of them).
@@ -68,21 +73,13 @@ ffigen: PHONY $(SAVI)
 example-eval: PHONY $(SAVI)
 	echo && $(SAVI) eval 'env.out.print("Hello, World!")'
 
-# Run the files in the given directory.
-example-run: PHONY $(SAVI)
-	echo && cd "$(dir)" && $(shell pwd)/$(SAVI) run $(extra_args)
+# Compile and run the user program binary in the given directory.
+example: PHONY $(SAVI)
+	echo && $(SAVI) --cd "$(dir)" run $(extra_args)
 
 # Compile the files in the given directory.
 example-compile: PHONY $(SAVI)
-	echo && cd "$(dir)" && $(shell pwd)/$(SAVI) $(extra_args)
-
-# Compile and run the user program binary in the given directory.
-example: example-compile
-	echo && "$(dir)/main"
-
-# Compile and run the user program binary in the given directory under LLDB.
-example-lldb: example-compile
-	echo && lldb -o run -- "$(dir)/main"
+	echo && $(SAVI) --cd "$(dir)" $(extra_args)
 
 # Compile the vscode extension.
 vscode: PHONY $(SAVI)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ asdf global savi latest
 savi eval 'env.out.print("Savi is installed!")'
 ```
 
-Once Savi is installed, you can enter any directory with Savi source code and run the `savi` command there to compile the program, resulting in an executable binary named `main` that you can use to run the program.
+Once Savi is installed, you can enter any directory with a `manifest.savi` file in it and run the `savi` command there to compile one of the manifests defined in it, resulting in an executable binary program in a `./bin` folder with the same name as that targeted manifest.
 
 Alternatively, you can invoke `savi run` to both compile and immediately run the program.
 
@@ -81,8 +81,6 @@ To get started, clone the project to your development machine, then run one of t
 
 - Run `make format.check` to check `*.savi` source files for formatting rule violations, or `make format` to fix them automatically.
 
-- Run `make example-run dir="/opt/code/examples/adventofcode/2018` to compile and run from the sources in `./examples/adventofcode/2018` directory (or similarly for any other example code directory).
-
-- Run `make example-lldb` to do the same as above, but run inside `lldb` to allow you to breakpoint and step through code.
+- Run `make example dir="/opt/code/examples/adventofcode/2018` to compile and run from the sources in `./examples/adventofcode/2018` directory (or similarly for any other example code directory).
 
 Alternatively, you can develop within the confines of a docker container, so that no development dependencies are needed other than `docker` itself. To do so, first run `docker/make ready` to run up a development container, then use `docker/make` instead of `make` to run any of the commands mentioned above (for example, `docker/make test`), which will run that command inside of the development container.

--- a/main.cr
+++ b/main.cr
@@ -18,7 +18,6 @@ module Savi
       option "--print-ir", desc: "Print generated LLVM IR", type: Bool, default: false
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
       option "-C", "--cd=DIR", desc: "Change the working directory"
-      option "-o NAME", "--output=NAME", desc: "Name of the output binary"
       option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
       run do |opts, args|
         options = Savi::Compiler::Options.new(
@@ -27,7 +26,6 @@ module Savi
           print_ir: opts.print_ir,
           print_perf: opts.print_perf,
         )
-        options.binary_name = opts.output.not_nil! if opts.output
         options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
         Dir.cd(opts.cd.not_nil!) if opts.cd
         Cli.compile options, opts.backtrace
@@ -98,7 +96,6 @@ module Savi
         argument "name", type: String, required: false, desc: "Name of the manifest to compile"
         option "-b", "--backtrace", desc: "Show backtrace on error", type: Bool, default: false
         option "-r", "--release", desc: "Compile in release mode", type: Bool, default: false
-        option "-o NAME", "--output=NAME", desc: "Name of the output binary"
         option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
         option "--print-ir", desc: "Print generated LLVM IR", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
@@ -110,7 +107,6 @@ module Savi
             print_ir: opts.print_ir,
             print_perf: opts.print_perf,
           )
-          options.binary_name = opts.output.not_nil! if opts.output
           options.manifest_name = args.name.not_nil! if args.name
           Dir.cd(opts.cd.not_nil!) if opts.cd
           Cli.compile options, opts.backtrace

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -8,12 +8,9 @@ class Savi::Compiler
     property no_debug
     property print_ir
     property print_perf
-    property binary_name
     property skip_manifest
     property manifest_name : String?
     property target_pass : Symbol?
-
-    DEFAULT_BINARY_NAME = "main"
 
     def initialize(
       @release = false,
@@ -21,7 +18,6 @@ class Savi::Compiler
       @print_ir = false,
       @print_perf = false,
       @skip_manifest = false,
-      @binary_name = DEFAULT_BINARY_NAME,
       @manifest_name = nil,
       @target_pass = nil,
     )

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -18,10 +18,11 @@ class Savi::Compiler::Binary
   end
 
   def run(ctx)
+    bin_path = ctx.manifests.root.not_nil!.bin_path
+
     # Compile a temporary binary object file, that we will remove after we
     # use it in the linker invocation to create the final binary.
-    obj_filename = File.tempname(".savi.user.program") + ".o"
-    BinaryObject.run(ctx, obj_filename)
+    obj_path = BinaryObject.run(ctx)
 
     # Use clang to orchestrate the linking process (clang will call the linker
     # for us with appropriate arguments based on the args we have given it).
@@ -57,17 +58,17 @@ class Savi::Compiler::Binary
     end
 
     # Finally, specify the input object file and the output filename.
-    link_args << obj_filename
-    link_args << "-o" << ctx.options.binary_name
+    link_args << obj_path
+    link_args << "-o" << bin_path
 
     res = Process.run("/usr/bin/env", link_args, output: STDOUT, error: STDERR)
     raise "linker failed" unless res.exit_code == 0
 
     if ctx.options.no_debug
-      res = Process.run("/usr/bin/env", ["strip", ctx.options.binary_name], output: STDOUT, error: STDERR)
+      res = Process.run("/usr/bin/env", ["strip", bin_path], output: STDOUT, error: STDERR)
       raise "strip failed" unless res.exit_code == 0
     end
   ensure
-    File.delete(obj_filename) if obj_filename && File.exists?(obj_filename)
+    File.delete(obj_path) if obj_path && File.exists?(obj_path)
   end
 end

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -1,4 +1,5 @@
 require "file"
+require "file_utils"
 require "llvm"
 
 ##
@@ -27,7 +28,7 @@ class Savi::Compiler::BinaryObject
       .find { |path| File.exists?(path) }
   end
 
-  def self.run(ctx, obj_filename = nil)
+  def self.run(ctx)
     llvm = ctx.code_gen.llvm
     machine = ctx.code_gen.target_machine
     mod = ctx.code_gen.mod
@@ -42,8 +43,12 @@ class Savi::Compiler::BinaryObject
     # Link the pony runtime bitcode into the generated module.
     LibLLVM.link_modules(mod.to_unsafe, ponyrt.to_unsafe)
 
-    obj_filename ||= "#{ctx.options.binary_name}.o"
+    obj_path = "#{ctx.manifests.root.not_nil!.bin_path}.o"
 
-    machine.emit_obj_to_file(mod, obj_filename)
+    FileUtils.mkdir_p(File.dirname(obj_path))
+
+    machine.emit_obj_to_file(mod, obj_path)
+
+    obj_path
   end
 end

--- a/src/savi/compiler/binary_verona.cr
+++ b/src/savi/compiler/binary_verona.cr
@@ -22,16 +22,17 @@ class Savi::Compiler::BinaryVerona
   end
 
   def run(ctx)
+    bin_path = ctx.manifests.root.not_nil!.bin_path
+
+    # Compile a temporary binary object file, that we will remove after we
+    # use it in the linker invocation to create the final binary.
+    obj_path = BinaryObject.run(ctx)
+
     llvm = ctx.code_gen_verona.llvm
     machine = ctx.code_gen_verona.target_machine
     mod = ctx.code_gen_verona.mod
 
-    bin_filename = File.tempname(".savi.user.program")
-    obj_filename = "#{bin_filename}.o"
-
-    machine.emit_obj_to_file(mod, obj_filename)
-
-    puts obj_filename
+    machine.emit_obj_to_file(mod, obj_path)
 
     link_args = %w{clang++
       -fuse-ld=lld -rdynamic -static -fpic
@@ -49,19 +50,19 @@ class Savi::Compiler::BinaryVerona
         "-O0"
       end
 
-    link_args << obj_filename
+    link_args << obj_path
     link_args << VERONA_STATIC_LIB
-    link_args << "-o" << ctx.options.binary_name
+    link_args << "-o" << bin_path
 
     res = Process.run("/usr/bin/env", link_args, output: STDOUT, error: STDERR)
     raise "linker failed" unless res.exit_code == 0
 
     if ctx.options.release
-      res = Process.run("/usr/bin/env", ["strip", ctx.options.binary_name], output: STDOUT, error: STDERR)
+      res = Process.run("/usr/bin/env", ["strip", bin_path], output: STDOUT, error: STDERR)
       raise "strip failed" unless res.exit_code == 0
     end
   ensure
-    File.delete(obj_filename) if obj_filename
+    File.delete(obj_path) if obj_path && File.exists?(obj_path)
   end
 
   def self.run_last_compiled_program

--- a/src/savi/compiler/eval.cr
+++ b/src/savi/compiler/eval.cr
@@ -14,9 +14,9 @@ class Savi::Compiler::Eval
   getter! exitcode : Int32
 
   def run(ctx)
-    binary_path = "./#{ctx.options.binary_name}"
+    bin_path = ctx.manifests.root.not_nil!.bin_path
 
-    res = Process.run("/usr/bin/env", [binary_path], output: STDOUT, error: STDERR)
+    res = Process.run("/usr/bin/env", [bin_path], output: STDOUT, error: STDERR)
     @exitcode = res.exit_code
   end
 end

--- a/src/savi/packaging/manifest.cr
+++ b/src/savi/packaging/manifest.cr
@@ -8,6 +8,10 @@ struct Savi::Packaging::Manifest
   def initialize(@name, @kind)
   end
 
+  def bin_path
+    File.join(name.pos.source.dirname, "bin", name.value)
+  end
+
   def is_main?
     @kind.value == "main"
   end


### PR DESCRIPTION
After this PR, compiling a manifest named `my-program` will no longer yield a binary executable named `./main`, but instead will be `bin/my-program`.