### PR TITLE
Use embedded lld linker, instead of external clang and linker.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,8 +30,8 @@ task:
         TRIPLE: x86_64-unknown-linux-musl
         DEPS_INSTALL: "\
           apk add --no-cache --update \
-            bash curl \
-            alpine-sdk coreutils gcc g++ clang make linux-headers llvm12-dev \
+            bash curl alpine-sdk coreutils \
+            gcc g++ clang make linux-headers llvm12-dev zlib-static \
             pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
@@ -44,8 +44,8 @@ task:
         TRIPLE: arm64-unknown-linux-musl
         DEPS_INSTALL: "\
           apk add --no-cache --update \
-            bash curl \
-            alpine-sdk coreutils gcc g++ clang make linux-headers llvm12-dev \
+            bash curl alpine-sdk coreutils \
+            gcc g++ clang make linux-headers llvm12-dev zlib-static \
             pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `arm64-unknown-linux-musl`.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ task:
         DEPS_INSTALL: "\
           apt-get update && \
           apt-get install -y --no-install-recommends \
-            apt-transport-https ca-certificates curl clang make \
+            apt-transport-https ca-certificates curl make \
             libgc-dev libevent-dev libpcre3-dev && \
           curl -fsSL https://crystal-lang.org/install.sh | bash"
         # Without this next environment var, apt-get will try to ask us
@@ -30,9 +30,9 @@ task:
         TRIPLE: x86_64-unknown-linux-musl
         DEPS_INSTALL: "\
           apk add --no-cache --update \
-            bash curl \
-            alpine-sdk coreutils gcc g++ clang make linux-headers llvm12-dev \
-            pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
+            bash curl alpine-sdk coreutils gcc g++ make linux-headers \
+            zlib-static pcre-dev libevent-static gc-dev libexecinfo-dev \
+            crystal shards"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
         MAKE_EXTRA_ARGS: CLANG_TARGET_PLATFORM=x86_64-alpine-linux-musl
@@ -44,9 +44,9 @@ task:
         TRIPLE: arm64-unknown-linux-musl
         DEPS_INSTALL: "\
           apk add --no-cache --update \
-            bash curl \
-            alpine-sdk coreutils gcc g++ clang make linux-headers llvm12-dev \
-            pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
+            bash curl alpine-sdk coreutils gcc g++ make linux-headers \
+            zlib-static pcre-dev libevent-static gc-dev libexecinfo-dev \
+            crystal shards"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `arm64-unknown-linux-musl`.
         # We also need to use `aarch64` instead of `arm64` here...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ task:
         DEPS_INSTALL: "\
           apt-get update && \
           apt-get install -y --no-install-recommends \
-            apt-transport-https ca-certificates curl make \
+            apt-transport-https ca-certificates curl clang make \
             libgc-dev libevent-dev libpcre3-dev && \
           curl -fsSL https://crystal-lang.org/install.sh | bash"
         # Without this next environment var, apt-get will try to ask us
@@ -30,9 +30,9 @@ task:
         TRIPLE: x86_64-unknown-linux-musl
         DEPS_INSTALL: "\
           apk add --no-cache --update \
-            bash curl alpine-sdk coreutils gcc g++ make linux-headers \
-            zlib-static pcre-dev libevent-static gc-dev libexecinfo-dev \
-            crystal shards"
+            bash curl \
+            alpine-sdk coreutils gcc g++ clang make linux-headers llvm12-dev \
+            pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
         MAKE_EXTRA_ARGS: CLANG_TARGET_PLATFORM=x86_64-alpine-linux-musl
@@ -44,9 +44,9 @@ task:
         TRIPLE: arm64-unknown-linux-musl
         DEPS_INSTALL: "\
           apk add --no-cache --update \
-            bash curl alpine-sdk coreutils gcc g++ make linux-headers \
-            zlib-static pcre-dev libevent-static gc-dev libexecinfo-dev \
-            crystal shards"
+            bash curl \
+            alpine-sdk coreutils gcc g++ clang make linux-headers llvm12-dev \
+            pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `arm64-unknown-linux-musl`.
         # We also need to use `aarch64` instead of `arm64` here...

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ MAKE_VAR_CACHE?=.make-var-cache
 SAVI=$(BUILD)/savi-$(config)
 SPEC=$(BUILD)/savi-spec
 
+CLANGXX?=clang++
+CLANG?=clang
+
 # Run the full CI suite.
 ci: PHONY
 	${MAKE} format.check
@@ -187,7 +190,7 @@ $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 # This bitcode needs to get linked into our Savi compiler executable.
 $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 	mkdir -p `dirname $@`
-	$(LLVM_PATH)/bin/clang -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
+	${CLANGXX} -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
 		-target $(CLANG_TARGET_PLATFORM) \
 		$(CRYSTAL_PATH)/llvm/ext/llvm_ext.cc \
 		-o $@
@@ -196,7 +199,7 @@ $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 # This bitcode needs to get linked into our Savi compiler executable.
 $(BUILD)/llvm_ext_for_savi.bc: $(LLVM_PATH) $(shell find src/savi/ext/llvm/for_savi -name '*.cc')
 	mkdir -p `dirname $@`
-	$(LLVM_PATH)/bin/clang -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
+	${CLANGXX} -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
 		-target $(CLANG_TARGET_PLATFORM) \
 		src/savi/ext/llvm/for_savi/main.cc \
 		-o $@
@@ -247,8 +250,7 @@ $(BUILD)/savi-spec.o: spec/all.cr $(LLVM_PATH) $(shell find src lib spec -name '
 # This variant of the target compiles in release mode.
 $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc lib/libsavi_runtime
 	mkdir -p `dirname $@`
-	$(LLVM_PATH)/bin/clang -O3 -o $@ -flto=thin -fPIC \
-		-B$(LLVM_PATH)/bin -fuse-ld=lld \
+	${CLANG} -O3 -o $@ -flto=thin -fPIC \
 		$(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
@@ -261,8 +263,7 @@ $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llv
 # This variant of the target compiles in debug mode.
 $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc lib/libsavi_runtime
 	mkdir -p `dirname $@`
-	$(LLVM_PATH)/bin/clang -O0 -o $@ -flto=thin -fPIC \
-		-B$(LLVM_PATH)/bin -fuse-ld=lld \
+	${CLANG} -O0 -o $@ -flto=thin -fPIC \
 		$(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
@@ -276,8 +277,7 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ex
 # This variant of the target will be used when running tests.
 $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc lib/libsavi_runtime
 	mkdir -p `dirname $@`
-	$(LLVM_PATH)/bin/clang -O0 -o $@ -flto=thin -fPIC \
-		-B$(LLVM_PATH)/bin -fuse-ld=lld \
+	${CLANG} -O0 -o $@ -flto=thin -fPIC \
 		$(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \

--- a/Makefile
+++ b/Makefile
@@ -190,16 +190,16 @@ $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 # This bitcode needs to get linked into our Savi compiler executable.
 $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 	mkdir -p `dirname $@`
-	${CLANGXX} -v -emit-llvm -c `$(LLVM_CONFIG) --cxxflags` \
+	${CLANGXX} -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
 		-target $(CLANG_TARGET_PLATFORM) \
 		$(CRYSTAL_PATH)/llvm/ext/llvm_ext.cc \
 		-o $@
 
 # Build the extra Savi LLVM extensions as LLVM bitcode.
 # This bitcode needs to get linked into our Savi compiler executable.
-$(BUILD)/llvm_ext_for_savi.bc: $(LLVM_PATH) src/savi/ext/llvm/for_savi/main.cc
+$(BUILD)/llvm_ext_for_savi.bc: $(LLVM_PATH) $(shell find src/savi/ext/llvm/for_savi -name '*.cc')
 	mkdir -p `dirname $@`
-	${CLANGXX} -v -emit-llvm -c `$(LLVM_CONFIG) --cxxflags` \
+	${CLANGXX} -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
 		-target $(CLANG_TARGET_PLATFORM) \
 		src/savi/ext/llvm/for_savi/main.cc \
 		-o $@
@@ -255,6 +255,7 @@ $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llv
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
+		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
 		`$(LLVM_CONFIG) --system-libs --link-static`
 
@@ -267,6 +268,7 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ex
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
+		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
 		`$(LLVM_CONFIG) --system-libs --link-static`
 
@@ -279,5 +281,6 @@ $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
+		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
 		`$(LLVM_CONFIG) --system-libs --link-static`

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
-LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220104b
+LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220106
 $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
@@ -271,6 +271,7 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ex
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
 		`$(LLVM_CONFIG) --system-libs --link-static`
+	if uname | grep -iq 'Darwin'; then dsymutil $@; fi
 
 # Build the Savi specs executable, by linking the above targets together.
 # This variant of the target will be used when running tests.
@@ -284,3 +285,4 @@ $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
 		`$(LLVM_CONFIG) --system-libs --link-static`
+	if uname | grep -iq 'Darwin'; then dsymutil $@; fi

--- a/Makefile
+++ b/Makefile
@@ -120,16 +120,6 @@ LLVM_STATIC_PLATFORM?=$(shell ./platform.sh llvm-static)
 TARGET_PLATFORM?=$(shell ./platform.sh host)
 CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
-# Based on the platform, we may need to pass extra flags to clang.
-# Particularly, on MacOS, we need to specify the SDK include and lib dirs.
-CLANG_EXTRA_FLAGS?=
-ifneq (,$(findstring macos,$(TARGET_PLATFORM)))
-	CLANG_EXTRA_FLAGS+=-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
-	CLANG_EXTRA_FLAGS+=-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
-# TODO: we shouldn't have to rely on system clang for this - our own vendored clang should include C stdlib headers.
-	CLANG_EXTRA_FLAGS+=-I$(shell find /Library/Developer/CommandLineTools/usr/lib/clang -name include | head -n 1)
-endif
-
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
 LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220112
@@ -198,7 +188,7 @@ $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 	mkdir -p `dirname $@`
 	$(LLVM_PATH)/bin/clang -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
-		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
+		-target $(CLANG_TARGET_PLATFORM) \
 		$(CRYSTAL_PATH)/llvm/ext/llvm_ext.cc \
 		-o $@
 
@@ -207,7 +197,7 @@ $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 $(BUILD)/llvm_ext_for_savi.bc: $(LLVM_PATH) $(shell find src/savi/ext/llvm/for_savi -name '*.cc')
 	mkdir -p `dirname $@`
 	$(LLVM_PATH)/bin/clang -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
-		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
+		-target $(CLANG_TARGET_PLATFORM) \
 		src/savi/ext/llvm/for_savi/main.cc \
 		-o $@
 
@@ -261,7 +251,7 @@ $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llv
 		-B$(LLVM_PATH)/bin -fuse-ld=lld \
 		$(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
-		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
+		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
@@ -275,7 +265,7 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ex
 		-B$(LLVM_PATH)/bin -fuse-ld=lld \
 		$(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
-		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
+		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
@@ -290,7 +280,7 @@ $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_
 		-B$(LLVM_PATH)/bin -fuse-ld=lld \
 		$(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
-		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
+		-target $(CLANG_TARGET_PLATFORM) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,16 @@ LLVM_STATIC_PLATFORM?=$(shell ./platform.sh llvm-static)
 TARGET_PLATFORM?=$(shell ./platform.sh host)
 CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
+# Based on the platform, we may need to pass extra flags to clang.
+# Particularly, on MacOS, we need to specify the SDK include and lib dirs.
+CLANG_EXTRA_FLAGS?=
+ifneq (,$(findstring macos,$(TARGET_PLATFORM)))
+	CLANG_EXTRA_FLAGS+=-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+	CLANG_EXTRA_FLAGS+=-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+# TODO: we shouldn't have to rely on system clang for this - our own vendored clang should include C stdlib headers.
+	CLANG_EXTRA_FLAGS+=-I$(shell find /Library/Developer/CommandLineTools/usr/lib/clang -name include | head -n 1)
+endif
+
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
 LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220112
@@ -188,7 +198,7 @@ $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 	mkdir -p `dirname $@`
 	$(LLVM_PATH)/bin/clang -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
-		-target $(CLANG_TARGET_PLATFORM) \
+		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
 		$(CRYSTAL_PATH)/llvm/ext/llvm_ext.cc \
 		-o $@
 
@@ -197,7 +207,7 @@ $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 $(BUILD)/llvm_ext_for_savi.bc: $(LLVM_PATH) $(shell find src/savi/ext/llvm/for_savi -name '*.cc')
 	mkdir -p `dirname $@`
 	$(LLVM_PATH)/bin/clang -v -emit-llvm -g -c `$(LLVM_CONFIG) --cxxflags` \
-		-target $(CLANG_TARGET_PLATFORM) \
+		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
 		src/savi/ext/llvm/for_savi/main.cc \
 		-o $@
 
@@ -251,7 +261,7 @@ $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llv
 		-B$(LLVM_PATH)/bin -fuse-ld=lld \
 		$(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
-		-target $(CLANG_TARGET_PLATFORM) \
+		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
@@ -265,7 +275,7 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ex
 		-B$(LLVM_PATH)/bin -fuse-ld=lld \
 		$(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
-		-target $(CLANG_TARGET_PLATFORM) \
+		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \
@@ -280,7 +290,7 @@ $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_
 		-B$(LLVM_PATH)/bin -fuse-ld=lld \
 		$(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
-		-target $(CLANG_TARGET_PLATFORM) \
+		-target $(CLANG_TARGET_PLATFORM) $(CLANG_EXTRA_FLAGS) \
 		`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'` \
 		`sh -c 'ls $(LLVM_PATH)/lib/liblld*.a'` \
 		`$(LLVM_CONFIG) --libfiles --link-static` \

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
-LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220106
+LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220112
 $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built LLVM/clang static libraries from.

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -25,36 +25,68 @@ class Savi::Compiler::Binary
     # use it in the linker invocation to create the final binary.
     obj_path = BinaryObject.run(ctx)
 
-    if target.macos?
+    # Use a linker to turn make an executable binary from the object file.
+    # We use an embedded lld linker, passing link arguments of our own crafting,
+    # based on information about the target platform and finding system paths.
+    if target.linux? || target.freebsd?
+      link_for_linux_or_bsd(ctx, target, obj_path, bin_path)
+    elsif target.macos?
       link_for_macosx(ctx, target, obj_path, bin_path)
     else
-      link_generic(ctx, target, obj_path, bin_path)
+      raise NotImplementedError.new(target.inspect)
     end
 
     # If requested, strip debugging symbols from the binary.
-    if ctx.options.no_debug
+    if ctx.options.no_debug && !target.macos?
       res = Process.run("/usr/bin/env", ["strip", bin_path], output: STDOUT, error: STDERR)
       raise "strip failed" unless res.exit_code == 0
+    end
+
+    # MacOS has a different way of dealing with debugging symbols - they are
+    # in a subdirectory whose name matches the binary but is suffixed with .dSYM
+    # rather than being embedded in the binary itself, as on other platforms.
+    if target.macos?
+      res = Process.run("/usr/bin/env", ["rm", "-rf", "#{bin_path}.dSYM"], output: STDOUT, error: STDERR)
+      raise "remove old dSYM failed" unless res.exit_code == 0
+
+      unless ctx.options.no_debug
+        res = Process.run("/usr/bin/env", ["dsymutil", bin_path], output: STDOUT, error: STDERR)
+        raise "dsymutil failed" unless res.exit_code == 0
+      end
     end
   ensure
     # Remove the temporary object file to clean up after ourselves a bit.
     File.delete(obj_path) if obj_path && File.exists?(obj_path)
   end
 
+  # Link a MachO executable for a MacOSX target.
   def link_for_macosx(ctx, target, obj_path, bin_path)
-    link_args = %w{lld -execute}
+    link_args = %w{ld64.lld -execute}
 
-    link_args << "-no_pie" unless target.arm64?
+    # Specify the target architecture.
     link_args << "-arch" << (target.arm64? ? "arm64" : "x86_64")
 
+    # Use no_pie where available, for performance reasons.
+    link_args << "-no_pie" unless target.arm64?
+
+    # Set up the main library paths.
+    # TODO: Support overriding (supplementing?) this via the `SDK_ROOT` env var.
+    each_sysroot_lib_path(target) { |lib_path| link_args << "-L#{lib_path}" }
+
+    # Link the main system libraries.
+    link_args << "-lSystem"
+
+    # Target the earliest version of the OS SDK supported for this arch.
+    # We don't expect the user program to use any bleeding-edge Apple features.
+    # TODO: Support overriding this via the `MACOSX_DEPLOYMENT_TARGET` env var.
+    sdk_version = (target.arm64? ? "11.0.0" : "10.9.0")
+    link_args << "-platform_version" << "macos" << sdk_version << sdk_version
+
+    # Finally, specify the input object file and the output filename.
     link_args << "-o" << bin_path
     link_args << obj_path
 
-    link_args << "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
-    link_args << "-lSystem"
-
-    link_args << "-lto_library" << "lib/libLTO.dylib"
-
+    # Invoke the linker, using the MachO flavor.
     link_res = LibLLVM.link_for_savi_directly(
       "mach_o",
       link_args.size, link_args.map(&.to_unsafe)
@@ -62,68 +94,149 @@ class Savi::Compiler::Binary
     raise "failed to link" unless link_res
   end
 
-  def link_generic(ctx, target, obj_path, bin_path)
-    # Use clang to orchestrate the linking process (clang will call the linker
-    # for us with appropriate arguments based on the args we have given it).
-    # For all platforms, we enable position-independent-code and
-    # thin link time optimization. We will use embedded lld as the linker.
-    link_args = %w{clang -fpic -flto=thin -fuse-ld=lld}
+  # Link an ELF executable for a Linux or FreeBSD target.
+  def link_for_linux_or_bsd(ctx, target, obj_path, bin_path)
+    link_args = %w{ld.lld}
 
-    # We also use clang for optimizations, when compiling in release mode.
-    # Note that we already optimized the program in the BinaryObject pass,
-    # but this gives us the opportunity to run link-time optimizations if any.
-    link_args << (ctx.options.release ? "-O3" : "-O0")
+    # Add various "extra flags" based on the target platform.
+    link_args << "-z" << "now" if target.musl?
+    link_args << "-z" << "relro" if target.linux?
+    link_args << "--hash-style=both"
+    link_args << "--eh-frame-hdr"
 
-    # Unless debugging info has been disabled, include it here.
-    link_args << "-g" unless ctx.options.no_debug
-
-    # Based on the target, choose which libraries to explicitly link.
-    # On some platforms, some of the relevant libraries we need are implicit.
-    link_args.concat(
-      if target.linux?
-        if target.musl?
-          %w{-ldl -pthread -lc -lm -lexecinfo -latomic}
-        else
-          %w{-ldl -pthread -lc -lm -latomic}
-        end
-      elsif target.freebsd?
-        %w{-ldl -pthread -lc -lm -lexecinfo -lelf}
-      elsif target.macos?
-        %w{}
-      else
-        raise NotImplementedError.new(target)
-      end
-    )
-
-    # Based on the target, choose the linker flavor to use.
-    link_flavor =
-      if target.linux?
-        "elf"
-      elsif target.freebsd?
-        "elf"
-      elsif target.macos?
-        "mach_o"
-      else
-        raise NotImplementedError.new(target)
-      end
-
-    # Link any additional libraries requested by the user program.
-    ctx.link_libraries.each do |x|
-      link_args << "-l" + x
+    # Specify the target architecture, in the terms the linker will understand.
+    if target.x86_64?
+      link_args << "-m" << "elf_x86_64"
+    elsif target.arm64?
+      link_args << "-m" << "aarch64linux"
+    else
+      raise NotImplementedError.new(target.inspect)
     end
 
-    # Finally, specify the input object file and the output filename.
-    link_args << obj_path
-    link_args << "-o" << bin_path
+    # Specify the dynamic linker library, based on the target platform.
+    link_args << "-dynamic-linker" << dynamic_linker_for_linux_or_bsd(target)
 
-    # Use a linker to turn make an executable binary from the object file.
-    # We use an embedded linker, passing the given link args to embedded clang,
-    # which will determine the right args to use for the embedded lld linker.
-    link_res = LibLLVM.link_for_savi(
-      link_flavor,
-      ctx.code_gen.target_machine.triple,
+    # Get the list of lib search paths within the sysroot.
+    lib_paths = [] of String
+    each_sysroot_lib_path(target) { |path| lib_paths << path }
+    lib_paths.each { |lib_path| link_args << "-L#{lib_path}" }
+
+    # Also find the mandatory ceremony objects that all programs need to link.
+    link_args << find_in_paths(lib_paths, "crt1.o")
+    link_args << find_in_paths(lib_paths, "crti.o")
+    link_args << find_in_paths(lib_paths, "crtbegin.o")
+    link_args << find_in_paths(lib_paths, "crtend.o")
+    link_args << find_in_paths(lib_paths, "crtn.o")
+
+    # Enable link-time-optimization with "thin" LTO.
+    link_args << "-plugin-opt=mcpu=#{target.arm64? ? "aarch64" : "x86-64"}"
+    link_args << "-plugin-opt=#{ctx.options.release ? "O3" : "O0"}"
+    link_args << "-plugin-opt=thinlto"
+
+    # TODO: Allow option to build with "-static" for linux-musl target
+
+    # Link the libraries that we always need.
+    link_args << "-lgcc" << "-lgcc_s"
+    link_args << "-lc" << "-ldl" << "-lpthread" << "-latomic" << "-lm"
+    link_args << "-lexecinfo" if target.musl? || target.freebsd?
+
+    # Finally, specify the input object file and the output filename.
+    link_args << "-o" << bin_path
+    link_args << obj_path
+
+    # Invoke the linker, using the ELF flavor.
+    link_res = LibLLVM.link_for_savi_directly(
+      "elf",
       link_args.size, link_args.map(&.to_unsafe)
     )
     raise "failed to link" unless link_res
+  end
+
+  # Get the path to the dynamic linker library for a Linux or FreeBSD target.
+  def dynamic_linker_for_linux_or_bsd(target) : String
+    if target.linux?
+      if target.musl?
+        if target.x86_64?
+          return "/lib/ld-musl-x86_64.so.1"
+        elsif target.arm64?
+          return "/lib/ld-musl-aarch64.so.1"
+        end
+      end
+
+      if target.x86_64?
+        return "/lib64/ld-linux-x86-64.so.2"
+      end
+    end
+
+    if target.freebsd?
+      return "/libexec/ld-elf.so.1"
+    end
+
+    raise NotImplementedError.new(target.inspect)
+  end
+
+  # Yield each sysroot-based path in which to search for linkable libs/objs.
+  def each_sysroot_lib_path(target)
+    sysroot = "/" # TODO: Allow user to supply custom sysroot for cross-compile.
+
+    yielded_any = false
+    each_sysroot_lib_glob(target) { |lib_glob|
+      Dir.glob(lib_glob) { |lib_path|
+        next unless Dir.exists?(lib_path)
+
+        yield lib_path
+        yielded_any = true
+      }
+    }
+
+    raise "couldn't find any valid sysroot lib paths" unless yielded_any
+  end
+
+  # Yield each sysroot-based glob used to find paths that exist.
+  def each_sysroot_lib_glob(target)
+    # For MacOS, we have just one valid sysroot path, so we can finish early.
+    if target.macos?
+      yield "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+      return
+    end
+
+    if target.linux?
+      if target.musl?
+        if target.x86_64?
+          # TODO: Support non-alpine musl variants?
+          yield "/usr/lib/gcc/x86_64-alpine-linux-musl/*"
+        elsif target.arm64?
+          # TODO: Support non-alpine musl variants?
+          yield "/usr/lib/gcc/aarch64-alpine-linux-musl/*"
+        else
+          raise NotImplementedError.new(target.inspect)
+        end
+      else
+        if target.x86_64?
+          yield "/lib/gcc/x86_64-linux-gnu/*"
+          yield "/lib/x86_64-linux-gnu"
+          yield "/usr/lib/gcc/x86_64-linux-gnu/*"
+          yield "/usr/lib/x86_64-linux-gnu"
+        else
+          raise NotImplementedError.new(target.inspect)
+        end
+      end
+    end
+
+    yield "/lib64"
+    yield "/usr/lib64"
+    yield "/lib"
+    yield "/usr/lib"
+  end
+
+  # Given a prioritized list of search paths and a file name, find the file.
+  # Raises an error if the file couldn't be found in any of the paths
+  def find_in_paths(paths, file_name) : String
+    paths.each { |path|
+      file_path = File.join(path, file_name)
+      return file_path if File.exists?(file_path)
+    }
+
+    raise "failed to find #{file_name}"
   end
 end

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -242,7 +242,17 @@ class Savi::Compiler::Binary
     # Print the output errors/warnings/info, if any.
     if out_size > 0
       output = String.new(out_ptr, out_size)
-      STDERR.puts(output)
+
+      # Filter the output to remove unnecessary warnings we don't want to see.
+      output_lines = output.split("\n").reject(&.empty?)
+        # MacOS likes to warn if you make your apps compatible with older
+        # versions of their SDK, even though this is explicitly supported,
+        # as long as your application isn't relying on new features of the SDK.
+        # We expect this warning to always be present, because we deliberately
+        # specify the oldest supported version, so we don't want to see it.
+        .reject(&.matches?(/which is newer than target minimum/))
+
+      output_lines.each { |line| STDERR.puts(line) }
     end
 
     # Ensure the output data pointer, which was a fresh allocation, is freed.

--- a/src/savi/ext/llvm/for_savi/LLVMLinkForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMLinkForSavi.cc
@@ -21,12 +21,17 @@ bool LLVMLinkForSaviDirectly(
 ) {
   std::vector<const char *> Args(ArgV, ArgV + ArgC);
 
+    for (auto it = Args.begin(); it != Args.end(); ++it) {
+      errs() << *it << "\n";
+    }
+
+
   // Invoke the linker.
   bool LinkResult = false;
   if (0 == strcmp(Flavor, "elf")) {
     LinkResult = lld::elf::link(Args, false, outs(), errs());
   } else if (0 == strcmp(Flavor, "mach_o")) {
-    LinkResult = lld::mach_o::link(Args, false, outs(), errs());
+    LinkResult = lld::macho::link(Args, false, outs(), errs());
   } else if (0 == strcmp(Flavor, "mingw")) {
     LinkResult = lld::mingw::link(Args, false, outs(), errs());
   } else if (0 == strcmp(Flavor, "coff")) {
@@ -39,9 +44,9 @@ bool LLVMLinkForSaviDirectly(
 
   // Show a helpful error message on failure.
   if (!LinkResult) {
-    errs() << "Failed to link with lld, using these args:";
+    errs() << "Failed to link with lld, using these args:" << "\n";
     for (auto it = Args.begin(); it != Args.end(); ++it) {
-      errs() << *it;
+      errs() << *it << "\n";
     }
   }
 

--- a/src/savi/ext/llvm/for_savi/LLVMLinkForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMLinkForSavi.cc
@@ -1,0 +1,99 @@
+#include <clang/Driver/Compilation.h>
+#include <clang/Driver/Driver.h>
+#include <clang/Frontend/TextDiagnosticPrinter.h>
+#include <lld/Common/Driver.h>
+#include <llvm/Support/InitLLVM.h>
+#include <llvm/Support/Process.h>
+#include <llvm/Support/VirtualFileSystem.h>
+
+///
+// LLVMLinkForSavi uses `lld` as a static library to embed a linker within the
+// Savi compiler, so that we can create executable programs without relying
+// on an external linker program as a (varying and hard to control) dependency.
+
+using namespace llvm;
+
+extern "C" {
+
+bool LLVMLinkForSaviDirectly(
+  const char* Flavor,
+  int ArgC, const char **ArgV
+) {
+  std::vector<const char *> Args(ArgV, ArgV + ArgC);
+
+  // Invoke the linker.
+  bool LinkResult = false;
+  if (0 == strcmp(Flavor, "elf")) {
+    LinkResult = lld::elf::link(Args, false, outs(), errs());
+  } else if (0 == strcmp(Flavor, "mach_o")) {
+    LinkResult = lld::mach_o::link(Args, false, outs(), errs());
+  } else if (0 == strcmp(Flavor, "mingw")) {
+    LinkResult = lld::mingw::link(Args, false, outs(), errs());
+  } else if (0 == strcmp(Flavor, "coff")) {
+    LinkResult = lld::coff::link(Args, false, outs(), errs());
+  } else if (0 == strcmp(Flavor, "wasm")) {
+    LinkResult = lld::wasm::link(Args, false, outs(), errs());
+  } else {
+    errs() << "Unsupported lld link flavor: " << Flavor;
+  }
+
+  // Show a helpful error message on failure.
+  if (!LinkResult) {
+    errs() << "Failed to link with lld, using these args:";
+    for (auto it = Args.begin(); it != Args.end(); ++it) {
+      errs() << *it;
+    }
+  }
+
+  return LinkResult;
+}
+
+bool LLVMLinkForSavi(
+  const char* Flavor,
+  const char* Target,
+  int ArgC, const char **ArgV
+) {
+  // The arguments list for clang was given in a C-like FFI-friendly way, but
+  // here we construct the C++-friendly equivalent of that args list.
+  std::vector<const char *> Args(ArgV, ArgV + ArgC);
+
+  // Create a libclang driver and compilation, using the given target and args.
+  auto Diags = new clang::DiagnosticIDs();
+  auto DiagOpts = new clang::DiagnosticOptions();
+  auto DiagClient = new clang::TextDiagnosticPrinter(llvm::errs(), DiagOpts);
+  clang::DiagnosticsEngine DiagEngine(Diags, DiagOpts, DiagClient);
+  clang::driver::Driver Driver("clang", Target, DiagEngine);
+  clang::driver::Compilation *Compilation = Driver.BuildCompilation(Args);
+
+  // Iterate over the list of jobs in the compilation, expecting in practice
+  // that this will only be a single job for linking, and that we can fulfill
+  // the linking job using the embedded lld instead of an external linker.
+  for (
+    auto it = Compilation->getJobs().begin();
+    it != Compilation->getJobs().end();
+    ++it
+  ) {
+    // Ensure that the only job we're doing is linking, since we want to
+    // avoid executing external shell commands, and only use embedded lld.
+    if (it->getSource().getKind() != clang::driver::Action::LinkJobClass) {
+      errs() << "Expected libclang to only need to link, but got this job:";
+      it->Print(errs(), "\n", false);
+      return false;
+    }
+
+    // Get the list of args that libclang says we should pass to the linker.
+    auto LinkArgs = it->getArguments();
+
+    // The lld library expects the first link argument to be the program name,
+    // so we need to insert an extra "argument" here to fill that space.
+    LinkArgs.insert(LinkArgs.begin(), "lld");
+
+    // Invoke the linker, failing if the linker failed.
+    if (!LLVMLinkForSaviDirectly(Flavor, LinkArgs.size(), LinkArgs.data()))
+      return false;
+  }
+
+  return true;
+}
+
+}

--- a/src/savi/ext/llvm/for_savi/main.cc
+++ b/src/savi/ext/llvm/for_savi/main.cc
@@ -11,5 +11,6 @@
 // That is, parts of the LLVM API are only exposed in C++ but not the C wrapper,
 // so if we want to use them, we need to wrap them ourselves here.
 
+#include "./LLVMLinkForSavi.cc"
 #include "./LLVMOptimizeForSavi.cc"
 #include "./LLVMRemapDIDirectoryForSavi.cc"

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -32,8 +32,7 @@ lib LibLLVM
   # Extra functions defined just for Savi go here:
   #
 
-  fun link_for_savi = LLVMLinkForSavi(flavor : UInt8*, target : UInt8*, argc : Int32, argv : UInt8**) : Bool
-  fun link_for_savi_directly = LLVMLinkForSaviDirectly(flavor : UInt8*, argc : Int32, argv : UInt8**) : Bool
+  fun link_for_savi = LLVMLinkForSavi(flavor : UInt8*, argc : Int32, argv : UInt8**, out_ptr : UInt8**, out_size : Int32*) : Bool
   fun optimize_for_savi = LLVMOptimizeForSavi(mod : ModuleRef, wants_full_optimization : Bool)
   fun remap_di_directory_for_savi = LLVMRemapDIDirectoryForSavi(mod : ModuleRef, before_dir : UInt8*, after_dir : UInt8*)
 end

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -32,6 +32,8 @@ lib LibLLVM
   # Extra functions defined just for Savi go here:
   #
 
+  fun link_for_savi = LLVMLinkForSavi(flavor : UInt8*, target : UInt8*, argc : Int32, argv : UInt8**) : Bool
+  fun link_for_savi_directly = LLVMLinkForSaviDirectly(flavor : UInt8*, argc : Int32, argv : UInt8**) : Bool
   fun optimize_for_savi = LLVMOptimizeForSavi(mod : ModuleRef, wants_full_optimization : Bool)
   fun remap_di_directory_for_savi = LLVMRemapDIDirectoryForSavi(mod : ModuleRef, before_dir : UInt8*, after_dir : UInt8*)
 end


### PR DESCRIPTION
This reduces our external dependencies and allows us to exercise
tighter control and reproducibility across similar environments,
but without us needing to deal too much with the details of linking
because we still delegate the process to clang and lld -
we just now leverage them as embedded static libraries
within the final Savi compiler binary.