### PR TITLE
Add Random frac_32, frac_32_nonzero, frac_64, and frac_64_nonzero.

### DIFF
--- a/packages/Random.manifest.savi
+++ b/packages/Random.manifest.savi
@@ -7,3 +7,5 @@
 
   :dependency Spec "TODO: specify version"
   :transitive dependency Map "TODO: specify version"
+
+  :dependency DeterministicRandom "TODO: specify version"

--- a/packages/spec/Random/Random.Spec.savi
+++ b/packages/spec/Random/Random.Spec.savi
@@ -43,3 +43,17 @@
     assert: random.f64 == F64.from_bits(0x0123456789abcdef)
     assert: random.f32 == F32.from_bits(0xf7e6d5c4)
     assert: random.bool == True
+
+  :it "generates 64-bit fractional values between 0 and 1, averaging around 0.5"
+    random = DeterministicRandom.Xoroshiro128.new_128(1, 2)
+    count USize = 0x1_0000
+    total F64 = 0
+    Count.to(count) -> (i | total += random.frac_64)
+    assert: (total / count.f64) == 0.49999695846019471
+
+  :it "generates 32-bit fractional values between 0 and 1, averaging around 0.5"
+    random = DeterministicRandom.Xoroshiro128.new_128(1, 2)
+    count USize = 0x1_0000
+    total F32 = 0
+    Count.to(count) -> (i | total += random.frac_32)
+    assert: (total / count.f32) == 0.49999812245368958

--- a/packages/spec/Savi/Numeric.Spec.savi
+++ b/packages/spec/Savi/Numeric.Spec.savi
@@ -362,6 +362,17 @@
     assert: F64[-123.456].is_negative
     assert: F32[-123.456].is_negative
 
+  :it "knows the bit widths used in the representation of floating-point values"
+    // We have significand bits, exponent bits, and 1 sign bit.
+    assert: F32.sig_bit_width + F32.exp_bit_width + 1 == F32.bit_width
+    assert: F64.sig_bit_width + F64.exp_bit_width + 1 == F64.bit_width
+
+  :it "knows floating-point units of least precision just above and below 1.0"
+    assert: F32.epsilon      == F32[2].pow(F32.sig_bit_width.f32.negate)
+    assert: F32.half_epsilon == F32[2].pow(F32.sig_bit_width.f32.negate - 1)
+    assert: F64.epsilon      == F64[2].pow(F64.sig_bit_width.f64.negate)
+    assert: F64.half_epsilon == F64[2].pow(F64.sig_bit_width.f64.negate - 1)
+
   :it "converts U8 integers from native to big/little endianness and vice versa"
     u8 = U8[0x12]
 

--- a/packages/src/Random/Random.savi
+++ b/packages/src/Random/Random.savi
@@ -28,4 +28,40 @@
   :fun ref f32 F32: F32.from_bits(@u32)
 
   // Boolean values are derived from the most significant bit of the value.
-  :fun ref bool Bool: @u8 >= 0x80
+  :fun ref bool Bool: @u8.bit_and(0x80) != 0
+
+  :: Return a random 32-bit fraction - an F32 in the range [0, 1).
+  ::
+  :: The possible values will be uniformly spaced at one half-epsilon apart,
+  :: because half-epsilon is the largest unit of least precision below 1.0.
+  ::
+  :: To generate in a range that includes 1 but excludes 0, see frac_32_nonzero.
+  :fun ref frac_32 F32
+    @u32.bit_shr(F32.exp_bit_width).f32 * F32.half_epsilon
+
+  :: Return a random 32-bit nonzero fraction - an F32 in the range (0, 1].
+  ::
+  :: The possible values will be uniformly spaced at one half-epsilon apart,
+  :: because half-epsilon is the largest unit of least precision below 1.0.
+  ::
+  :: To generate in a range that includes 0 but excludes 1, see frac_32.
+  :fun ref frac_32_nonzero F32
+    @frac_32 + F32.half_epsilon
+
+  :: Return a random 64-bit fraction - an F64 in the range [0, 1).
+  ::
+  :: The possible values will be uniformly spaced at one half-epsilon apart,
+  :: because half-epsilon is the largest unit of least precision below 1.0.
+  ::
+  :: To generate in a range that includes 1 but excludes 0, see frac_64_nonzero.
+  :fun ref frac_64 F64
+    @u64.bit_shr(F64.exp_bit_width).f64 * F64.half_epsilon
+
+  :: Return a random 64-bit nonzero fraction - an F64 in the range (0, 1].
+  ::
+  :: The possible values will be uniformly spaced at one half-epsilon apart,
+  :: because half-epsilon is the largest unit of least precision below 1.0.
+  ::
+  :: To generate in a range that includes 0 but excludes 1, see frac_64.
+  :fun ref frac_64_nonzero F64
+    @frac_64 + F64.half_epsilon

--- a/packages/src/Savi/Numeric.savi
+++ b/packages/src/Savi/Numeric.savi
@@ -129,11 +129,28 @@
   :fun non from_bits(bits U32) @'val: compiler intrinsic
   :fun val bits U32: compiler intrinsic
 
+  // TODO: These should be :const (should they be capitalized)?
   :fun non nan:          @from_bits(0x7FC0_0000)
   :fun non infinity:     @from_bits(0x7F80_0000)
   :fun non neg_infinity: @from_bits(0xFF80_0000)
   :fun non max_value:    @from_bits(0x7F7F_FFFF)
   :fun non min_value:    @from_bits(0xFF7F_FFFF)
+
+  :: The number of bits representing the exponent.
+  :fun non exp_bit_width U8: 8
+
+  :: The number of bits representing the significand (a.k.a. mantissa).
+  :: Note that this does not include the implicit/hidden leading bit,
+  :: because that implicit bit is not actually in the memory representation.
+  :fun non sig_bit_width U8: 23
+
+  :: The difference between 1.0 and the next larger representable number.
+  :: This is the unit of least precision in the semi-open range [1.0, 2.0).
+  :fun non epsilon: @from_bits(0x3400_0000) // 2 ** -23
+
+  :: The difference between 1.0 and the next smaller representable number.
+  :: This is the unit of least precision in the semi-open range [0.5, 1.0).
+  :fun non half_epsilon: @from_bits(0x33800000) // 2 ** -24
 
   :fun val log @: compiler intrinsic
   :fun val log2 @: compiler intrinsic
@@ -161,11 +178,28 @@
   :fun non from_bits(bits U64) @'val: compiler intrinsic
   :fun val bits U64: compiler intrinsic
 
+  // TODO: These should be :const (should they be capitalized)?
   :fun non nan:          @from_bits(0x7FF8_0000_0000_0000)
   :fun non infinity:     @from_bits(0x7FF0_0000_0000_0000)
   :fun non neg_infinity: @from_bits(0xFFF0_0000_0000_0000)
   :fun non max_value:    @from_bits(0x7FEF_FFFF_FFFF_FFFF)
   :fun non min_value:    @from_bits(0xFFEF_FFFF_FFFF_FFFF)
+
+  :: The number of bits representing the exponent.
+  :fun non exp_bit_width U8: 11
+
+  :: The number of bits representing the significand (a.k.a. mantissa).
+  :: Note that this does not include the implicit/hidden leading bit,
+  :: because that implicit bit is not actually in the memory representation.
+  :fun non sig_bit_width U8: 52
+
+  :: The difference between 1.0 and the next larger representable number.
+  :: This is the unit of least precision in the semi-open range [1.0, 2.0).
+  :fun non epsilon: @from_bits(0x3cb0000000000000) // 2 ** -52
+
+  :: The difference between 1.0 and the next smaller representable number.
+  :: This is the unit of least precision in the semi-open range [0.5, 1.0).
+  :fun non half_epsilon: @from_bits(0x3ca0000000000000) // 2 ** -53
 
   :fun val log @: compiler intrinsic
   :fun val log2 @: compiler intrinsic

--- a/src/savi/compiler/load.cr
+++ b/src/savi/compiler/load.cr
@@ -15,6 +15,12 @@ class Savi::Compiler::Load
   def run(ctx)
     return if ctx.options.skip_manifest
 
-    ctx.manifests.manifests_by_name.each_value { |m| ctx.compile_package(m) }
+    loaded = Set(Packaging::Manifest).new
+    ctx.manifests.manifests_by_name.each_value { |manifest|
+      next if loaded.includes?(manifest)
+      loaded.add(manifest)
+
+      ctx.compile_package(manifest)
+    }
   end
 end

--- a/src/savi/compiler/namespace.cr
+++ b/src/savi/compiler/namespace.cr
@@ -175,7 +175,9 @@ class Savi::Compiler::Namespace
     manifest.dependencies.each { |dep|
       next if dep.transitive?
 
-      @types_by_package_name[dep.name.value].each { |name, new_type_link|
+      dep_manifest = ctx.manifests.manifests_by_name[dep.name.value]
+
+      @types_by_package_name[dep_manifest.name.value].each { |name, new_type_link|
         new_type = new_type_link.resolve(ctx)
         next if new_type.has_tag?(:private)
 

--- a/src/savi/packaging/manifest.cr
+++ b/src/savi/packaging/manifest.cr
@@ -2,6 +2,7 @@ struct Savi::Packaging::Manifest
   getter name : AST::Identifier
   getter kind : AST::Identifier
   getter copies_names = [] of AST::Identifier
+  getter provides_names = [] of AST::Identifier
   getter sources_paths = [] of AST::LiteralString
   getter dependencies = [] of Dependency
 

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -23,7 +23,11 @@ module Savi::Program::Intrinsic
       when "manifest"
         name = terms["name"].as(AST::Identifier)
         kind = terms["kind"].as(AST::Identifier)
-        scope.current_manifest = Packaging::Manifest.new(name, kind)
+
+        scope.current_manifest = manifest = Packaging::Manifest.new(name, kind)
+
+        # Every manifest automatically "provides" its main name.
+        manifest.provides_names << name
       when "import"
         scope.current_package.imports << Import.new(
           terms["path"].as(AST::LiteralString),


### PR DESCRIPTION
This PR adds fractional-value-generating methods to the `Random` trait.

A few other changes were also needed to facilitate this.

See individual commit messages for details.