### PR TITLE
Fix `savi eval` command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ ci: PHONY
 	make format.check
 	make spec.all extra_args="--backtrace $(extra_args)"
 	make example dir="examples/adventofcode/2018" extra_args="--backtrace $(extra_args)"
+	make example-eval
 
 # Remove temporary/generated files.
 clean: PHONY
@@ -71,7 +72,7 @@ ffigen: PHONY $(SAVI)
 
 # Evaluate a Hello World example.
 example-eval: PHONY $(SAVI)
-	echo && $(SAVI) eval 'env.out.print("Hello, World!")'
+	echo && $(SAVI) eval 'env.out.print("Hello, World!")' --backtrace
 
 # Compile and run the user program binary in the given directory.
 example: PHONY $(SAVI)

--- a/main.cr
+++ b/main.cr
@@ -185,8 +185,8 @@ module Savi
 
     def self.run(options, backtrace = false)
       _add_backtrace backtrace do
-        ctx = Savi.compiler.compile(Dir.current, options.target_pass || :eval, options)
-        ctx.errors.any? ? finish_with_errors(ctx.errors, backtrace) : ctx.eval.exitcode
+        ctx = Savi.compiler.compile(Dir.current, options.target_pass || :run, options)
+        ctx.errors.any? ? finish_with_errors(ctx.errors, backtrace) : ctx.run.exitcode
       end
     end
 
@@ -202,8 +202,8 @@ module Savi
           "#{dirname}/src/main.savi",
           ":actor Main\n:new (env)\n#{code}"
         )
-        ctx = Savi.compiler.compile(dirname, :eval, options)
-        ctx.errors.any? ? finish_with_errors(ctx.errors, backtrace) : ctx.eval.exitcode
+        ctx = Savi.compiler.compile(dirname, :run, options)
+        ctx.errors.any? ? finish_with_errors(ctx.errors, backtrace) : ctx.run.exitcode
       end
     end
 

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -66,7 +66,7 @@ class Savi::Compiler
     when "lifetime"         then :lifetime
     when "binary_object"    then :binary_object
     when "binary"           then :binary
-    when "eval"             then :eval
+    when "run"              then :run
     when "codegen_verona"   then :codegen_verona
     when "binary_verona"    then :binary_verona
     when "serve_errors"     then :serve_errors
@@ -120,7 +120,7 @@ class Savi::Compiler
       when :lifetime         then ctx.run_whole_program(ctx.lifetime)
       when :binary_object    then ctx.run_whole_program(BinaryObject)
       when :binary           then ctx.run_whole_program(Binary)
-      when :eval             then ctx.run_whole_program(ctx.eval)
+      when :run              then ctx.run_whole_program(ctx.run)
       when :codegen_verona   then ctx.run_whole_program(ctx.code_gen_verona)
       when :binary_verona    then ctx.run_whole_program(BinaryVerona)
       when :serve_errors     then nil # we only care that the dependencies have run, to generate compile errors
@@ -179,7 +179,7 @@ class Savi::Compiler
     when :lifetime then [:reach, :local, :refer, :classify]
     when :binary_object then [:codegen]
     when :binary then [:codegen]
-    when :eval then [:binary]
+    when :run then [:binary]
     when :codegen_verona then [:lifetime, :paint, :verify, :reach, :completeness, :privacy, :type_check, :infer, :pre_infer, :inventory, :local, :flow]
     when :binary_verona then [:codegen_verona]
     when :serve_errors then [:completeness, :privacy, :verify, :type_check, :local]
@@ -211,7 +211,7 @@ class Savi::Compiler
     compile(sources, target, options)
   end
 
-  def compile(dirname : String, target : Symbol = :eval, options = Compiler::Options.new)
+  def compile(dirname : String, target : Symbol = :run, options = Compiler::Options.new)
     sources =
       if options.skip_manifest
         source_service.get_directory_sources(dirname)
@@ -223,7 +223,7 @@ class Savi::Compiler
   end
 
   @prev_ctx : Context?
-  def compile(sources : Array(Source), target : Symbol = :eval, options = Compiler::Options.new)
+  def compile(sources : Array(Source), target : Symbol = :run, options = Compiler::Options.new)
     ctx = Context.new(self, options, @prev_ctx)
 
     docs = sources.compact_map do |source|

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -206,14 +206,6 @@ class Savi::Compiler
     end
   end
 
-  def eval(string : String, options = Compiler::Options.new) : Context
-    content = ":actor Main\n:new (env)\n#{string}"
-    package = Savi::Source::Package.new("(eval)")
-    source = Savi::Source.new("", "(eval)", content, package)
-
-    Savi.compiler.compile([source], :eval, options)
-  end
-
   def test_compile(sources : Array(Source), target : Symbol, options = Compiler::Options.new)
     options.skip_manifest = true
     compile(sources, target, options)

--- a/src/savi/compiler/context.cr
+++ b/src/savi/compiler/context.cr
@@ -7,7 +7,7 @@ class Savi::Compiler::Context
   getter code_gen = CodeGen.new(CodeGen::PonyRT)
   getter code_gen_verona = CodeGen.new(CodeGen::VeronaRT)
   getter completeness = Completeness::Pass.new
-  getter eval = Eval.new
+  getter run = Run.new
   getter flow = Flow::Pass.new
   getter infer = Infer::Pass.new
   getter infer_edge = Infer::PassEdge.new

--- a/src/savi/compiler/run.cr
+++ b/src/savi/compiler/run.cr
@@ -1,7 +1,7 @@
 require "llvm"
 
 ##
-# The purpose of the Eval pass is to run the program built by the Binary pass.
+# The purpose of the Run pass is to run the program built by the Binary pass.
 #
 # This pass does not mutate the Program topology.
 # This pass does not mutate the AST.
@@ -10,7 +10,7 @@ require "llvm"
 # This pass produces output state at the program level (the exit code).
 # !! This pass has the side-effect of executing the program.
 #
-class Savi::Compiler::Eval
+class Savi::Compiler::Run
   getter! exitcode : Int32
 
   def run(ctx)

--- a/src/savi/compiler/source_service.cr
+++ b/src/savi/compiler/source_service.cr
@@ -155,7 +155,7 @@ class Savi::Compiler::SourceService
       next unless content
 
       yield ({name, content})
-    }
+    } if Dir.exists?(internal_dirname)
 
     # Now yield the fake files implied by the source overrides for this dirname.
     dir_source_overrides.try(&.each { |name, content|
@@ -184,6 +184,16 @@ class Savi::Compiler::SourceService
         content = File.read(name) rescue nil
         yield ({name, content}) if content
       end
+    }
+
+    # Now yield any source overrides that match the given glob.
+    @source_overrides.each { |dirname, dir_source_overrides|
+      dir_source_overrides.each { |name, content|
+        full_path = File.join(dirname, name)
+        next unless File.match?(glob, full_path)
+
+        yield ({full_path, content})
+      }
     }
   end
 


### PR DESCRIPTION
This command was broken during the work to add packages/manifests.

Which is unfortunate because the main `README` suggests you use this command to test your installation. Hopefully nobody got tripped up by that this week while attempting to test a new installation.