### PR TITLE
Add Bytes#push_bytes as an alias for #<<

### DIFF
--- a/packages/src/Savi/Bytes.savi
+++ b/packages/src/Savi/Bytes.savi
@@ -258,6 +258,10 @@
     )
     @
 
+  :: An alias for `<<` that works better with method chaining.
+  :fun ref push_bytes(other Bytes'box)
+    @ << other
+
   :fun ref concat_byte_slice(
     other Bytes'box
     from ISize = 0


### PR DESCRIPTION
The `push_bytes` method works better in cases like this:

```savi
Bytes
  .new_iso
  .push_native_u32(0)
  .push_bytes(b"abc")
  .push(0)
```