### PR TITLE
Change IO flush operations to `error!` instead of returning `Bool`.

### DIFF
--- a/examples/http/src/main.savi
+++ b/examples/http/src/main.savi
@@ -44,10 +44,10 @@
             .header("Content-Length", "0")
             .finish
 
-          @io.flush
+          try @io.flush!
         )
       )
     | IO.Action.Write |
-      @io.flush
+      try @io.flush!
     )
     @

--- a/packages/spec/ByteStream/Reader.Spec.savi
+++ b/packages/spec/ByteStream/Reader.Spec.savi
@@ -21,7 +21,7 @@
 
     // Add a chunk so that those bytes are available for reading.
     write_stream << b"hello"
-    write_stream.flush
+    assert no_error: write_stream.flush!
     assert: stream.bytes_ahead == 5
     assert: stream.bytes_ahead_of_marker == 5
     assert: stream.space_ahead == initial_space
@@ -60,7 +60,7 @@
     // Add some more chunks.
     write_stream << b"world"
     write_stream << b"lings"
-    write_stream.flush
+    assert no_error: write_stream.flush!
     assert: stream.bytes_ahead == 15
     assert: stream.bytes_ahead_of_marker == 15
     assert: stream.space_ahead == initial_space
@@ -182,7 +182,7 @@
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
-    write_stream.flush
+    assert no_error: write_stream.flush!
 
     try stream.advance!(2).mark_here.advance!(6)
 
@@ -197,7 +197,7 @@
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
-    write_stream.flush
+    assert no_error: write_stream.flush!
 
     collected Array(U8) = []
 
@@ -222,7 +222,7 @@
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
-    write_stream.flush
+    assert no_error: write_stream.flush!
 
     collected Array(U8) = []
 
@@ -245,7 +245,7 @@
     write_stream << b"hel"
     write_stream << b"lowo"
     write_stream << b"rld"
-    write_stream.flush
+    assert no_error: write_stream.flush!
 
     // Compare the entire stream.
     stream.advance_to_end
@@ -270,7 +270,7 @@
     write_stream << b"HeL"
     write_stream << b"LoWo"
     write_stream << b"RlD"
-    write_stream.flush
+    assert no_error: write_stream.flush!
 
     // Compare the entire stream.
     stream.advance_to_end
@@ -295,7 +295,7 @@
     write_stream << b"192"
     write_stream << b"8374"
     write_stream << b"650"
-    write_stream.flush
+    assert no_error: write_stream.flush!
 
     // Parse the entire stream as an integer.
     stream.advance_to_end
@@ -310,7 +310,7 @@
 
     // Add an invalid character to the stream and get an error.
     write_stream << b":" // only digits (0-9) are valid
-    write_stream.flush
+    assert no_error: write_stream.flush!
     stream.advance_to_end
     assert error: stream.token_as_positive_integer!
 
@@ -319,7 +319,7 @@
     write_stream = ByteStream.Writer.to_reader(stream)
     write_stream << b"garbage"
     write_stream << Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
-    write_stream.flush
+    assert no_error: write_stream.flush!
     try stream.advance!(7) // drop "garbage"
     stream.mark_here
     stream.advance_to_end

--- a/packages/spec/HTTPServer/RequestReader.Spec.savi
+++ b/packages/spec/HTTPServer/RequestReader.Spec.savi
@@ -97,7 +97,7 @@
             )
           )
           write_stream << Bytes.from_array([byte])
-          write_stream.flush
+          try write_stream.flush!
         )
       )
     )
@@ -157,7 +157,7 @@
             )
           )
           write_stream << Bytes.from_array([byte])
-          write_stream.flush
+          try write_stream.flush!
         )
       )
     )

--- a/packages/spec/TCP/TCP.Spec.savi
+++ b/packages/spec/TCP/TCP.Spec.savi
@@ -34,7 +34,7 @@
         @env.err.print("[Echoer] Received:")
         @env.err.print(bytes.as_string)
         @io.write_stream << bytes.clone // TODO: is clone still needed?
-        @io.flush // TODO: should we flush automatically on close below?
+        try @io.flush! // TODO: should we flush automatically on close below?
         @io.close
       )
     | IO.Action.Closed |
@@ -63,7 +63,7 @@
     | IO.Action.Opened |
       @env.err.print("[EchoClient] Connected")
       @io.write_stream << b"Hello, World!"
-      @io.flush
+      try @io.flush!
 
     | IO.Action.OpenFailed |
       @env.err.print("[EchoClient] Failed to connect:")

--- a/packages/src/ByteStream/Sink.savi
+++ b/packages/src/ByteStream/Sink.savi
@@ -4,26 +4,27 @@
   :: Add a chunk of bytes to the buffer.
   ::
   :: The bytes are not guaranteed to actually be written until the next call
-  :: to the `write_flush` method, though some implementations may choose to
-  :: flush more proactively (or even on every chunk) as they see fit.
+  :: to the `write_flush!` method, though some implementations may choose to
+  :: silently flush more proactively (or even on every chunk) as they see fit.
   :fun ref write_bytes(bytes Bytes'val) @
 
   :: Try to write all buffered data.
   ::
-  :: If all data was successfully flushed into the target, it returns True.
-  :: This includes the case where there was no remaining buffered data to flush.
+  :: Raises an error if there is still some data buffered that could not yet be
+  :: flushed, either because the underlying sink was not in a writable state,
+  :: or because it wasn't prepared to accept the full amount yet.
   ::
-  :: If False, some data was not written and this must be called again later.
-  :: This includes the case where flushing is not currently possible at all,
-  :: wherein False is returned without trying to flush anything.
-  :fun ref write_flush Bool // TODO: Raise an error instead of returning Bool
+  :: However, note that even if an error is raised, there may have been some
+  :: amount of successful data transfer already - all that is known is that
+  :: some amount of data still remains in the internal buffer to be transferred.
+  :fun ref write_flush! @
 
 :: This class is an implementation of `ByteStream.Sink` which emits into
 :: a given `ByteStream.Reader`, acting as the `ByteStream.Source` for it.
 :: This is often useful for testing protocol reading and writing in test suites.
 ::
 :: The `write_bytes` call writes to a local chunk buffer, which gets flushed
-:: into the `ByteStream.Reader` when the `write_flush` method is called.
+:: into the `ByteStream.Reader` when the `write_flush!` method is called.
 ::
 :: Note that this approach will incur costs for copying the chunks, because the
 :: underlying data model of `ByteStream.Reader` is a single contiguous buffer.
@@ -44,14 +45,10 @@
     @_total_size += bytes.size
     @
 
-  :fun ref write_flush Bool
+  :fun ref write_flush!
     @reader.reserve_additional(@_total_size)
-    try (
-      @reader.receive_from!(@)
-      True
-    |
-      False
-    )
+    @reader.receive_from!(@)
+    @
 
   :fun ref emit_bytes_into!(buffer Bytes'ref) USize
     @_chunks.each -> (chunk | buffer << chunk)

--- a/packages/src/ByteStream/Writer.savi
+++ b/packages/src/ByteStream/Writer.savi
@@ -22,10 +22,13 @@
 
   :: Try to write all data that is currently buffered to the `target` sink.
   ::
-  :: If all data was successfully flushed in the target, it returns True.
-  :: Otherwise, some data was not written and this must be called again later.
+  :: Raises an error if there is still some data buffered that could not yet be
+  :: flushed, either because the underlying sink was not in a writable state,
+  :: or because it wasn't prepared to accept the full amount yet.
   ::
-  :: If the target is not in a writable state when calling this method,
-  :: then no data will be written and it was useless to make this call.
-  :fun ref flush Bool
-    @target.write_flush
+  :: However, note that even if an error is raised, there may have been some
+  :: amount of successful data transfer already - all that is known is that
+  :: some amount of data still remains in the internal buffer to be transferred.
+  :fun ref flush! @
+    @target.write_flush!
+    @

--- a/packages/src/IO/_WriteBuffer.savi
+++ b/packages/src/IO/_WriteBuffer.savi
@@ -34,58 +34,50 @@
     @_write_total_size += chunk.size
     @
 
-  :fun ref write_flush Bool
+  :fun ref write_flush! @
     case (
-    | @_write_total_size == 0 | True  // nothing left to flush
-    | !@_is_writable          | False // can't flush right now
-    | Platform.windows        | @_write_flush_windows
-    |                           @_write_flush_posix
+    | @_write_total_size == 0 | @      // nothing left to flush
+    | !@_is_writable          | error! // can't flush right now
+    | Platform.windows        | @_write_flush_windows!
+    |                           @_write_flush_posix!
     )
 
-  :fun ref _write_flush_posix Bool
+  :fun ref _write_flush_posix!
     writev_max_chunks = LibPonyOs.pony_os_writev_max
     num_to_send USize = 0
     bytes_to_send USize = 0
 
-    try (
-      while (@_write_total_size > 0) (
-        if (@_write_chunks.size < writev_max_chunks) (
-          num_to_send = @_write_chunks.size
-          bytes_to_send = @_write_total_size
-        |
-          num_to_send = writev_max_chunks
-          // TODO: This could be done with an equivalent reduce
-          bytes_to_send = 0
-          @_write_chunks.each(0, num_to_send) -> (chunk |
-            bytes_to_send += chunk.size
-          )
+    while (@_write_total_size > 0) (
+      if (@_write_chunks.size < writev_max_chunks) (
+        num_to_send = @_write_chunks.size
+        bytes_to_send = @_write_total_size
+      |
+        num_to_send = writev_max_chunks
+        // TODO: This could be done with an equivalent reduce
+        bytes_to_send = 0
+        @_write_chunks.each(0, num_to_send) -> (chunk |
+          bytes_to_send += chunk.size
         )
-
-        bytes_written = LibPonyOs.pony_os_writev!(
-          @_event
-          @_write_chunks.cpointer
-          num_to_send
-        )
-        @_manage_chunks(bytes_written, bytes_to_send, num_to_send)
       )
-      True
-    |
-      False
-    )
 
-  :fun ref _write_flush_windows Bool
-    try (
-      LibPonyOs.pony_os_writev!(
+      bytes_written = LibPonyOs.pony_os_writev!(
         @_event
         @_write_chunks.cpointer
-        @_write_windows_unacknowledged_chunks
+        num_to_send
       )
-      @_write_windows_unacknowledged_chunks += @_write_chunks.size
-      @_write_windows_unacknowledged_total_size = @_write_total_size
-      True
-    |
-      False
+      @_manage_chunks(bytes_written, bytes_to_send, num_to_send)
     )
+    @
+
+  :fun ref _write_flush_windows!
+    LibPonyOs.pony_os_writev!(
+      @_event
+      @_write_chunks.cpointer
+      @_write_windows_unacknowledged_chunks
+    )
+    @_write_windows_unacknowledged_chunks += @_write_chunks.size
+    @_write_windows_unacknowledged_total_size = @_write_total_size
+    @
 
   :fun ref _write_acknowledge_windows(bytes_written USize)
     @_manage_chunks(

--- a/packages/src/TCP/ConnectionEngine.savi
+++ b/packages/src/TCP/ConnectionEngine.savi
@@ -58,8 +58,8 @@
     @io.close
     @
 
-  :fun ref flush
-    @write_stream.flush
+  :fun ref flush!
+    @write_stream.flush!
 
   :fun ref pending_reads
     :yields USize for None


### PR DESCRIPTION
It's more idiomatic to raise an error, as that makes the distinction between success and failure harder to ignore at the call site.