### PR TITLE
Detect missing transitive dependencies (and auto-fix with `--fix` flag).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ spec.unit.all: PHONY $(SPEC)
 	echo && $(SPEC)
 
 # Run the integration tests, which invoke the compiler in a real directory.
+spec.integration: PHONY $(SAVI)
+	echo && spec/integration/run-one.sh "$(name)" $(SAVI)
 spec.integration.all: PHONY $(SAVI)
 	echo && spec/integration/run-all.sh $(SAVI)
 

--- a/spec/integration/README.md
+++ b/spec/integration/README.md
@@ -6,7 +6,7 @@ To test a case, the Savi compiler will be invoked in that subdirectory by the in
 
 Each subdirectory contains Savi source files as well as some testing-related files/folders to let the integration test runner know exactly what and how to test. The integration test runner will choose a testing strategy based on which testing-related files/folders are present. See the sections describing the different testing strategies below for more information.
 
-## Error output
+## Error output tests
 
 If the test case subdirectory contains a `savi.errors.txt` file, then the compiler invocation is expected to fail, and produce error output that exactly matches the content of that file.
 
@@ -14,4 +14,14 @@ If the error output doesn't exactly match the expected output, the test case wil
 
 By convention, test case subdirectories like this are named with the `error-` prefix, followed by the name of the pass that is expected to produce the errors, followed by a brief description of the error we are testing for.
 
-For example, the test case subdirectory `error-manifests-non-unique-names` is an error output test case, testing errors produced in the `manifests` pass, where the errors under test relate with the compiler rejecting non-unique manifest names.
+For example, the test case subdirectory `error-manifests-non-unique-names` is an error output test case, testing errors produced in the `manifests` pass, where what is being tested are the errors emitted when the compiler encounters non-unique manifest names.
+
+## Auto-fix tests
+
+If the test case subdirectory contains a `savi.fix.before.dir` subdirectory, a `savi.fix.after.dir` subdirectory, and an `savi.errors.txt` file, then like the error output tests, the initial compiler invocation is expected to fail with a specified error output, but the compiler witll be invoked again with the `--fix` flag, wherein it is expected to fix all of those errors automatically and succeed in compiling the program.
+
+Before the invocation, source files from `savi.fix.before.dir` will be copied into the directory. After the invocation, the resulting fixed files will be compared with the source files in `savi.fix.after.dir` to confirm that the contents of each compared file exactly matches the corresponding "after" file. If any such file is missing, or its content doesn't exactly match, the test case will fail. After the test is finished (succeed or fail), the files that were copied from the "before" directory are removed, to leave the test case directory in an empty state without extra files to be tracked in git.
+
+By convention, test case subdirectories like this are named with the `fix-` prefix, followed by the name of the pass that is expected to produce the auto-fixable errors, followed by a brief description of the error we are testing for.
+
+For example, the test case subdirectory `fix-manifests-missing-transitive-deps` is an error output test case, testing auto-fixable errors produced in the `manifests` pass, where what is being tested is the compiler being able to auto-fix missing transitive dependencies in the manifest being compiled.

--- a/spec/integration/README.md
+++ b/spec/integration/README.md
@@ -1,0 +1,17 @@
+# Savi Integration Tests
+
+This folder contains a collection of subdirectories, with each subdirectory being an integration test case.
+
+To test a case, the Savi compiler will be invoked in that subdirectory by the integration test runner, which will observe the effects of the invocation and validate that they match the expected effects.
+
+Each subdirectory contains Savi source files as well as some testing-related files/folders to let the integration test runner know exactly what and how to test. The integration test runner will choose a testing strategy based on which testing-related files/folders are present. See the sections describing the different testing strategies below for more information.
+
+## Error output
+
+If the test case subdirectory contains a `savi.errors.txt` file, then the compiler invocation is expected to fail, and produce error output that exactly matches the content of that file.
+
+If the error output doesn't exactly match the expected output, the test case will fail.
+
+By convention, test case subdirectories like this are named with the `error-` prefix, followed by the name of the pass that is expected to produce the errors, followed by a brief description of the error we are testing for.
+
+For example, the test case subdirectory `error-manifests-non-unique-names` is an error output test case, testing errors produced in the `manifests` pass, where the errors under test relate with the compiler rejecting non-unique manifest names.

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
@@ -1,0 +1,59 @@
+
+Compilation Errors:
+
+---
+
+A transitive dependency is missing from this manifest:
+from ./manifest.savi:1:
+:manifest "example"
+          ^~~~~~~~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:4:
+  :dependency ByteStream "TODO: specify version"
+              ^~~~~~~~~~
+
+- it is required by this existing dependency:
+  from ./manifest.savi:4:
+  :dependency TCP "TODO: specify version"
+              ^~~
+
+- run again with --fix to auto-fix this issue.
+
+---
+
+A transitive dependency is missing from this manifest:
+from ./manifest.savi:1:
+:manifest "example"
+          ^~~~~~~~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:5:
+  :dependency IO "TODO: specify version"
+              ^~
+
+- it is required by this existing dependency:
+  from ./manifest.savi:4:
+  :dependency TCP "TODO: specify version"
+              ^~~
+
+- run again with --fix to auto-fix this issue.
+
+---
+
+A transitive dependency is missing from this manifest:
+from ./manifest.savi:1:
+:manifest "example"
+          ^~~~~~~~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:6:
+  :dependency OSError "TODO: specify version"
+              ^~~~~~~
+
+- it is required by this existing dependency:
+  from ./manifest.savi:4:
+  :dependency TCP "TODO: specify version"
+              ^~~
+
+- run again with --fix to auto-fix this issue.

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
@@ -1,0 +1,10 @@
+:manifest "example"
+  :sources "main.savi"
+
+  :dependency TCP "TODO: specify version"
+
+  :transitive dependency ByteStream "TODO: specify version"
+
+  :transitive dependency IO "TODO: specify version"
+
+  :transitive dependency OSError "TODO: specify version"

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/main.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/main.savi
@@ -1,0 +1,3 @@
+:actor Main
+  :new (env)
+    TCP.ConnectionEngine // just ensure the type name is reachable

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/manifest.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/manifest.savi
@@ -1,0 +1,4 @@
+:manifest "example"
+  :sources "main.savi"
+
+  :dependency TCP "TODO: specify version"

--- a/spec/integration/run-all.sh
+++ b/spec/integration/run-all.sh
@@ -12,40 +12,8 @@ cd -- "$(dirname -- "$0")"
 # Start running integation tests.
 echo "Running integration tests..."
 echo
-for subdir in $(find ./ -maxdepth 1 -mindepth 1 -type d | sort --ignore-case); do
-  # If this subdirectory has an expected errors file, use that test approach.
-  if [ -f "$subdir/savi.errors.txt" ]; then
-    actual=$(cd $subdir && "$SAVI" --backtrace 2>&1 || true)
-    expected=$(cat $subdir/savi.errors.txt)
-    if [ "$actual" = "$expected" ]; then
-      echo "✓    $subdir"
-    else
-      did_fail="X"
-      echo "---"
-      echo "---"
-      echo
-      echo "FAIL $subdir"
-      echo
-      echo "---"
-      echo
-      echo "EXPECTED $expected"
-      echo
-      echo "---"
-      echo
-      echo "ACTUAL $actual"
-      echo
-      echo "---"
-      echo "---"
-    fi
-
-  # Otherwise, we have no test approaches left that can be tried.
-  else
-    did_fail="X"
-    echo "FAIL $subdir"
-    echo "     (missing files needed for integration testing)"
-    echo "     (please add a savi.errors.txt file to that directory)"
-  fi
-  echo
+for subdir in $(find ./ -maxdepth 1 -mindepth 1 -type d | cut -b 3- | sort --ignore-case); do
+  ./run-one.sh $subdir $SAVI || did_fail="X"
 done
 
 # If any test failed, report overall failure here.

--- a/spec/integration/run-one.sh
+++ b/spec/integration/run-one.sh
@@ -24,7 +24,7 @@ if ! [ -d $subdir ]; then
   exit 2
 fi
 
-# If this subdirectory has an expected errors file, use that test approach.
+# If this subdirectory has an expected errors file, use that testing strategy.
 if [ -f "$subdir/savi.errors.txt" ]; then
   actual=$(cd $subdir && "$SAVI" --backtrace 2>&1 || true)
   expected=$(cat $subdir/savi.errors.txt)
@@ -48,6 +48,9 @@ if [ -f "$subdir/savi.errors.txt" ]; then
     echo "---"
     exit 1
   fi
+
+## NOTE: When adding new testing strategy, also add a description to the
+##       integration testing documentation in `spec/integration/README.md`
 
 # Otherwise, we have no test approaches left that can be tried.
 else

--- a/spec/integration/run-one.sh
+++ b/spec/integration/run-one.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+
+set -e
+
+# The first arg is the subdir name to test.
+subdir="$1"
+
+# Set up path to the Savi compiler to use, based on the path provided via arg.
+SAVI=$(CDPATH= cd -- "$(dirname -- "${2:-build/savi-debug}")" && pwd)/$(basename "${2:-build/savi-debug}")
+
+# Change directory to the directory where this script is located.
+cd -- "$(dirname -- "$0")"
+
+# Confirm that a subdirectory was actually given.
+if [ -z $subdir ]; then
+  echo "FAIL (no subdirectory name given)"
+  exit 2
+fi
+
+# Confirm that the given subdirectory name exists.
+if ! [ -d $subdir ]; then
+  echo "FAIL $subdir"
+  echo "     (does not exist within $(pwd))"
+  exit 2
+fi
+
+# If this subdirectory has an expected errors file, use that test approach.
+if [ -f "$subdir/savi.errors.txt" ]; then
+  actual=$(cd $subdir && "$SAVI" --backtrace 2>&1 || true)
+  expected=$(cat $subdir/savi.errors.txt)
+  if [ "$actual" = "$expected" ]; then
+    echo "✓    $subdir"
+  else
+    echo "---"
+    echo "---"
+    echo
+    echo "FAIL $subdir"
+    echo
+    echo "---"
+    echo
+    echo "EXPECTED $expected"
+    echo
+    echo "---"
+    echo
+    echo "ACTUAL $actual"
+    echo
+    echo "---"
+    echo "---"
+    exit 1
+  fi
+
+# Otherwise, we have no test approaches left that can be tried.
+else
+  echo "FAIL $subdir"
+  echo "     (missing files needed for integration testing)"
+  echo "     (please add a savi.errors.txt file to that directory)"
+  exit 2
+fi
+echo

--- a/src/savi/ast.cr
+++ b/src/savi/ast.cr
@@ -146,6 +146,15 @@ module Savi::AST
     def initialize(@terms = [] of Term)
     end
 
+    def span_pos(source)
+      return Source::Pos.none unless pos.source == source
+      pos.span(
+        terms.map(&.span_pos(source)) +
+        nested.map(&.span_pos(source)) +
+        [body.try(&.span_pos(source))].compact
+      )
+    end
+
     def name; :declare end
     def to_a: Array(A)
       res = [name] of A

--- a/src/savi/compiler/context.cr
+++ b/src/savi/compiler/context.cr
@@ -91,7 +91,8 @@ class Savi::Compiler::Context
     # Otherwise go ahead and load the manifests.
     sources = compiler.source_service.get_manifest_sources_at_or_above(path)
     docs = sources.map { |source| Parser.parse(source) }
-    compile_package(sources.first.package, docs)
+    package = compile_package(sources.first.package, docs)
+    self
   end
 
   def compile_package(manifest : Packaging::Manifest)
@@ -103,6 +104,9 @@ class Savi::Compiler::Context
   def compile_package(*args)
     package = compile_package_inner(*args)
     @program.packages << package
+    package.manifests_declared.each { |manifest|
+      @program.manifests << manifest
+    }
     package
   rescue e : Error
     @errors << e

--- a/src/savi/error.cr
+++ b/src/savi/error.cr
@@ -8,7 +8,8 @@ class Savi::Error < Exception
   protected setter cause
   getter pos : Source::Pos
   getter headline : String
-  getter info : Array(Info)
+  getter info = [] of {Source::Pos, String}
+  getter fix_edits = [] of {Source::Pos, String}
 
   def initialize(@pos, @headline)
     @info = [] of {Source::Pos, String}
@@ -33,6 +34,9 @@ class Savi::Error < Exception
       else
         strings << "- #{info_msg}:\n  #{info_pos.show}\n"
       end
+    end
+    if fix_edits.any?
+      strings << "- run again with --fix to auto-fix this issue."
     end
     # If a causing exception is present, this indicates a compiler hole.
     cause.try { |cause|
@@ -72,13 +76,18 @@ class Savi::Error < Exception
 
   # Raise an error for the given source position, with the given message,
   # along with extra details taken from the following array of tuples.
-  def self.build(any, msg : String, info); build(any.pos, msg, info) end
-  def self.build(pos : Source::Pos, msg : String, info)
+  def self.build(any, msg : String, info, fix_edits = nil)
+    build(any.pos, msg, info, fix_edits)
+  end
+  def self.build(pos : Source::Pos, msg : String, info, fix_edits = nil)
     new(pos, msg).tap do |err|
       info.each do |info_any, info_msg|
         info_pos = info_any.is_a?(Source::Pos) ? info_any : info_any.pos
         err.info << {info_pos, info_msg}
       end
+      fix_edits.try(&.each { |fix_edit|
+        err.fix_edits << fix_edit
+      })
     end
   end
 

--- a/src/savi/ext/file.cr
+++ b/src/savi/ext/file.cr
@@ -1,0 +1,49 @@
+require "file"
+
+# Patch File to add a new static function to construct a relative path.
+#
+# It will add as many ".." segments as it needs to find a common root,
+# then remove the common root.
+#
+# We use this for showing source paths in error messages in ways that
+# are not dependent on where on the filesystem the code is checked out,
+# but still showing a fully navigable path to that given filename.
+
+class File
+  def self.make_relative_path(from_path : String, to_path : String)
+    up_levels = 0
+
+    # We can't make one path relative to another unless they are both
+    # "normal" paths on a real file system (as opposed to things like
+    # an "(eval)" string or "(compiler-spec)" pseudo-source).
+    return to_path \
+      unless from_path.starts_with?("/") && to_path.starts_with?("/")
+
+    loop {
+      # Try to produce a relative path result assuming that the to_path
+      # is nested directly some number of layers within the current from_path.
+      result_path = to_path.sub(from_path, ".")
+
+      # If we've reached a relative path from the current from_path,
+      # then we'll break out of the loop with an early return,
+      # Returning the result path, possibly with a number of ".." segments
+      # with each of those indicating a time we had to move up one level
+      # before we reached a common prefix.
+      # If there are any ".." segments, we strip out the unneeded "." segment.
+      if result_path.starts_with?("./")
+        return File.join(
+          up_levels.times.map { ".." }.to_a + [
+            result_path.sub(up_levels > 0 ? "./" : "", "")
+          ]
+        )
+      end
+
+      # Move our "from_path" up one level, and count each time we do this.
+      # Then continue the loop and try to reach a relative path from there.
+      from_path = File.expand_path("..", from_path)
+      up_levels += 1
+
+      raise "This is probably an infinite loop" if up_levels > 10_000
+    }
+  end
+end

--- a/src/savi/packaging/dependency.cr
+++ b/src/savi/packaging/dependency.cr
@@ -1,4 +1,5 @@
 struct Savi::Packaging::Dependency
+  getter ast : AST::Declare
   getter name : AST::Identifier
   getter version_node : AST::LiteralString
   getter version_major : Int32
@@ -9,7 +10,7 @@ struct Savi::Packaging::Dependency
   getter revision_nodes = [] of AST::Identifier
   getter depends_on_nodes = [] of AST::Identifier
 
-  def initialize(@name, @version_node, @transitive = false)
+  def initialize(@ast, @name, @version_node, @transitive = false)
     @version_major = 0 # TODO
     @version_minor = 0 # TODO
     @version_patch = 0 # TODO

--- a/src/savi/packaging/manifest.cr
+++ b/src/savi/packaging/manifest.cr
@@ -1,4 +1,5 @@
 struct Savi::Packaging::Manifest
+  getter ast : AST::Declare
   getter name : AST::Identifier
   getter kind : AST::Identifier
   getter copies_names = [] of AST::Identifier
@@ -6,7 +7,7 @@ struct Savi::Packaging::Manifest
   getter sources_paths = [] of AST::LiteralString
   getter dependencies = [] of Dependency
 
-  def initialize(@name, @kind)
+  def initialize(@ast, @name, @kind)
   end
 
   def bin_path
@@ -27,5 +28,9 @@ struct Savi::Packaging::Manifest
 
   def is_whole_program?
     !is_lib?
+  end
+
+  def append_pos
+    ast.span_pos(ast.pos.source).next_line_start_as_pos
   end
 end

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -18,6 +18,7 @@ class Savi::Program
     getter enum_members
     getter imports
     getter declarators
+    getter manifests_declared = [] of Packaging::Manifest
     getter source_package : Source::Package
 
     def initialize(@source_package)

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -24,7 +24,8 @@ module Savi::Program::Intrinsic
         name = terms["name"].as(AST::Identifier)
         kind = terms["kind"].as(AST::Identifier)
 
-        scope.current_manifest = manifest = Packaging::Manifest.new(name, kind)
+        scope.current_manifest = manifest =
+          Packaging::Manifest.new(declare, name, kind)
 
         # Every manifest automatically "provides" its main name.
         manifest.provides_names << name
@@ -172,13 +173,13 @@ module Savi::Program::Intrinsic
         name = terms["name"].as(AST::Identifier)
         version = terms["version"].as(AST::LiteralString)
         scope.current_manifest_dependency = dep =
-          Packaging::Dependency.new(name, version)
+          Packaging::Dependency.new(declare, name, version)
         scope.current_manifest.dependencies << dep
       when "transitive"
         name = terms["name"].as(AST::Identifier)
         version = terms["version"].as(AST::LiteralString)
         scope.current_manifest_dependency = dep =
-          Packaging::Dependency.new(name, version, transitive: true)
+          Packaging::Dependency.new(declare, name, version, transitive: true)
         scope.current_manifest.dependencies << dep
       else
         raise NotImplementedError.new(declarator.pretty_inspect)
@@ -455,7 +456,7 @@ module Savi::Program::Intrinsic
   )
     case declarator.name.value
     when "manifest"
-      ctx.program.manifests << scope.current_manifest
+      scope.current_package.manifests_declared << scope.current_manifest
       scope.current_manifest = nil
     when "manifest_dependency"
       scope.current_manifest_dependency = nil

--- a/src/savi/spec_markdown/format.cr
+++ b/src/savi/spec_markdown/format.cr
@@ -15,7 +15,9 @@ class Savi::SpecMarkdown::Format
     @examples.each { |example|
       code_pos = SpecMarkdown.get_code_pos(@source, example.code_blocks.first)
       example.expected_format_results.each { |format_rule, expected|
-        actual_pos, actual_edits = AST::Format.apply_edits(code_pos, edits)
+        actual_pos, actual_edits = code_pos.apply_edits(
+          edits.map { |e| {e.pos, e.replacement} }
+        )
 
         actual = actual_pos.content
         unless actual.sub(/\n+\z/, "") == expected.sub(/\n+\z/, "")
@@ -35,7 +37,9 @@ class Savi::SpecMarkdown::Format
           puts
         end
 
-        extra_edits = actual_edits.reject(&.rule.to_s.==(format_rule))
+        extra_edits = edits.reject(&.rule.to_s.==(format_rule)).select { |edit|
+          actual_edits.includes?({edit.pos, edit.replacement})
+        }
         unless extra_edits.empty?
           any_failures = true
 


### PR DESCRIPTION
This is another step toward having our package manager working (#44).

This PR introduces the new `--fix` flag which can be used to
instruct the compiler to automatically fix any errors which have
"fix edits" attached to them, by applying those fix edits to the
relevant source files on disk.

Fix edits are surgical, and do not rewrite/format the entire file.

This commit also introduces a new kind of integration test case,
which can test for fixable errors, by first checking the
expected error messages, then running again with `--fix` and
expecting compilation to succeed, and expecting files to be
modified to match an expected "after" content.

See `spec/integration/README.md` for more details on how to
write such an integration test.

Note that this PR still does not test anything about the
transitive deps other than the fact that they are present.

Further checks can come in future work that leverages this
basic foundation.
