### PR TITLE
Use the new bundled format of the runtime-bitcode.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -122,7 +122,7 @@ task:
 
   copy_runtime_script:
     - mkdir -p out/lib
-    - cp lib/libsavi_runtime.bc out/lib/
+    - cp -r lib/libsavi_runtime out/lib/libsavi_runtime
 
   archive_script:
     - tar -czvf /tmp/savi.tar.gz -C out .

--- a/src/savi/compiler/target.cr
+++ b/src/savi/compiler/target.cr
@@ -6,4 +6,12 @@ class Savi::Compiler::Target < Crystal::Codegen::Target
   def musl?
     linux? && `ldd --version 2>&1`.starts_with?("musl")
   end
+
+  def arm64?
+    architecture == "aarch64"
+  end
+
+  def x86_64?
+    architecture == "x86_64"
+  end
 end


### PR DESCRIPTION
Now all platforms are included and the correct one is chosen
within the Savi compiler execution based on the target platform.