### PR TITLE
Temporarily disable LLVM optimizations.

### DIFF
--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -79,9 +79,11 @@ class Savi::Compiler::BinaryObject
     # Link the runtime bitcode module into the generated application module.
     LibLLVM.link_modules(mod.to_unsafe, runtime.to_unsafe)
 
-    # Now run LLVM passes, doing full optimization if in release mode.
-    # Otherwise we will only run a minimal set of passes.
-    LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
+    # # Now run LLVM passes, doing full optimization if in release mode.
+    # # Otherwise we will only run a minimal set of passes.
+    # # TODO: Re-enable this once we've troubleshooted the issues it is causing
+    # # on some platforms with preventing program termination/quiescence.
+    # LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
 
     # Write the program to disk as a binary object file.
     obj_path = "#{ctx.manifests.root.not_nil!.bin_path}.o"


### PR DESCRIPTION
These are causing some kind of problem with program termination
on arm64 platforms (including arm64-apple-macosx and
arm64-unknown-linux-musl).

We will re-enable these later once we've solved the problem.