### PR TITLE
Refactor the order of passes, putting Populate before Macros.

### DIFF
--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -33,10 +33,10 @@ class Savi::Compiler
     when "populate_types"   then :populate_types
     when "namespace"        then :namespace
     when "reparse"          then :reparse
+    when "populate"         then :populate
     when "macros"           then :macros
     when "sugar"            then :sugar
     when "refer_type"       then :refer_type
-    when "populate"         then :populate
     when "lambda"           then :lambda
     when "flow"             then :flow
     when "refer"            then :refer
@@ -87,10 +87,10 @@ class Savi::Compiler
       when :populate_types   then ctx.run_copy_on_mutate(ctx.populate_types)
       when :namespace        then ctx.run_whole_program(ctx.namespace)
       when :reparse          then ctx.run_copy_on_mutate(Reparse)
+      when :populate         then ctx.run_copy_on_mutate(ctx.populate)
       when :macros           then ctx.run_copy_on_mutate(Macros)
       when :sugar            then ctx.run_copy_on_mutate(Sugar)
       when :refer_type       then ctx.run(ctx.refer_type)
-      when :populate         then ctx.run_copy_on_mutate(ctx.populate)
       when :lambda           then ctx.run_copy_on_mutate(Lambda)
       when :flow             then ctx.run(ctx.flow)
       when :refer            then ctx.run(ctx.refer)
@@ -146,10 +146,10 @@ class Savi::Compiler
     when :populate_types then [:load]
     when :namespace then [:populate_types, :load]
     when :reparse then [:namespace]
-    when :macros then [:reparse]
+    when :populate then [:reparse, :namespace]
+    when :macros then [:populate]
     when :sugar then [:macros]
     when :refer_type then [:sugar, :macros, :reparse, :namespace, :populate_types]
-    when :populate then [:sugar, :macros, :reparse, :refer_type]
     when :lambda then [:sugar, :macros, :reparse]
     when :flow then [:lambda, :populate, :sugar, :macros, :reparse]
     when :classify then [:refer_type, :lambda, :populate, :sugar, :macros, :reparse]

--- a/src/savi/compiler/namespace.cr
+++ b/src/savi/compiler/namespace.cr
@@ -10,10 +10,11 @@
 # This pass produces output state at the source and source package level.
 #
 class Savi::Compiler::Namespace
-  struct SourceAnalysis
+  struct Analysis
+    getter source : Source
     protected getter types
 
-    def initialize(@source : Source)
+    def initialize(@source)
       @types = {} of String => (
         Program::Type::Link | Program::TypeAlias::Link | Program::TypeWithValue::Link \
       )
@@ -27,7 +28,7 @@ class Savi::Compiler::Namespace
     @types_by_package_name = Hash(String, Hash(String,
       Program::Type::Link | Program::TypeAlias::Link | Program::TypeWithValue::Link
     )).new
-    @source_analyses = Hash(Source, SourceAnalysis).new
+    @source_analyses = Hash(Source, Analysis).new
   end
 
   def main_type!(ctx); main_type?(ctx).not_nil! end
@@ -92,9 +93,11 @@ class Savi::Compiler::Namespace
   end
 
   # When given a Source, return the set of analysis for that source.
-  # TODO: Get rid of other forms of [] here in favor of this one.
-  def [](source : Source) : SourceAnalysis
+  def [](source : Source) : Analysis
     @source_analyses[source]
+  end
+  def []?(source : Source) : Analysis?
+    @source_analyses[source]?
   end
 
   # When given a String name, try to find the type in the core_savi package.
@@ -154,7 +157,7 @@ class Savi::Compiler::Namespace
     source = new_type.ident.pos.source
     name = new_type.ident.value
 
-    source_analysis = @source_analyses[source] ||= SourceAnalysis.new(source)
+    source_analysis = @source_analyses[source] ||= Analysis.new(source)
 
     source_analysis.types[name] = new_type.make_link(package)
   end

--- a/src/savi/compiler/pass/analyze.cr
+++ b/src/savi/compiler/pass/analyze.cr
@@ -153,6 +153,18 @@ abstract class Savi::Compiler::Pass::Analyze(TypeAliasAnalysis, TypeAnalysis, Fu
     end
   end
 
+  # If the set of cache dependencies may change during analysis, use these
+  # methods to override the cached hash used for invalidation in future runs.
+  private def set_type_alias_cache_deps(t, t_link, deps)
+    cache_info_for_alias[t_link] = {t, deps}.hash
+  end
+  private def set_type_cache_deps(t, t_link, deps)
+    cache_info_for_type[t_link] = {t, deps}.hash
+  end
+  private def set_func_cache_deps(f, f_link, deps)
+    cache_info_for_func[f_link] = {f, deps}.hash
+  end
+
   # Required hook to make the pass create an analysis for the given type alias.
   abstract def analyze_type_alias(
     ctx : Context,

--- a/src/savi/compiler/sugar.cr
+++ b/src/savi/compiler/sugar.cr
@@ -13,12 +13,14 @@
 class Savi::Compiler::Sugar < Savi::AST::CopyOnMutateVisitor
   # TODO: Clean up, consolidate, and improve this caching mechanism.
   @@cache = {} of Program::Function::Link => {UInt64, Program::Function}
-  def self.cached_or_run(l, t, f) : Program::Function
+  def self.cached_or_run(ctx, l, t, f) : Program::Function
     f_link = f.make_link(t.make_link(l.make_link))
     input_hash = f.hash
     cache_result = @@cache[f_link]?
     cached_hash, cached_func = cache_result if cache_result
     return cached_func if cached_func && cached_hash == input_hash
+
+    puts "    RERUN . #{self.class} #{f_link.show}" if cache_result && ctx.options.print_perf
 
     yield
 
@@ -30,7 +32,7 @@ class Savi::Compiler::Sugar < Savi::AST::CopyOnMutateVisitor
   def self.run(ctx, package)
     package.types_map_cow do |t|
       t.functions_map_cow do |f|
-        cached_or_run package, t, f do
+        cached_or_run ctx, package, t, f do
           sugar = new
           f = sugar.run(ctx, f)
         end


### PR DESCRIPTION
This necessitated some changes to the Populate pass, including
making it depend on the Namespace pass instead of ReferType,
and also refactoring it to have better caching properties
so that it does not wreck caching of passes after it.

While refactoring caching properties, it was noticed that some
caching functions lack the standard printing when the `--print-perf`
CLI flag is used.