### PR TITLE
Add :excluding declarator to narrow a manifest's :sources declaration.

### DIFF
--- a/packages/src/Savi/declarators/declarators.savi
+++ b/packages/src/Savi/declarators/declarators.savi
@@ -471,6 +471,14 @@
 :declarator sources
   :intrinsic
   :context manifest
+  :begins manifest_sources
+
+  :term path String
+
+// TODO: Document this.
+:declarator excluding
+  :intrinsic
+  :context manifest_sources
 
   :term path String
 

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/manifest.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/manifest.savi
@@ -1,0 +1,28 @@
+:manifest "example"
+  :sources "src/*.savi"
+    :excluding "src/exclude-*.savi"
+  :sources "src2/*.savi"
+    :excluding "src2/exclude-a.savi"
+    :excluding "src2/exclude-b.savi"
+    :excluding "src/include-*.savi" // (this will have no effect, because it is
+//                                  // nested in a :sources declaration
+//                                  // which includes `src2` but not the `src`
+//                                  // directory, and it can only limit
+//                                  // the inclusion from that set - not others)
+
+// For convenience of reasoning, here's a summary of the types in each file:
+//
+// src/
+// include-a exclude-a include-b exclude-b exclude-extra
+// Alice     Andre     Bob       Bob       Alice
+// Alex      Alex      Bernice   Bill      Andre
+//
+// src2/
+// include-a exclude-a include-b exclude-b exclude-extra
+// Andre     Alice     Bob       Bobby     Bob
+// Alex      Alex      Bill      Bill      Bobby
+//
+// Given the exclusions in the manifest resolving correctly, we expect
+// only the following conflicts, and no more:
+// - Alex (x2)
+// - Bob (x3) (note that src/exclude-extra.savi is not actually excluded)

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/savi.errors.txt
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/savi.errors.txt
@@ -1,0 +1,38 @@
+
+Compilation Errors:
+
+---
+
+This type conflicts with another declared type in the same package:
+from ./src2/exclude-extra.savi:1:
+:module Bob
+        ^~~
+
+- the other type with the same name is here:
+  from ./src/include-b.savi:1:
+:module Bob
+        ^~~
+
+---
+
+This type conflicts with another declared type in the same package:
+from ./src2/include-a.savi:2:
+:module Alex
+        ^~~~
+
+- the other type with the same name is here:
+  from ./src/include-a.savi:2:
+:module Alex
+        ^~~~
+
+---
+
+This type conflicts with another declared type in the same package:
+from ./src2/include-b.savi:1:
+:module Bob
+        ^~~
+
+- the other type with the same name is here:
+  from ./src/include-b.savi:1:
+:module Bob
+        ^~~

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/exclude-a.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/exclude-a.savi
@@ -1,0 +1,2 @@
+:module Andre
+:module Alex

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/exclude-b.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/exclude-b.savi
@@ -1,0 +1,2 @@
+:module Bob
+:module Bill

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/exclude-extra.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/exclude-extra.savi
@@ -1,0 +1,2 @@
+:module Alice
+:module Andre

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/include-a.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/include-a.savi
@@ -1,0 +1,2 @@
+:module Alice
+:module Alex

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/include-b.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src/include-b.savi
@@ -1,0 +1,2 @@
+:module Bob
+:module Bernice

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/exclude-a.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/exclude-a.savi
@@ -1,0 +1,2 @@
+:module Alice
+:module Alex

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/exclude-b.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/exclude-b.savi
@@ -1,0 +1,2 @@
+:module Bobby
+:module Bill

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/exclude-extra.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/exclude-extra.savi
@@ -1,0 +1,2 @@
+:module Bob
+:module Bobby

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/include-a.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/include-a.savi
@@ -1,0 +1,2 @@
+:module Andre
+:module Alex

--- a/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/include-b.savi
+++ b/spec/integration/error-namespace-conflicts-and-sources-exclusions/src2/include-b.savi
@@ -1,0 +1,2 @@
+:module Bob
+:module Bill

--- a/src/savi/compiler/manifests.cr
+++ b/src/savi/compiler/manifests.cr
@@ -234,8 +234,8 @@ class Savi::Compiler::Manifests
       next_from_manifest.provides_names.reverse_each { |path|
         to_manifest.provides_names.unshift(path)
       }
-      next_from_manifest.sources_paths.reverse_each { |path|
-        to_manifest.sources_paths.unshift(path)
+      next_from_manifest.sources_paths.reverse_each { |pair|
+        to_manifest.sources_paths.unshift(pair)
       }
       next_from_manifest.dependencies.reverse_each { |path|
         to_manifest.dependencies.unshift(path)

--- a/src/savi/packaging/manifest.cr
+++ b/src/savi/packaging/manifest.cr
@@ -4,7 +4,7 @@ struct Savi::Packaging::Manifest
   getter kind : AST::Identifier
   getter copies_names = [] of AST::Identifier
   getter provides_names = [] of AST::Identifier
-  getter sources_paths = [] of AST::LiteralString
+  getter sources_paths = [] of {AST::LiteralString, Array(AST::LiteralString)}
   getter dependencies = [] of Dependency
 
   def initialize(@ast, @name, @kind)

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -168,7 +168,7 @@ module Savi::Program::Intrinsic
         scope.current_manifest.copies_names << name
       when "sources"
         path = terms["path"].as(AST::LiteralString)
-        scope.current_manifest.sources_paths << path
+        scope.current_manifest.sources_paths << {path, [] of AST::LiteralString}
       when "dependency"
         name = terms["name"].as(AST::Identifier)
         version = terms["version"].as(AST::LiteralString)
@@ -181,6 +181,16 @@ module Savi::Program::Intrinsic
         scope.current_manifest_dependency = dep =
           Packaging::Dependency.new(declare, name, version, transitive: true)
         scope.current_manifest.dependencies << dep
+      else
+        raise NotImplementedError.new(declarator.pretty_inspect)
+      end
+
+    # Declarations within a manifest sources definition.
+    when "manifest_sources"
+      case declarator.name.value
+      when "excluding"
+        path = terms["path"].as(AST::LiteralString)
+        scope.current_manifest.sources_paths.last.last << path
       else
         raise NotImplementedError.new(declarator.pretty_inspect)
       end


### PR DESCRIPTION
Each `:excluding` declaration can only narrow the `:sources` declaration
that it is nested under - it cannot narrow other `:sources` declarations
in the same manifest. This choice helps to prevent the declarations
from being order dependent - we still have a grow-only data structure semantics.