### PR TITLE
Add `ByteStream.Sink.ToReader`.

### DIFF
--- a/packages/spec/ByteStream/Reader.Spec.savi
+++ b/packages/spec/ByteStream/Reader.Spec.savi
@@ -9,7 +9,7 @@
 
   :it "can accept chunks, advance, and read tokens"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     initial_space = stream.space_ahead
 
     assert: stream.bytes_ahead == 0
@@ -21,6 +21,7 @@
 
     // Add a chunk so that those bytes are available for reading.
     write_stream << b"hello"
+    write_stream.flush
     assert: stream.bytes_ahead == 5
     assert: stream.bytes_ahead_of_marker == 5
     assert: stream.space_ahead == initial_space
@@ -59,6 +60,7 @@
     // Add some more chunks.
     write_stream << b"world"
     write_stream << b"lings"
+    write_stream.flush
     assert: stream.bytes_ahead == 15
     assert: stream.bytes_ahead_of_marker == 15
     assert: stream.space_ahead == initial_space
@@ -176,10 +178,11 @@
 
   :it "extracts an isolated token destructively from the stream"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
+    write_stream.flush
 
     try stream.advance!(2).mark_here.advance!(6)
 
@@ -190,10 +193,11 @@
 
   :it "yields each byte of a token"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
+    write_stream.flush
 
     collected Array(U8) = []
 
@@ -214,10 +218,11 @@
 
   :it "yields each byte of a token until the block returns True"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
+    write_stream.flush
 
     collected Array(U8) = []
 
@@ -236,10 +241,11 @@
 
   :it "compares a token for equivalence to a given string"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
+    write_stream.flush
 
     // Compare the entire stream.
     stream.advance_to_end
@@ -260,10 +266,11 @@
 
   :it "compares an ASCII-lowercased token for equivalence to a given string"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"HeL"
     write_stream << b"LoWo"
     write_stream << b"RlD"
+    write_stream.flush
 
     // Compare the entire stream.
     stream.advance_to_end
@@ -284,10 +291,11 @@
 
   :it "parses a token as a positive integer in decimal notation"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"192"
     write_stream << b"8374"
     write_stream << b"650"
+    write_stream.flush
 
     // Parse the entire stream as an integer.
     stream.advance_to_end
@@ -302,14 +310,16 @@
 
     // Add an invalid character to the stream and get an error.
     write_stream << b":" // only digits (0-9) are valid
+    write_stream.flush
     stream.advance_to_end
     assert error: stream.token_as_positive_integer!
 
   :it "reads integers in native, big and little endianness at specific offsets"
     stream = ByteStream.Reader.new
-    write_stream = TestByteStreamSource.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"garbage"
     write_stream << Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
+    write_stream.flush
     try stream.advance!(7) // drop "garbage"
     stream.mark_here
     stream.advance_to_end
@@ -334,28 +344,3 @@
     assert: stream.read_be_u32!(1) == 0x23456789
     assert: stream.read_be_u64!(0) == 0x0123456789ABCDEF
     assert: stream.read_be_u64!(1) == 0x23456789ABCDEF01
-
-
-// This is a utility class used here in testing as a way to get chunks
-// inserted into the byte stream of a ByteStream.Reader, one chunk at a time.
-:class TestByteStreamSource
-  // On creation, accept a ByteStream.Reader to target.
-  :let _target_read_stream ByteStream.Reader
-  :new (@_target_read_stream)
-
-  // When a new chunk is accepted, add it to the list we hold and invoke
-  // the target's receive_from! method, using us as the source, indirectly
-  // invoking the emit_bytes_into! method back here in our own class.
-  :let _chunks: Array(Bytes).new
-  :fun ref "<<"(chunk Bytes)
-    @_chunks << chunk
-    try @_target_read_stream.receive_from!(@)
-    @
-
-  // We are a source of bytes, able to push all available bytes into the buffer.
-  :is ByteStream.Source
-  :fun ref emit_bytes_into!(buffer Bytes'ref, offset USize)
-    orig_size = buffer.size
-    @_chunks.each -> (chunk | chunk.each -> (byte | buffer.push(byte)))
-    @_chunks.clear
-    buffer.size - orig_size

--- a/packages/spec/HTTPServer/RequestReader.Spec.savi
+++ b/packages/spec/HTTPServer/RequestReader.Spec.savi
@@ -74,7 +74,7 @@
     :yields HTTPServer.Request
     reader = HTTPServer.RequestReader.new
     stream = ByteStream.Reader.new
-    write_stream = TestByteStream.Source.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
 
     // Feed the data one byte at a time into the stream, which will
     // maximally test for parsing state problems at chunk boundaries.
@@ -97,6 +97,7 @@
             )
           )
           write_stream << Bytes.from_array([byte])
+          write_stream.flush
         )
       )
     )
@@ -133,7 +134,7 @@
   ) Bool
     reader = HTTPServer.RequestReader.new
     stream = ByteStream.Reader.new
-    write_stream = TestByteStream.Source.new(stream)
+    write_stream = ByteStream.Writer.to_reader(stream)
 
     // Feed the data one byte at a time into the stream, which will
     // maximally test for parsing state problems at chunk boundaries.
@@ -156,6 +157,7 @@
             )
           )
           write_stream << Bytes.from_array([byte])
+          write_stream.flush
         )
       )
     )
@@ -183,28 +185,3 @@
       @env.err.print(" to have an error, but it finished successfully")
       False
     )
-
-// This is a utility class used here in testing as a way to get chunks
-// inserted into the byte stream of a ByteStream.Reader, one chunk at a time.
-// TODO: Is there a better way to share this across different packages' tests?
-:class TestByteStream.Source
-  // On creation, accept a ByteStream.Reader to target.
-  :let _target_read_stream ByteStream.Reader
-  :new (@_target_read_stream)
-
-  // When a new chunk is accepted, add it to the list we hold and invoke
-  // the target's receive_from! method, using us as the source, indirectly
-  // invoking the emit_bytes_into! method back here in our own class.
-  :let _chunks: Array(Bytes).new
-  :fun ref "<<"(chunk Bytes)
-    @_chunks << chunk
-    try @_target_read_stream.receive_from!(@)
-    @
-
-  // We are a source of bytes, able to push all available bytes into the buffer.
-  :is ByteStream.Source
-  :fun ref emit_bytes_into!(buffer Bytes'ref, offset USize)
-    orig_size = buffer.size
-    @_chunks.each -> (chunk | chunk.each -> (byte | buffer.push(byte)))
-    @_chunks.clear
-    buffer.size - orig_size

--- a/packages/src/ByteStream/Reader.savi
+++ b/packages/src/ByteStream/Reader.savi
@@ -62,7 +62,7 @@
   :: Raises an error if the source has become permanently closed off.
   :fun ref receive_from!(source ByteStream.Source)
     if (@_data.space == 0) @_data.reserve(0x4000) // TODO: customizable reserve?
-    source.emit_bytes_into!(@_data, @_data.size)
+    source.emit_bytes_into!(@_data)
 
   :: Move the mark position to match the current cursor position.
   :: This is often used to mark the start of a token in a token stream,
@@ -101,9 +101,9 @@
 
   :: Reserve additional space in the underlying byte buffer, which forces a
   :: reallocation now, but sets a minimum number of bytes that the buffer
-  :: can receive in the future without forcing a reallocation.
-  :fun ref reserve_additional(space USize)
-    @_data.reserve(@_data.space + space)
+  :: can receive beyond the current size without forcing a reallocation.
+  :fun ref reserve_additional(additional_space USize)
+    @_data.reserve(@_data.size + additional_space)
 
   :: Get the number of bytes in the currently marked token.
   :: That is, the number of bytes between the marker and the cursor.

--- a/packages/src/ByteStream/Sink.savi
+++ b/packages/src/ByteStream/Sink.savi
@@ -16,4 +16,48 @@
   :: If False, some data was not written and this must be called again later.
   :: This includes the case where flushing is not currently possible at all,
   :: wherein False is returned without trying to flush anything.
+  :fun ref write_flush Bool // TODO: Raise an error instead of returning Bool
+
+:: This class is an implementation of `ByteStream.Sink` which emits into
+:: a given `ByteStream.Reader`, acting as the `ByteStream.Source` for it.
+:: This is often useful for testing protocol reading and writing in test suites.
+::
+:: The `write_bytes` call writes to a local chunk buffer, which gets flushed
+:: into the `ByteStream.Reader` when the `write_flush` method is called.
+::
+:: Note that this approach will incur costs for copying the chunks, because the
+:: underlying data model of `ByteStream.Reader` is a single contiguous buffer.
+:: Given that testing is the primary use case for synchronously connecting a
+:: `ByteStream.Writer` to a `ByteStream.Reader`, this copying cost is
+:: considered mostly unimportant.
+:class ByteStream.Sink.ToReader
+  :is ByteStream.Sink
+  :is ByteStream.Source
+
+  :let reader ByteStream.Reader
+  :let _chunks Array(Bytes): []
+  :var _total_size USize: 0
+  :new (@reader)
+
+  :fun ref write_bytes(bytes Bytes'val)
+    @_chunks << bytes
+    @_total_size += bytes.size
+    @
+
   :fun ref write_flush Bool
+    @reader.reserve_additional(@_total_size)
+    try (
+      @reader.receive_from!(@)
+      True
+    |
+      False
+    )
+
+  :fun ref emit_bytes_into!(buffer Bytes'ref) USize
+    @_chunks.each -> (chunk | buffer << chunk)
+    bytes_read = @_total_size
+
+    @_chunks.clear
+    @_total_size = 0
+
+    bytes_read

--- a/packages/src/ByteStream/Source.savi
+++ b/packages/src/ByteStream/Source.savi
@@ -2,8 +2,8 @@
 :: bytes into a ByteStream.Reader, including compatibility with efficient
 :: patterns that write directly into a buffer from an I/O or network stack.
 :trait ByteStream.Source
-  :: Emit zero or more bytes into the given buffer starting at the given offset,
-  :: possibly expanding the size of the buffer if that turns out to be needed.
+  :: Emit zero or more bytes into the given buffer starting at the buffer's end,
+  :: possibly expanding the space of the buffer if that turns out to be needed.
   :: Returns the number of bytes that were written.
   :: Raises an error if the source has become permanently closed off.
-  :fun ref emit_bytes_into!(buffer Bytes'ref, offset USize) USize
+  :fun ref emit_bytes_into!(buffer Bytes'ref) USize

--- a/packages/src/ByteStream/Writer.savi
+++ b/packages/src/ByteStream/Writer.savi
@@ -10,6 +10,9 @@
   :let target ByteStream.Sink
   :new (@target)
 
+  :new to_reader(reader ByteStream.Reader)
+    @target = ByteStream.Sink.ToReader.new(reader)
+
   :: Add a chunk of bytes to the stream.
   ::
   :: It won't actually get written until the `flush` method is called.

--- a/packages/src/IO/IO.savi
+++ b/packages/src/IO/IO.savi
@@ -99,18 +99,18 @@
     @_is_send_shutdown = True
     @_is_recv_shutdown = True
 
-  :: Receive bytes into the given read buffer, starting at the given offset.
+  :: Receive bytes into the given read buffer, starting at the buffer's end.
   :: Raises an error and initiates a hard close if the socket was closed
   :: on the other side of the connection.
-  :fun ref emit_bytes_into!(read_buffer Bytes'ref, offset USize) USize
+  :fun ref emit_bytes_into!(read_buffer Bytes'ref) USize
     try (
-      // TODO: Safety checking on offset value, maybe using checked subtraction?
+      orig_size = read_buffer.size
       bytes_read = LibPonyOs.pony_os_recv!(
         @_event
-        read_buffer.cpointer(offset)
-        read_buffer.space - offset
+        read_buffer.cpointer(orig_size)
+        read_buffer.space - orig_size
       )
-      new_size = offset + bytes_read
+      new_size = orig_size + bytes_read
       read_buffer.resize_possibly_including_uninitialized_memory(new_size)
 
       // If we read zero bytes, we know that further reading would block,

--- a/packages/src/StdIn/Engine.savi
+++ b/packages/src/StdIn/Engine.savi
@@ -133,22 +133,23 @@
 
     did_read
 
-  :: Receive bytes into the given read buffer, starting at the given offset.
-  :fun ref emit_bytes_into!(read_buffer Bytes'ref, offset USize) USize
+  :: Receive bytes into the given read buffer, starting at the buffer's end.
+  :fun ref emit_bytes_into!(read_buffer Bytes'ref) USize
     // Raise an error if there is no space left in the buffer.
-    if (offset >= read_buffer.space) error!
+    orig_size = read_buffer.size
+    if (orig_size == read_buffer.space) error!
 
     // Read into the buffer.
     bytes_read = LibPony.pony_os_stdin_read(
-      read_buffer.cpointer(offset)
-      read_buffer.space - offset
+      read_buffer.cpointer(orig_size)
+      read_buffer.space - orig_size
     )
 
     // Raise an error if there was nothing available to read right now.
     if (bytes_read == -1) error!
 
     // Update the size of the buffer with the newly filled bytes.
-    new_size = offset + bytes_read
+    new_size = orig_size + bytes_read
     read_buffer.resize_possibly_including_uninitialized_memory(new_size)
 
     // Return the number of bytes that were read into the buffer.


### PR DESCRIPTION
This class is an implementation of `ByteStream.Sink` which emits into
a given `ByteStream.Reader`, acting as the `ByteStream.Source` for it.
This is often useful for testing protocol reading and writing in test suites.

The `write_bytes` call writes to a local chunk buffer, which gets flushed
into the `ByteStream.Reader` when the `write_flush` method is called.

Note that this approach will incur costs for copying the chunks, because the
underlying data model of `ByteStream.Reader` is a single contiguous buffer.
Given that testing is the primary use case for synchronously connecting a
`ByteStream.Writer` to a `ByteStream.Reader`, this copying cost is
considered mostly unimportant.