### PR TITLE
Add initial revision of the StdIn package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,9 @@ CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220112
 $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
-# Specify where to download our pre-built LLVM/clang static libraries from.
-# This needs to get bumped explicitly here when we do a new LLVM build.
-RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/20220105b
+# Specify where to download our pre-built runtime bitcode from.
+# This needs to get bumped explicitly here when we do a new runtime build.
+RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/20220206
 $(eval $(call MAKE_VAR_CACHE_FOR,RUNTIME_BITCODE_RELEASE_URL))
 
 # This is the path where we look for the LLVM pre-built static libraries to be,

--- a/packages/StdIn.manifest.savi
+++ b/packages/StdIn.manifest.savi
@@ -1,0 +1,6 @@
+:manifest lib StdIn
+  :sources "src/StdIn/**/*.savi"
+
+  :dependency ByteStream "TODO: specify version"
+  :dependency IO "TODO: specify version"
+  :transitive dependency OSError "TODO: specify version"

--- a/packages/src/IO/IO.savi
+++ b/packages/src/IO/IO.savi
@@ -18,9 +18,15 @@
   :fun ref react(event CPointer(AsioEvent), flags U32, arg U32) @
     :yields ActionType for None
 
+  :fun ref deferred_actions @
+    :yields ActionType for None
+
 :trait tag IO.Actor(ActionType val)
   :fun io @->(IO.Engine(ActionType)) // TODO: somehow private... allow the trait to use this, but make it private to other callers?
   :fun ref _io_react(action ActionType) @
+
+  :be io_deferred_actions // TODO: somehow private...
+    @io.deferred_actions -> (action | @_io_react(action))
 
   :: This is a special behaviour that hooks into the AsioEventNotify runtime,
   :: called whenever an event handle we're subscribed to receives an event.
@@ -57,6 +63,7 @@
 
   :new
 
+  // TODO: Make private or move to another package:
   :new new_tcp_connect!(
     actor AsioEventNotify
     host String
@@ -71,10 +78,16 @@
     if (connect_count == 0) error!
     @_pending_connect_count = connect_count
 
+  // TODO: Make private or move to another package:
   :new new_from_fd_rw(actor AsioEventNotify, @_fd)
     asio_flags =
       if Platform.windows (AsioEvent.read_write | AsioEvent.read_write_oneshot)
     @_event = AsioEvent.create(actor, @_fd, asio_flags, 0, True)
+
+  // TODO: Make private or move to another package:
+  :new new_from_fd_r(actor AsioEventNotify, @_fd)
+    asio_flags = AsioEvent.read
+    @_event = AsioEvent.create(actor, @_fd, AsioEvent.read, 0, True)
 
   :fun ref _clear_state_after_final_dispose
     @_event = AsioEvent.none
@@ -140,6 +153,11 @@
     @_fd = fd
     @_is_writable = True // TODO: Remove these lines?
     @_is_readable = True // TODO: Remove these lines?
+    @
+
+  :fun ref deferred_actions
+    :yields IO.Action for None
+    // TODO
     @
 
   :fun ref react(event CPointer(AsioEvent), flags U32, arg U32) @

--- a/packages/src/Savi/Env.Root.TicketIssuer.savi
+++ b/packages/src/Savi/Env.Root.TicketIssuer.savi
@@ -1,0 +1,29 @@
+:actor Env.Root.TicketIssuer
+  :new _new // private constructor for security
+
+  // TODO: Use a generic Accessible trait
+  :be access(courier Env.Root.TicketIssuer.Courier.Any): courier.call(@)
+
+  :var _issued_ticket_types Array(Any'non): []
+
+  :fun ref mark_as_issued_if_available!(ticket_type Any'non)
+    error! if @_issued_ticket_types.includes(ticket_type)
+    @_issued_ticket_types.push(ticket_type)
+
+:trait iso Env.Root.TicketIssuer.Ticket
+  :new iso new_from_issuer!(issuer Env.Root.TicketIssuer'ref)
+
+// TODO: Probably remove this glue trait when we have proper lambdas.
+:trait val Env.Root.TicketIssuer.Courier.Any
+  :fun val call(issuer Env.Root.TicketIssuer'ref) None
+
+// TODO: Probably remove this glue class when we have proper lambdas.
+:class val Env.Root.TicketIssuer.Courier(T Env.Root.TicketIssuer.Ticket'iso)
+  :let recipient Env.Root.TicketIssuer.Recipient(T)
+  :new val (@recipient)
+  :fun val call(issuer Env.Root.TicketIssuer'ref) None
+    @recipient.accept_ticket(try T.new_from_issuer!(issuer))
+
+// TODO: Probably remove this glue trait when we have proper lambdas.
+:trait tag Env.Root.TicketIssuer.Recipient(T Any'iso)
+  :be accept_ticket(ticket (T | None))

--- a/packages/src/Savi/Env.savi
+++ b/packages/src/Savi/Env.savi
@@ -2,8 +2,16 @@
   :let out StdStream
   :let err StdStream
   :let args Array(String'val)
-  :let vars EnvVars
+  :let vars Env.Vars
+  :let root: Env.Root._new
 
+  :: Create an instance of `Env`. This is private for security reasons.
+  ::
+  :: That is, the `Env` object capability is the root of trust and authority
+  :: for an application, and the trust model relies on it being unforgeable,
+  :: with the only instance of it being given out to the `Main` actor,
+  :: which can then use it or distribute it (or as a better pattern,
+  :: distribute more limited authority objects derived from it) as needed.
   :new val _create(
     argc I32
     argv CPointer(CPointer(U8)'ref)'ref
@@ -22,12 +30,17 @@
       i += 1
     )
 
-    @vars = EnvVars._from_envp(envp)
+    @vars = Env.Vars._from_envp(envp)
 
   :fun "exit_code="(value)
     LibPony.pony_exitcode(value)
 
-:struct val EnvVars
+:struct val Env.Root
+  :let ticket_issuer Env.Root.TicketIssuer
+  :new val _new // private constructor for security
+    @ticket_issuer = Env.Root.TicketIssuer._new
+
+:struct val Env.Vars
   :let _vars Array(Pair(String))
 
   :new val _from_envp(envp CPointer(CPointer(U8)'ref)'ref)

--- a/packages/src/StdIn/Actor.savi
+++ b/packages/src/StdIn/Actor.savi
@@ -1,0 +1,8 @@
+// TODO: Documentation
+:trait StdIn.Actor
+  :is IO.Actor(IO.Action)
+
+  :is Env.Root.TicketIssuer.Recipient(StdIn.Ticket)
+
+  :fun io @->(StdIn.Engine)
+  :be accept_ticket(ticket (StdIn.Ticket | None)): @io.run(--ticket)

--- a/packages/src/StdIn/Engine.savi
+++ b/packages/src/StdIn/Engine.savi
@@ -1,0 +1,155 @@
+:ffi LibPony
+  :fun pony_os_stdin_setup Bool
+  :fun pony_os_stdin_read(buffer CPointer(U8), size USize) USize
+
+// TODO: Documentation
+:class StdIn.Engine
+  :is IO.Engine(IO.Action)
+  :is ByteStream.Source
+
+  :let _actor IO.Actor(IO.Action)
+
+  :var _deferred_action_opened: False
+  :var _deferred_action_open_failed: False
+  :var _deferred_action_read: False
+
+  :let read_stream: ByteStream.Reader.new
+
+  :var _evented_core (IO.CoreEngine | None): None
+  :fun _has_evented_core: @_evented_core !<: None
+
+  :var _ticket (StdIn.Ticket | None): None
+  :fun has_ticket: @_ticket !<: None
+
+  :new (@_actor) // Note that we don't actually start until `run` is called
+
+  :fun ref run(ticket (StdIn.Ticket | None))
+    if (ticket <: StdIn.Ticket) (
+      @_ticket = --ticket
+      @_setup_core
+      @_deferred_action_opened = True
+    |
+      @_deferred_action_open_failed = True
+    )
+    @_actor.io_deferred_actions
+
+  // TODO: Allow extracting the ticket with :fun ref dispose
+  // Thus allowing you to read part of the stdin stream with one actor,
+  // then transfer authority to another actor after decommissioning the first.
+
+  :fun ref _setup_core
+    // We use an evented core only if `pony_os_stdin_setup` returns true.
+    // We'll use a non-evented core on unix systems where the stdin fd comes
+    // from a file instead of from a tty (which is properly evented).
+    @_evented_core =
+      if LibPony.pony_os_stdin_setup IO.CoreEngine.new_from_fd_r(@_actor, 0)
+
+    // If we have no evented core, immediately begin reading by deferring
+    // a read action, which will end up repeating until reading is done.
+    if !@_has_evented_core (
+      @_deferred_action_read = True
+    )
+
+  :fun ref deferred_actions
+    // If we have a deferred action from opening, yield it now.
+    case (
+    | @_deferred_action_opened |
+      @_deferred_action_opened = False
+      yield IO.Action.Opened
+
+    | @_deferred_action_open_failed |
+      @_deferred_action_open_failed = False
+      yield IO.Action.OpenFailed
+    )
+
+    if @_deferred_action_read (
+      @_deferred_action_read = False
+
+      // Try to read.
+      did_read = @_read_if_available
+      if did_read (
+        yield IO.Action.Read
+      |
+        // If we weren't able to read anything, and we're in a non-evented mode,
+        // mark the stream as closed and emit the "closed" action.
+        // We won't try to read anything again.
+        if !@_has_evented_core (
+          yield IO.Action.Closed
+        )
+      )
+    )
+
+    // TODO: Enable this section:
+    // // If we have an evented core, run any deferred actions it needs to run.
+    // evented_core = @_evented_core
+    // if (evented_core <: IO.CoreEngine) (
+    //   evented_core.deferred_actions -> (action | yield action)
+    // )
+
+    @
+
+  :fun ref react(event CPointer(AsioEvent), flags U32, arg U32) @
+    :yields IO.Action for None
+    evented_core = @_evented_core
+    if (evented_core <: IO.CoreEngine) (
+      evented_core.react(event, flags, arg) -> (action |
+        case action == (
+        | IO.Action.Read | if @_read_if_available (yield IO.Action.Read)
+        | yield action
+        )
+      )
+    )
+    @
+
+  :fun ref _read_if_available Bool
+    did_read = try (
+      bytes_read = @read_stream.receive_from!(@)
+
+      // If we've reached the end of the stream, close things out.
+      if (bytes_read == 0) (
+        // Close the evented core.
+        evented_core = @_evented_core
+        if (evented_core <: IO.CoreEngine) (
+          // TODO: We need to disentangle the core engine from TCP stuff,
+          // because this function also tries to close the socket.
+          // We only call this function here to unsubscribe the ASIO event.
+          evented_core.hard_close
+        )
+
+        return False
+      )
+
+      True // we did read something
+    |
+      False // there was nothing to read now, but the stream is still open
+    )
+
+    // If we read some amount of bytes, ask the actor to call us again soon,
+    // so we can try again to read more bytes, until there's nothing to read.
+    if did_read (
+      @_deferred_action_read = True
+      @_actor.io_deferred_actions
+    )
+
+    did_read
+
+  :: Receive bytes into the given read buffer, starting at the given offset.
+  :fun ref emit_bytes_into!(read_buffer Bytes'ref, offset USize) USize
+    // Raise an error if there is no space left in the buffer.
+    if (offset >= read_buffer.space) error!
+
+    // Read into the buffer.
+    bytes_read = LibPony.pony_os_stdin_read(
+      read_buffer.cpointer(offset)
+      read_buffer.space - offset
+    )
+
+    // Raise an error if there was nothing available to read right now.
+    if (bytes_read == -1) error!
+
+    // Update the size of the buffer with the newly filled bytes.
+    new_size = offset + bytes_read
+    read_buffer.resize_possibly_including_uninitialized_memory(new_size)
+
+    // Return the number of bytes that were read into the buffer.
+    bytes_read

--- a/packages/src/StdIn/Ticket.savi
+++ b/packages/src/StdIn/Ticket.savi
@@ -1,0 +1,14 @@
+// TODO: Documentation
+:class iso StdIn.Ticket
+  :is Env.Root.TicketIssuer.Ticket
+
+  :fun non get(
+    issuer Env.Root.TicketIssuer
+    recipient Env.Root.TicketIssuer.Recipient(StdIn.Ticket)
+  )
+    courier = Env.Root.TicketIssuer.Courier(StdIn.Ticket).new(recipient)
+    issuer.access(courier)
+
+  :: This constructor can only be called via the `Env.Root.TicketIssuer`
+  :new iso new_from_issuer!(issuer Env.Root.TicketIssuer'ref)
+    issuer.mark_as_issued_if_available!(@)

--- a/packages/src/TCP/ConnectionEngine.savi
+++ b/packages/src/TCP/ConnectionEngine.savi
@@ -33,6 +33,11 @@
 
   :new _new_with_io(@io)
 
+  :fun ref deferred_actions
+    :yields IO.Action for None
+    // TODO
+    @
+
   :fun ref react(event CPointer(AsioEvent), flags U32, arg U32) @
     :yields IO.Action
     @io.react(event, flags, arg) -> (action |

--- a/spec/integration/run-one.sh
+++ b/spec/integration/run-one.sh
@@ -76,6 +76,30 @@ test_fixed_files_content() {
   done
 }
 
+# Test that the output of running the compiler matches the expected errors.
+test_run_output() {
+  actual=$(env SAVI="$SAVI" sh -c "cd $subdir && ./savi.run.test.sh")
+  expected=$(cat $subdir/savi.run.output.txt)
+  if [ "$actual" != "$expected" ]; then
+    echo "---"
+    echo "---"
+    echo
+    echo "FAIL $subdir"
+    echo
+    echo "---"
+    echo
+    echo "EXPECTED $expected"
+    echo
+    echo "---"
+    echo
+    echo "ACTUAL $actual"
+    echo
+    echo "---"
+    echo "---"
+    return 1
+  fi
+}
+
 # If this subdirectory has auto-fix information, use that testing strategy.
 if [ -d "$subdir/savi.fix.before.dir" ] \
 && [ -d "$subdir/savi.fix.after.dir" ] \
@@ -105,6 +129,11 @@ if [ -d "$subdir/savi.fix.before.dir" ] \
 # If this subdirectory has an expected errors file, use that testing strategy.
 elif [ -f "$subdir/savi.errors.txt" ]; then
   test_error_output
+
+# If this subdirectory has a script and expected output file, use that strategy.
+elif [ -f "$subdir/savi.run.test.sh" ] \
+  && [ -f "$subdir/savi.run.output.txt" ]; then
+  test_run_output
 
 ## NOTE: When adding new testing strategy, also add a description to the
 ##       integration testing documentation in `spec/integration/README.md`

--- a/spec/integration/run-stdin-from-file/manifest.savi
+++ b/spec/integration/run-stdin-from-file/manifest.savi
@@ -1,0 +1,7 @@
+:manifest "example"
+  :sources "src/*.savi"
+
+  :dependency StdIn "TODO: specify version"
+  :dependency IO "TODO: specify version"
+  :transitive dependency ByteStream "TODO: specify version"
+  :transitive dependency OSError "TODO: specify version"

--- a/spec/integration/run-stdin-from-file/savi.run.output.txt
+++ b/spec/integration/run-stdin-from-file/savi.run.output.txt
@@ -1,0 +1,5 @@
+IO.Action.Opened
+IO.Action.Read
+foo
+bar
+IO.Action.Closed

--- a/spec/integration/run-stdin-from-file/savi.run.test.sh
+++ b/spec/integration/run-stdin-from-file/savi.run.test.sh
@@ -1,0 +1,3 @@
+$SAVI
+file=$(mktemp)
+sh -c "echo foo; echo bar" > $file; bin/example < $file

--- a/spec/integration/run-stdin-from-file/src/Main.savi
+++ b/spec/integration/run-stdin-from-file/src/Main.savi
@@ -1,0 +1,18 @@
+:actor Main
+  :new (env)
+    ExampleStdIn.new(env)
+
+:actor ExampleStdIn
+  :is StdIn.Actor
+  :let env Env
+  :let io StdIn.Engine
+  :new (@env)
+    @io = StdIn.Engine.new(@)
+    StdIn.Ticket.get(@env.root.ticket_issuer, @)
+
+  :fun ref _io_react(action IO.Action)
+    @env.out.print(Inspect[action])
+    if (action == IO.Action.Read) (
+      @env.out.write(@io.read_stream.advance_to_end.extract_token.as_string)
+    )
+    @

--- a/spec/integration/run-stdin-from-pipe/manifest.savi
+++ b/spec/integration/run-stdin-from-pipe/manifest.savi
@@ -1,0 +1,7 @@
+:manifest "example"
+  :sources "src/*.savi"
+
+  :dependency StdIn "TODO: specify version"
+  :dependency IO "TODO: specify version"
+  :transitive dependency ByteStream "TODO: specify version"
+  :transitive dependency OSError "TODO: specify version"

--- a/spec/integration/run-stdin-from-pipe/savi.run.output.txt
+++ b/spec/integration/run-stdin-from-pipe/savi.run.output.txt
@@ -1,0 +1,6 @@
+IO.Action.Opened
+IO.Action.Read
+foo
+IO.Action.Read
+bar
+IO.Action.Closed

--- a/spec/integration/run-stdin-from-pipe/savi.run.test.sh
+++ b/spec/integration/run-stdin-from-pipe/savi.run.test.sh
@@ -1,0 +1,2 @@
+$SAVI
+sh -c 'echo foo; sleep 0.5; echo bar' | bin/example

--- a/spec/integration/run-stdin-from-pipe/src/Main.savi
+++ b/spec/integration/run-stdin-from-pipe/src/Main.savi
@@ -1,0 +1,18 @@
+:actor Main
+  :new (env)
+    ExampleStdIn.new(env)
+
+:actor ExampleStdIn
+  :is StdIn.Actor
+  :let env Env
+  :let io StdIn.Engine
+  :new (@env)
+    @io = StdIn.Engine.new(@)
+    StdIn.Ticket.get(@env.root.ticket_issuer, @)
+
+  :fun ref _io_react(action IO.Action)
+    @env.out.print(Inspect[action])
+    if (action == IO.Action.Read) (
+      @env.out.write(@io.read_stream.advance_to_end.extract_token.as_string)
+    )
+    @

--- a/src/savi/compiler/infer/meta_type/intersection.cr
+++ b/src/savi/compiler/infer/meta_type/intersection.cr
@@ -444,6 +444,10 @@ struct Savi::Compiler::Infer::MetaType::Intersection
     # multiple terms to work with here.
     return false if terms.size == 1
 
+    # If the other term was a concrete type, we have failed the test.
+    # No type is a subtype of a concrete type except itself.
+    return false if other.is_concrete?
+
     # However we have not yet implemented this logic.
     # TODO: we may have to do something subtle here when dealing with
     # subtyping of intersections of traits, where multiple traits


### PR DESCRIPTION
The new `StdIn` package will allow Savi programs to read from the "stdin" stream.

We also add a new mechanism for producing single-owner authority tokens (for now called "tickets") using an actor called `Env.Root.TicketIssuer`, which can issue for any type without knowing the type ahead of time, and will issue at most one ticket of that type.

This is the mechanism of authority we use to put `StdIn` outside of the core Savi library, without sacrificing the property that only one actor can read from stdin at a time.

That is, to run an actor that uses `StdIn.Engine`, that actor must first acquire the `StdIn.Ticket`, which is an `iso` object that cannot have more than one instance in the program, via using the `Env.Root.TicketIssuer` as a central authority for issuing it. Just like the other object capabilities we will use (and like object capabilities in Pony), the authority to issue a ticket is derived via `Env.Root`, which is the root of trust for authority in a program, given directly to the `Main` actor, which can then use dole out sub-authorities to other places in the code as desired.

The specific way we get the ticket out of the `Env.Root.TicketIssuer` and into the desired actor will likely change once we have proper lambdas in the language (#130), but for now this mechanism is sufficient.