### PR TITLE
Improve LLVM optimizations and debug information.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -31,7 +31,12 @@ class Savi::Compiler::Binary
     link_args = %w{clang -fpic -flto=thin}
 
     # We also use clang for optimizations, when compiling in release mode.
+    # Note that we already optimized the program in the BinaryObject pass,
+    # but this gives us the opportunity to run link-time optimizations if any.
     link_args << (ctx.options.release ? "-O3" : "-O0")
+
+    # Unless debugging info has been disabled, include it here.
+    link_args << "-g" unless ctx.options.no_debug
 
     # Based on the target, choose which libraries to explicitly link.
     # On some platforms, some of the relevant libraries we need are implicit.

--- a/src/savi/ext/llvm/for_savi/LLVMOptimizeForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMOptimizeForSavi.cc
@@ -1,0 +1,43 @@
+#include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Passes/PassBuilder.h>
+
+///
+// LLVMOptimizeForSavi runs standard (and in the future, also Savi-specific)
+// LLVM passes on the given module, to optimize it. A boolean parameter allows
+// the caller to specify whether full or minimum optimization is desired.
+
+using namespace llvm;
+
+extern "C" {
+
+void LLVMOptimizeForSavi(LLVMModuleRef ModRef, LLVMBool WantsFullOptimization) {
+  // Most of this is the standard ceremony for running standard LLVM passes.
+  // See <https://llvm.org/docs/NewPassManager.html> for details.
+
+  PassBuilder PB;
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+
+  // Enable the default alias analysis pipeline.
+  FAM.registerPass([&] { return PB.buildDefaultAAPipeline(); });
+
+  // Wire in all of the analysis managers.
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+  // Create the top-level module pass manager using the default LLVM pipeline.
+  // Respect the parameter that either requests or declines full optimization.
+  ModulePassManager MPM = PB.buildPerModuleDefaultPipeline(
+    WantsFullOptimization
+      ? PassBuilder::OptimizationLevel::O3
+      : PassBuilder::OptimizationLevel::O0
+  );
+  MPM.run(*unwrap(ModRef), MAM);
+}
+
+}

--- a/src/savi/ext/llvm/for_savi/LLVMRemapDIDirectoryForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMRemapDIDirectoryForSavi.cc
@@ -1,0 +1,60 @@
+#include <llvm/IR/DebugInfo.h>
+#include <llvm/IR/DIBuilder.h>
+#include <llvm/Passes/PassBuilder.h>
+
+///
+// LLVMRemapDIDirectoryForSavi modifies the debug information for a module.
+// Specifically, for each DIFile whose Directory is the given BeforeDirectory,
+// it will replace that Directory with the given AfterDirectory string.
+
+using namespace llvm;
+
+class RemapDIDirectoryPass : public PassInfoMixin<RemapDIDirectoryPass> {
+  StringRef BeforeDirectory;
+  StringRef AfterDirectory;
+
+public:
+  RemapDIDirectoryPass(StringRef BeforeDirectory, StringRef AfterDirectory)
+    : BeforeDirectory(BeforeDirectory), AfterDirectory(AfterDirectory) {}
+
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) {
+    DIBuilder DI(M);
+    DebugInfoFinder Finder;
+
+    // Iterate over all DIScopes in the Module.
+    Finder.processModule(M);
+    auto DIScopes = Finder.scopes();
+    for (auto it = DIScopes.begin(); it != DIScopes.end(); ++it) {
+      DIFile* File = (*it)->getFile();
+      if (!File) continue;
+
+      // Skip this DIFile if it doesn't match the BeforeDirectory.
+      if (!File->getDirectory().equals(BeforeDirectory)) continue;
+
+      // Replace the Directory (index 1) of the DIFile with the AfterDirectory.
+      File->replaceOperandWith(1, MDString::get(M.getContext(), AfterDirectory));
+    }
+
+    return PreservedAnalyses::all();
+  }
+};
+
+extern "C" {
+
+void LLVMRemapDIDirectoryForSavi(
+  LLVMModuleRef ModRef,
+  const char* BeforeDirectory,
+  const char* AfterDirectory
+) {
+  PassBuilder PB;
+  ModuleAnalysisManager MAM;
+  PB.registerModuleAnalyses(MAM);
+
+  ModulePassManager MPM;
+  MPM.addPass(
+    RemapDIDirectoryPass(StringRef(BeforeDirectory), StringRef(AfterDirectory))
+  );
+  MPM.run(*unwrap(ModRef), MAM);
+}
+
+}

--- a/src/savi/ext/llvm/for_savi/main.cc
+++ b/src/savi/ext/llvm/for_savi/main.cc
@@ -1,0 +1,15 @@
+// For convenience of compilation, we just use the C++ preprocessor to
+// combine the following C++ files here into one file, as if they were headers.
+//
+// This implies we won't be able to have static naming collisions in them,
+// but that's an acceptable limitation for us for now.
+//
+// Each C++ file defines a C function of the same name, which is meant to
+// expose some LLVM-related functionality (which cannot be accomplished with
+// the LLVM C API alone) in a C function that is FFI-callable from the compiler.
+//
+// That is, parts of the LLVM API are only exposed in C++ but not the C wrapper,
+// so if we want to use them, we need to wrap them ourselves here.
+
+#include "./LLVMOptimizeForSavi.cc"
+#include "./LLVMRemapDIDirectoryForSavi.cc"

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -27,4 +27,11 @@ lib LibLLVM
   end
 
   fun byte_order = LLVMByteOrder(TargetDataRef) : ByteOrdering
+
+  ##
+  # Extra functions defined just for Savi go here:
+  #
+
+  fun optimize_for_savi = LLVMOptimizeForSavi(mod : ModuleRef, wants_full_optimization : Bool)
+  fun remap_di_directory_for_savi = LLVMRemapDIDirectoryForSavi(mod : ModuleRef, before_dir : UInt8*, after_dir : UInt8*)
 end


### PR DESCRIPTION
This commit includes a few changes:
- C++ code to remap runtime debug info source directory to match the actual
- C++ code to activate the standard LLVM optimization pipeline
  - (this also gives us a place to add Savi-specific optimizations later)