### PR TITLE
Update runtime-bitcode and llvm-static prebuilts to 20220103.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,7 +41,7 @@ task:
         CPLUS_INCLUDE_PATH: /usr/include/c++/10.3.1:/usr/include/c++/10.3.1/x86_64-alpine-linux-musl
         LIBRARY_PATH: /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1
       container:
-        image: alpine:edge # TODO: use alpine:3.15 or newest stable release when available
+        image: alpine:3.15
 
     # # TODO: Enable FreeBSD after getting it working:
     # - name: x86_64-unknown-freebsd

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ bin
 /.make-var-cache
 /build
 /build-in-docker
-/lib/libsavi_runtime.bc
+/lib/libsavi_runtime*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN apk add --no-cache --update \
 ENV CC=clang
 ENV CXX=clang++
 
+# For some reason clang doesn't like it if we omit the "alpine" vendor
+# in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
+ENV CLANG_TARGET_PLATFORM x86_64-alpine-linux-musl
+
 # Create a basic working directory to use for code.
 RUN mkdir /opt/code
 WORKDIR /opt/code
@@ -34,6 +38,13 @@ RUN apk add --no-cache --update \
     libexecinfo-dev libretls-dev pcre2-dev \
     llvm12-dev llvm12-static \
     crystal shards
+
+ENV CC=clang
+ENV CXX=clang++
+
+# For some reason clang doesn't like it if we omit the "alpine" vendor
+# in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
+ENV CLANG_TARGET_PLATFORM x86_64-alpine-linux-musl
 
 COPY --from=dev /usr/lib/libponyrt.bc \
                 /usr/lib/

--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,12 @@ CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
-LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20211223
+LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220103
 $(eval $(call MAKE_VAR_CACHE,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
-RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/20211101
+RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/20220103
 $(eval $(call MAKE_VAR_CACHE,RUNTIME_BITCODE_RELEASE_URL))
 
 # This is the path where we look for the LLVM pre-built static libraries to be,
@@ -159,17 +159,19 @@ endif
 # including the LLVM extensions C++ file we need to build and link.
 CRYSTAL_PATH?=$(shell env $(shell crystal env) printenv CRYSTAL_PATH | rev | cut -d ':' -f 1 | rev)
 
-# Download the static LLVM/clang libraries we have built separately.
-# See github.com/savi-lang/llvm-static for more info.
-# This target will be unused if someone overrides the LLVM_PATH variable
-# to point to an LLVM installation they obtained by some other means.
+# Download the runtime bitcode library we have built separately.
+# See github.com/savi-lang/runtime-bitcode for more info.
 lib/libsavi_runtime.bc: .make-var-cache/RUNTIME_BITCODE_RELEASE_URL
-	rm -f $@.tmp
-	curl -L --fail -sS \
-		"${RUNTIME_BITCODE_RELEASE_URL}/${TARGET_PLATFORM}-libponyrt.bc" \
-	> $@.tmp
-	rm -f $@
-	mv $@.tmp $@
+	rm -rf lib/libsavi_runtime-tmp
+	mkdir -p lib/libsavi_runtime-tmp
+	cd lib/libsavi_runtime-tmp && curl -L --fail -sS \
+		"${RUNTIME_BITCODE_RELEASE_URL}/${TARGET_PLATFORM}-libsavi_runtime.tar.gz" \
+	| tar -xzvf -
+	rm -f lib/libsavi_runtime.bc
+	mv lib/libsavi_runtime-tmp/libsavi_runtime.bc lib/libsavi_runtime.bc
+	rm -rf lib/libsavi_runtime
+	mv lib/libsavi_runtime-tmp/libsavi_runtime lib/libsavi_runtime
+	rm -rf lib/libsavi_runtime-tmp
 	touch $@
 
 # Download the static LLVM/clang libraries we have built separately.

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,9 @@ $(BUILD)/savi-spec.o: spec/all.cr $(LLVM_PATH) $(shell find src lib spec -name '
 # This variant of the target compiles in release mode.
 $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc lib/libsavi_runtime.bc
 	mkdir -p `dirname $@`
-	${CLANG} -O3 -o $@ -flto=thin -fPIC $^ ${CRYSTAL_RT_LIBS} \
+	${CLANG} -O3 -o $@ -flto=thin -fPIC \
+		$(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc \
+		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
@@ -253,7 +255,9 @@ $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc lib/libsavi_
 # This variant of the target compiles in debug mode.
 $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc lib/libsavi_runtime.bc
 	mkdir -p `dirname $@`
-	${CLANG} -O0 -o $@ -flto=thin -fPIC $^ ${CRYSTAL_RT_LIBS} \
+	${CLANG} -O0 -o $@ -flto=thin -fPIC \
+		$(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc \
+		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
@@ -263,7 +267,9 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc lib/libsavi_runt
 # This variant of the target will be used when running tests.
 $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc lib/libsavi_runtime.bc
 	mkdir -p `dirname $@`
-	${CLANG} -O0 -o $@ -flto=thin -fPIC $^ ${CRYSTAL_RT_LIBS} \
+	${CLANG} -O0 -o $@ -flto=thin -fPIC \
+		$(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc \
+		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \


### PR DESCRIPTION
This PR updates our code to use the latest prebuilt releases for the runtime LLVM bitcode and the LLVM static libraries.

Part of the reason for this update is to fix an alpine linux version drift issue - locking all pieces to alpine 3.15