### PR TITLE
Make I32 and F64 the fallback types for when numeric literal inference fails.

### DIFF
--- a/spec/compiler/t_type_check.inference.savi.spec.md
+++ b/spec/compiler/t_type_check.inference.savi.spec.md
@@ -144,76 +144,48 @@ It infers an integer through a variable with only a cap as its explicit type:
 
 ---
 
-It complains when a literal couldn't be resolved to a single type:
+It treats non-inferred integer literals as I32:
 
 ```savi
-    x (F64 | U64) = 42
-```
-```error
-This literal value couldn't be inferred as a single concrete type:
-    x (F64 | U64) = 42
-                    ^~
-
-- it is required here to be a subtype of (F64 | U64):
-    x (F64 | U64) = 42
-      ^~~~~~~~~~~
-
-- and the literal itself has an intrinsic type of Numeric.Convertible:
-    x (F64 | U64) = 42
-                    ^~
-
-- Please wrap an explicit numeric type around the literal (for example: U64[42])
+    x = (
+      42 ::t_type=> I32
+    ).u64 ::t_type=> U64
 ```
 
 ---
 
-It complains when literal couldn't resolve even when calling u64 method:
+It treats non-inferred integer literals as F64:
 
 ```savi
-    x = 42.u64
-```
-```error
-This literal value couldn't be inferred as a single concrete type:
-    x = 42.u64
-        ^~
-
-- and the literal itself has an intrinsic type of Numeric.Convertible:
-    x = 42.u64
-        ^~
-
-- Please wrap an explicit numeric type around the literal (for example: U64[42])
+    x = (
+      42.0 ::t_type=> F64
+    ).u64 ::t_type=> U64
 ```
 
 ---
 
-It complains when literal couldn't resolve and had conflicting hints:
+It infers a literal through peer hints:
+
+```savi
+    string = "Hello, World"
+    case (
+    | string.size < 10 | U64[99]
+    | string.size > 90 | U64[88]
+    | 0 ::t_type=> U64
+    ) ::t_type=> U64
+```
+
+---
+
+It ignores peer hints when more than one might apply:
 
 ```savi
     string = "Hello, World"
     case (
     | string.size < 10 | U64[99]
     | string.size > 90 | I64[88]
-    | 0
-    )
-```
-```error
-This literal value couldn't be inferred as a single concrete type:
-    | 0
-      ^
-
-- it is suggested here that it might be a U64:
-    | string.size < 10 | U64[99]
-                            ^~~~
-
-- it is suggested here that it might be a I64:
-    | string.size > 90 | I64[88]
-                            ^~~~
-
-- and the literal itself has an intrinsic type of Numeric.Convertible:
-    | 0
-      ^
-
-- Please wrap an explicit numeric type around the literal (for example: U64[0])
+    | 0 ::t_type=> I32
+    ) ::t_type=> (U64 | I64 | I32)
 ```
 
 ---

--- a/spec/compiler/type_check.inference.savi.spec.md
+++ b/spec/compiler/type_check.inference.savi.spec.md
@@ -171,7 +171,11 @@ This literal value couldn't be inferred as a single concrete type:
     x (F64 | U64) = 42
       ^~~~~~~~~~~
 
-- and the literal itself has an intrinsic type of Numeric.Convertible:
+- the literal could be any subtype of Numeric.Convertible:
+    x (F64 | U64) = 42
+                    ^~
+
+- but the fallback type for this kind of literal would be I32:
     x (F64 | U64) = 42
                     ^~
 
@@ -180,53 +184,48 @@ This literal value couldn't be inferred as a single concrete type:
 
 ---
 
-It complains when literal couldn't resolve even when calling u64 method:
+It treats non-inferred integer literals as I32:
 
 ```savi
-    x = 42.u64
-```
-```error
-This literal value couldn't be inferred as a single concrete type:
-    x = 42.u64
-        ^~
-
-- and the literal itself has an intrinsic type of Numeric.Convertible:
-    x = 42.u64
-        ^~
-
-- Please wrap an explicit numeric type around the literal (for example: U64[42])
+    x = (
+      42 ::type=> I32
+    ).u64 ::type=> U64
 ```
 
 ---
 
-It complains when literal couldn't resolve and had conflicting hints:
+It treats non-inferred integer literals as F64:
+
+```savi
+    x = (
+      42.0 ::type=> F64
+    ).u64 ::type=> U64
+```
+
+---
+
+It infers a literal through peer hints:
+
+```savi
+    string = "Hello, World"
+    case (
+    | string.size < 10 | U64[99]
+    | string.size > 90 | U64[88]
+    | 0 ::type=> U64
+    ) ::type=> U64
+```
+
+---
+
+It ignores peer hints when more than one might apply:
 
 ```savi
     string = "Hello, World"
     case (
     | string.size < 10 | U64[99]
     | string.size > 90 | I64[88]
-    | 0
-    )
-```
-```error
-This literal value couldn't be inferred as a single concrete type:
-    | 0
-      ^
-
-- it is suggested here that it might be a U64:
-    | string.size < 10 | U64[99]
-                            ^~~~
-
-- it is suggested here that it might be a I64:
-    | string.size > 90 | I64[88]
-                            ^~~~
-
-- and the literal itself has an intrinsic type of Numeric.Convertible:
-    | 0
-      ^
-
-- Please wrap an explicit numeric type around the literal (for example: U64[0])
+    | 0 ::type=> I32
+    ) ::type=> (U64 | I64 | I32)
 ```
 
 ---

--- a/src/savi/compiler/infer/info.cr
+++ b/src/savi/compiler/infer/info.cr
@@ -498,7 +498,7 @@ module Savi::Compiler::Infer
 
     def describe_kind : String; "literal value" end
 
-    def initialize(@pos, @layer_index, @possible : MetaType)
+    def initialize(@pos, @layer_index, @possible : MetaType, @fallback : MetaType)
       @peer_hints = [] of Info
     end
 
@@ -506,8 +506,17 @@ module Savi::Compiler::Infer
       @peer_hints << peer
     end
 
+    def widest_mt
+      @possible
+    end
+
+    def fallback_mt
+      @fallback
+    end
+
     def resolve_span!(ctx : Context, infer : Visitor) : Span
       simple_span = Span.simple(@possible)
+      fallback_span = Span.simple(@fallback)
 
       # Look at downstream tether constraints to try to resolve the literal
       # to a more specific type than the simple "possible" type indicated by it.
@@ -541,11 +550,11 @@ module Savi::Compiler::Infer
             }
             .maybe_fallback_based_on_mt_simplify([
               # If, with peer hints, we are still not a single concrete type,
-              # there's nothing more to try, so we return the simple type.
-              {:mt_non_singular_concrete, simple_span}
+              # there's nothing more to try, so we use the fallback type.
+              {:mt_non_singular_concrete, fallback_span}
             ])
           else
-            simple_span
+            fallback_span
           end
         }
       ])

--- a/src/savi/compiler/t_infer/info.cr
+++ b/src/savi/compiler/t_infer/info.cr
@@ -467,7 +467,7 @@ module Savi::Compiler::TInfer
 
     def describe_kind : String; "literal value" end
 
-    def initialize(@pos, @layer_index, @possible : MetaType)
+    def initialize(@pos, @layer_index, @possible : MetaType, @fallback : MetaType)
       @peer_hints = [] of Info
     end
 
@@ -475,8 +475,17 @@ module Savi::Compiler::TInfer
       @peer_hints << peer
     end
 
+    def widest_mt
+      @possible
+    end
+
+    def fallback_mt
+      @fallback
+    end
+
     def resolve_span!(ctx : Context, infer : Visitor) : Span
       simple_span = Span.simple(@possible)
+      fallback_span = Span.simple(@fallback)
 
       # Look at downstream tether constraints to try to resolve the literal
       # to a more specific type than the simple "possible" type indicated by it.
@@ -510,11 +519,11 @@ module Savi::Compiler::TInfer
             }
             .maybe_fallback_based_on_mt_simplify([
               # If, with peer hints, we are still not a single concrete type,
-              # there's nothing more to try, so we return the simple type.
-              {:mt_non_singular_concrete, simple_span}
+              # there's nothing more to try, so we use the fallback type.
+              {:mt_non_singular_concrete, fallback_span}
             ])
           else
-            simple_span
+            fallback_span
           end
         }
       ])

--- a/src/savi/compiler/t_type_check.cr
+++ b/src/savi/compiler/t_type_check.cr
@@ -281,13 +281,16 @@ class Savi::Compiler::TTypeCheck
 
     # Sometimes print a special case error message for Literal values.
     def type_check_pre(ctx : Context, info : TInfer::Literal, mt : MetaType) : Bool
-      # If we've resolved to a single concrete type already, move forward.
-      return true if mt.singular? && mt.single!.link.is_concrete?
+      downstream_mt = info.total_downstream_constraint(ctx, self)
 
-      # If we can't be satisfiably intersected with the downstream constraints,
-      # move forward and let the standard type checker error happen.
-      constrained_mt = mt.intersect(info.total_downstream_constraint(ctx, self))
-      return true if constrained_mt.simplify(ctx).unsatisfiable?
+      # If the widest type is not satisfiable with downstream constraints,
+      # fail early here to show the standard type checker error.
+      return true if info.widest_mt.intersect(downstream_mt).simplify(ctx).unsatisfiable?
+
+      # If the constrained type is singular and concrete, move forward
+      # expecting no errors to need to be shown for this type.
+      constrained_mt = mt.intersect(downstream_mt).simplify(ctx)
+      return true if constrained_mt.singular? && constrained_mt.single!.link.is_concrete?
 
       # Otherwise, print a Literal-specific error that includes peer hints,
       # as well as a call to action to use an explicit numeric type.
@@ -298,7 +301,10 @@ class Savi::Compiler::TTypeCheck
       }
       error_info.concat(info.describe_downstream_constraints(ctx, self))
       error_info.push({info.pos,
-        "and the literal itself has an intrinsic type of #{mt.show_type}"
+        "the literal could be any subtype of #{info.widest_mt.show_type}"
+      })
+      error_info.push({info.pos,
+        "but the fallback type for this kind of literal would be #{info.fallback_mt.show_type}"
       })
       error_info.push({Source::Pos.none,
         "Please wrap an explicit numeric type around the literal " \


### PR DESCRIPTION
See [the relevant Zulip discussion here](https://savi.zulipchat.com/#narrow/stream/294906-libraries/topic/.60Count.2Eto.60.20vs.20.60Numeric.2Etimes.60/near/254278996).

Particularly relevant are the arguments in [this Rust RFC](https://github.com/rust-lang/rfcs/blob/master/text/0212-restore-int-fallback.md), which we are aligning Savi with when we make this change.