### PR TITLE
Add support for building on Apple M1 (a.k.a. `arm64-apple-macosx`)

### DIFF
--- a/platform.sh
+++ b/platform.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+purpose="$1"
+
 fail() {
   >&2 echo $@
   exit 1
@@ -30,9 +32,18 @@ elif uname | grep -iq 'FreeBSD'; then
 elif uname | grep -iq 'Darwin'; then
   if uname -m | grep -iq 'x86_64'; then
     echo 'x86_64-apple-macosx'
+  elif uname -m | grep -iq 'arm64'; then
+    # LLVM static pre-built libraries are dual-arch, but we upload them
+    # under the name of the x86_64 arch - so we fake that arch here only
+    # for the case of determining paltform for downloading llvm-static libs.
+    # For all other purposes we return the true platform triple.
+    if [ "$purpose" = 'llvm-static' ]; then
+      echo 'x86_64-apple-macosx'
+    else
+      echo 'arm64-apple-macosx'
+    fi
   else
-    # TODO: Add arm64 (M1) when binary builds for it are supported.
-    fail "On Darwin, the only arch currently supported is: x86_64"
+    fail "On Darwin, the only arches currently supported are: x86_64, arm64"
   fi
 else
   fail "The only supported operating systems are: Linux, FreeBSD, Darwin"

--- a/platform.sh
+++ b/platform.sh
@@ -19,16 +19,21 @@ if uname | grep -iq 'Linux'; then
       fail "On Linux, the supported libc variants are: gnu, musl"
     fi
   else
-    fail "On Linux, the only curently supported arch is: x86_64"
+    fail "On Linux, the only arch currently supported is: x86_64"
   fi
-  # TODO: Add FreeBSD when binary builds for it are supported.
+elif uname | grep -iq 'FreeBSD'; then
+  if uname -m | grep -iq 'x86_64'; then
+    echo 'x86_64-unknown-freebsd'
+  else
+    fail "On FreeBSD, the only arch currently supported is: x86_64"
+  fi
 elif uname | grep -iq 'Darwin'; then
   if uname -m | grep -iq 'x86_64'; then
     echo 'x86_64-apple-macosx'
   else
     # TODO: Add arm64 (M1) when binary builds for it are supported.
-    fail "On Darwin, the only curently supported arch is: x86_64"
+    fail "On Darwin, the only arch currently supported is: x86_64"
   fi
 else
-  fail "The only supported operating systems are: Linux, Darwin"
+  fail "The only supported operating systems are: Linux, FreeBSD, Darwin"
 fi

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -94,7 +94,9 @@ class Savi::Compiler::CodeGen
 
   def initialize(runtime : PonyRT.class | VeronaRT.class = PonyRT)
     LLVM.init_x86
-    @target_triple = LLVM.default_target_triple
+    LLVM.init_aarch64
+    LLVM.init_arm
+    @target_triple = LLVM.configured_default_target_triple.as(String)
     @target = LLVM::Target.from_triple(@target_triple)
     @target_machine = @target.create_target_machine(@target_triple).as(LLVM::TargetMachine)
     @llvm = LLVM::Context.new

--- a/src/savi/ext/llvm.cr
+++ b/src/savi/ext/llvm.cr
@@ -1,2 +1,8 @@
 require "llvm"
 require "./llvm/*"
+
+module LLVM
+  def self.configured_default_target_triple
+    {{ env("LLVM_DEFAULT_TARGET") }} || default_target_triple
+  end
+end


### PR DESCRIPTION
This PR finishes adding support for Apple M1 machines (using the target triple `arm64-apple-macosx`).

After the changes on this branch, it should be possible to invoke all of the normal `make` commands mentioned in the README.

~More work is needed (in a separate PR) to try~ [EDIT: this is now done, and merged into this branch] to set up CI release binary builds for `arm64-apple-macosx`, and set up the asdf plugin to be able to detect and download the appropriate release binary build.

