### PR TITLE
Add initial `Bytes.Slice` type.

### DIFF
--- a/packages/src/ByteStream/ChunkedSink.savi
+++ b/packages/src/ByteStream/ChunkedSink.savi
@@ -1,13 +1,8 @@
 :: This trait is meant to create a common interface that can receive chunks
-:: from a ByteStream.ChunkedWriter. It is currently designed to only be really
-:: usable with an FFI-using I/O sink, since it gives opaque data pointers.
-::
-:: TODO: Refactor to use an Array(BytesSlice) instead of Array(CPointer(U8)),
-:: where BytesSlice is a new struct type that has a pointer and a size field,
-:: placed in memory in a platform-dependent order because Windows and POSIX
-:: expect their writev struct elements to be in an opposite order.
+:: from a ByteStream.ChunkedWriter. It takes an `Array(Bytes.Slice)`, which
+:: is ABI-compatible with the `writev` system call, without restructuring.
 :trait ByteStream.ChunkedSink
   :fun box is_writable Bool
-  :fun ref writev_windows!(data_pairs Array(CPointer(U8)), offset USize) None
-  :fun ref writev_posix!(data_pairs Array(CPointer(U8)), offset USize) USize
+  :fun ref writev_windows!(chunks Array(Bytes.Slice), offset USize) None
+  :fun ref writev_posix!(chunks Array(Bytes.Slice), offset USize) USize
   :fun non writev_posix_max_chunks USize

--- a/packages/src/ByteStream/ChunkedWriter.savi
+++ b/packages/src/ByteStream/ChunkedWriter.savi
@@ -7,7 +7,7 @@
 :class ByteStream.ChunkedWriter
   :is ByteStream.Writable
 
-  :let _data_pairs Array(CPointer(U8)): []
+  :let _chunks Array(Bytes.Slice): []
   :var _total_size USize: 0
   :var _windows_unacknowledged_chunks USize: 0
   :var _windows_unacknowledged_total_size USize: 0
@@ -16,29 +16,8 @@
   ::
   :: It won't actually get written until the flush method is called.
   :fun ref "<<"(chunk Bytes'val)
-    // In @_data_pairs, we hold on to the data chunk pointer, as well as a
-    // fake pointer representing the size of the data chunk to be written,
-    // because a writev system call always interleaves both.
-    //
-    // The reason we convert the size into a fake pointer is so that
-    // we can still have a homogenous element type for the writev array,
-    // and because we can't drop the real pointer to a USize since that
-    // would remove it from garbage collector tracing, possibly allowing
-    // it to be deallocated between behaviors, despite still being "held".
-    //
-    // Windows wants them in the opposite order from what POSIX wants,
-    // so we deal with that here and everywhere else we use the _data_pairs.
-    if Platform.windows (
-      @_data_pairs << CPointer(U8).from_usize(chunk.size)
-      @_data_pairs << chunk.cpointer
-    |
-      @_data_pairs << chunk.cpointer
-      @_data_pairs << CPointer(U8).from_usize(chunk.size)
-    )
-
-    // Also track the total size of all chunks.
+    @_chunks << chunk.as_slice
     @_total_size += chunk.size
-
     @
 
   :: Try to write all buffered data to the given target.
@@ -50,10 +29,10 @@
   :: then no data will be written and it was useless to make this call.
   :fun ref flush(target ByteStream.ChunkedSink) Bool
     case (
-    | @_total_size == 0       | True  // nothing left to flush
+    | @_total_size == 0      | True  // nothing left to flush
     | target.is_writable.not | False // can't flush right now
-    | Platform.windows        | @_flush_windows(target)
-    |                           @_flush_posix(target)
+    | Platform.windows       | @_flush_windows(target)
+    |                          @_flush_posix(target)
     )
 
   :fun ref _flush_posix(target ByteStream.ChunkedSink) Bool
@@ -63,21 +42,20 @@
 
     try (
       while (@_total_size > 0) (
-        total_pairs = @_data_pairs.size / 2
-        if (total_pairs < writev_max_chunks) (
-          num_to_send = total_pairs
+        if (@_chunks.size < writev_max_chunks) (
+          num_to_send = @_chunks.size
           bytes_to_send = @_total_size
         |
           num_to_send = writev_max_chunks
           // TODO: This could be done with an equivalent reduce
           bytes_to_send = 0
-          @_data_pairs.each(1, num_to_send * 2, 2) -> (size_ptr |
-            bytes_to_send += size_ptr.usize
+          @_chunks.each(0, num_to_send) -> (chunk |
+            bytes_to_send += chunk.size
           )
         )
 
-        bytes_written = target.writev_posix!(@_data_pairs, num_to_send)
-        @_manage_data_pairs(bytes_written, bytes_to_send, num_to_send)
+        bytes_written = target.writev_posix!(@_chunks, num_to_send)
+        @_manage_chunks(bytes_written, bytes_to_send, num_to_send)
       )
       True
     |
@@ -86,8 +64,8 @@
 
   :fun ref _flush_windows(target ByteStream.ChunkedSink) Bool
     try (
-      target.writev_windows!(@_data_pairs, @_windows_unacknowledged_chunks * 2)
-      @_windows_unacknowledged_chunks += @_data_pairs.size / 2 // TODO: remove cancelled-out *2/2 ?
+      target.writev_windows!(@_chunks, @_windows_unacknowledged_chunks)
+      @_windows_unacknowledged_chunks += @_chunks.size
       @_windows_unacknowledged_total_size = @_total_size
       True
     |
@@ -95,14 +73,14 @@
     )
 
   :fun ref acknowledge_writes_windows(bytes_written USize)
-    @_manage_data_pairs(
+    @_manage_chunks(
       bytes_written
       @_windows_unacknowledged_total_size
       @_windows_unacknowledged_chunks
     )
     @
 
-  :fun ref _manage_data_pairs(
+  :fun ref _manage_chunks(
     bytes_sent USize
     bytes_to_send USize
     num_to_send USize
@@ -111,27 +89,18 @@
     if (bytes_sent == bytes_to_send) (
       // Fast path for the case of having sent all bytes we wanted to send.
       // We can simply trim the intended number of chunks.
-      @_data_pairs.trim_in_place(num_to_send * 2)
+      @_chunks.trim_in_place(num_to_send)
     |
-      // Otherwise, we need to iterate through the pending_writev pairs,
+      // Otherwise, we need to iterate through the pending writev chunks,
       // Clearing away those that are already sent, but keeping the rest.
-
-      // The packing of data pointers and corresponding sizes (fake pointers)
-      // is platform-dependent, because the writev call works differently.
-      first_size_ptr_index = if Platform.windows (0 | 1)
 
       // Find the index of the first chunk size pointer that was not fully sent,
       // and also get a count of how many bytes worth of size were sent in it.
       further_bytes_sent = bytes_sent
-      lingering_size_ptr_index = try (
-        @_data_pairs.find_index!(
-          first_size_ptr_index
-          USize.max_value
-          2
-        ) -> (chunk_size_ptr |
-          chunk_size = chunk_size_ptr.usize
+      lingering_chunk_index = try (
+        @_chunks.find_index! -> (chunk |
           try (
-            further_bytes_sent = further_bytes_sent -! chunk_size
+            further_bytes_sent = further_bytes_sent -! chunk.size
             False
           |
             True
@@ -146,28 +115,20 @@
         // by just using an index beyond the end of the array size,
         // which will cause us to trim away everything in the array.
         further_bytes_sent = 0
-        @_data_pairs.size + first_size_ptr_index
+        @_chunks.size
       )
 
       // If the lingering chunk was only partially sent, we need to trim it.
       if (further_bytes_sent > 0) (
-        lingering_data_ptr_index = lingering_size_ptr_index +
-          if Platform.windows (1 | -1)
         try (
-          @_data_pairs.replace_at!(lingering_data_ptr_index) -> (data_ptr |
-            data_ptr.offset(further_bytes_sent)
-          )
-        )
-        try (
-          @_data_pairs.replace_at!(lingering_size_ptr_index) -> (size_ptr |
-            CPointer(U8).from_usize(size_ptr.usize - further_bytes_sent)
+          @_chunks.replace_at!(lingering_chunk_index) -> (chunk |
+            chunk.trim(further_bytes_sent)
           )
         )
       )
 
       // Trim the left side of the array to remove the fully sent bytes.
-      trim_index = lingering_size_ptr_index - first_size_ptr_index
-      @_data_pairs.trim_in_place(trim_index)
+      @_chunks.trim_in_place(lingering_chunk_index)
     )
     @
 

--- a/packages/src/IO/IO.savi
+++ b/packages/src/IO/IO.savi
@@ -98,11 +98,13 @@
     @_is_send_shutdown = True
     @_is_recv_shutdown = True
 
-  :fun ref writev_windows!(data_pairs Array(CPointer(U8)), offset USize) None
-    LibPonyOs.pony_os_writev!(@_event, data_pairs.cpointer, data_pairs.size / 2)
+  // TODO: Why is the offset parameter not being used here?
+  :fun ref writev_windows!(chunks Array(Bytes.Slice), offset USize) None
+    LibPonyOs.pony_os_writev!(@_event, chunks.cpointer, chunks.size)
 
-  :fun ref writev_posix!(data_pairs Array(CPointer(U8)), offset USize) USize
-    LibPonyOs.pony_os_writev!(@_event, data_pairs.cpointer, data_pairs.size / 2)
+  // TODO: Why is the offset parameter not being used here?
+  :fun ref writev_posix!(chunks Array(Bytes.Slice), offset USize) USize
+    LibPonyOs.pony_os_writev!(@_event, chunks.cpointer, chunks.size)
 
   :fun non writev_posix_max_chunks USize: LibPonyOs.pony_os_writev_max
 

--- a/packages/src/IO/lib.savi
+++ b/packages/src/IO/lib.savi
@@ -11,7 +11,7 @@
   :fun pony_os_socket_close(fd U32) None
   :fun pony_os_socket_shutdown(fd U32) None
   :fun pony_os_writev_max USize
-  :fun pony_os_writev!(event CPointer(AsioEvent), iov CPointer(CPointer(U8)), count USize) USize
+  :fun pony_os_writev!(event CPointer(AsioEvent), iov CPointer(Bytes.Slice), count USize) USize
   :fun pony_os_recv!(event CPointer(AsioEvent), buffer CPointer(U8), count USize) USize
   :fun pony_os_errno OSError
 

--- a/packages/src/Savi/Bytes.Slice.savi
+++ b/packages/src/Savi/Bytes.Slice.savi
@@ -1,0 +1,32 @@
+// TODO: Documentation
+//
+// TODO: Many more methods, duplicating most of the Bytes methods,
+// apart from the mutating ones, obviously.
+:struct val Bytes.Slice
+  // TODO: Platform-specific field order - on Windows writev, size comes first.
+  //
+  // As ugly as it would be, we can probably just hard-code this special case
+  // in the code gen pass of the compiler if we can't come up with a clean
+  // language feature for this that serves other use cases beyond this one.
+  //
+  // It's unfortunate that the implementation of libc writev affects us here
+  // but on the other hand, it wouldn't make sense to duplicate the otherwise
+  // identical purpose in another type that differed only in field order.
+  // Also, field order has no other impact on Savi semantics apart from FFI
+  // interaction, so at least the platform-dependent ordering won't have an
+  // impact outside of the limited scope of how it interacts with FFI.
+  :let _ptr CPointer(U8)'val
+  :let _size USize
+  :new val from_cpointer(@_ptr, @_size)
+
+  :fun size: @_size
+
+  :fun val trim(from USize = 0, to = USize.max_value)
+    try (
+      finish = to.max(@_size)
+      size = finish -! from
+      @from_cpointer(@_ptr._offset(from)._unsafe_val, size)
+    |
+      @from_cpointer(@_ptr._null._unsafe_val, 0)
+    )
+

--- a/packages/src/Savi/Bytes.savi
+++ b/packages/src/Savi/Bytes.savi
@@ -44,6 +44,7 @@
     @_space = data.space
     @_ptr = data.cpointer._unsafe
 
+  :fun val as_slice: Bytes.Slice.from_cpointer(@_ptr, @_size)
   :fun val as_array: Array(U8).val_from_cpointer(@_ptr._unsafe, @_size, @_space)
   :fun val as_string: String.from_bytes(@)
 

--- a/packages/src/Savi/CPointer.savi
+++ b/packages/src/Savi/CPointer.savi
@@ -42,6 +42,15 @@
   :: The caller is expected to only do this for memory they know that they own.
   :fun tag _unsafe @'ref: compiler intrinsic
 
+  :: Allow unsafely converting from a opaque capability to an immutable one,
+  :: which is required for the internals of this package, but obviously
+  :: not suitable for capability safety in general programs.
+  ::
+  :: The caller is expected to only do this for memory they know that they
+  :: can guarantee will never be mutated in the future, at least until all
+  :: references to that region of memory have been garbage-collected.
+  :fun tag _unsafe_val @'val: compiler intrinsic
+
   :: Get a pointer that points to a subset of this original pointer's memory,
   :: starting at the given element index from the current pointer's address,
   :: as a basic building block for operations that begin starting at an offset.

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -870,7 +870,7 @@ class Savi::Compiler::CodeGen
         llvm_func.add_attribute(LLVM::Attribute::DereferenceableOrNull, LLVM::AttributeIndex::ReturnIndex, elem_size_value)
         llvm_func.add_attribute(LLVM::Attribute::Alignment, LLVM::AttributeIndex::ReturnIndex, PonyRT::HEAP_MIN)
         @runtime.gen_intrinsic_cpointer_realloc(self, params, llvm_type, elem_size_value)
-      when "_unsafe"
+      when "_unsafe", "_unsafe_val"
         params[0]
       when "_offset", "offset"
         @builder.bit_cast(


### PR DESCRIPTION
Currently this type does almost nothing, but in the future it will
expose most of the read-only methods present on the `Bytes` type.

This allows us to clean up the implementation of some things in
`ByteStream.ChunkedWriter` and `ByteStream.ChunkedSink`,
which will also pave the way for us to have a `ByteStream.Pipe`
in the future, by having the byte slices be stored in form that
is safe (pointer-tamper-proof) but also efficient and compatible
with `writev` system calls without copying into other data structures.

In a future change, when we add the missing methods from `Bytes`
into `Bytes.Slice`, we will also add corresponding `:trait`s for
all shared features, so that we can keep the two in sync and
reduce some of the code duplication of having two different ways
to deal with an immutable sequence of bytes.
