### PR TITLE
Add proper support for Bytes in Inspect output.

### DIFF
--- a/packages/spec/Savi/Inspect.Spec.savi
+++ b/packages/spec/Savi/Inspect.Spec.savi
@@ -51,6 +51,12 @@
     assert: Inspect["example"] == "\"example\""
     assert: Inspect[String.new] == "\"\""
 
+  :it "inspects bytes"
+    assert: Inspect[b"example"] == "b\"example\""
+    assert: Inspect[b"\x00\x08\x1A ABC123\n\r\t\x7F\x80\xFF"] == <<<
+      b"\x00\x08\x1A ABC123\n\r\t\x7F\x80\xFF"
+    >>>
+
   :it "inspects arrays"
     assert: Inspect[["foo", "bar", "baz"]] == "[\"foo\", \"bar\", \"baz\"]"
     assert: Inspect[[U8[10], U8[5], U8[6], U8[5]]] == "[10, 5, 6, 5]"

--- a/packages/src/Savi/Inspect.savi
+++ b/packages/src/Savi/Inspect.savi
@@ -57,6 +57,21 @@
       output << input.clone // TODO: show some characters as escaped.
       output.push_byte('"')
       --output
+    | Bytes'box |
+      output.push_byte('b')
+      output.push_byte('"')
+      input.each -> (byte |
+        case (
+        | byte >= 0x7F | output = @_inspect_hex_byte_escape_into(--output, byte)
+        | byte >= 0x20 | output.push_byte(byte)
+        | byte == '\n' | output.push_byte('\\').push_byte('n')
+        | byte == '\r' | output.push_byte('\\').push_byte('r')
+        | byte == '\t' | output.push_byte('\\').push_byte('t')
+        |                output = @_inspect_hex_byte_escape_into(--output, byte)
+        )
+      )
+      output.push_byte('"')
+      --output
     | _InspectEach |
       output.push_byte('[')
       index USize = 0
@@ -76,6 +91,21 @@
       output << reflection_of_runtime_type_name input
       --output
     )
+
+  :fun non _inspect_hex_byte_escape_into(out String'iso, byte U8)
+    out.push_byte('\\')
+    out.push_byte('x')
+    out = @_inspect_hex_digit_into(--out, byte.bit_shr(4))
+    out = @_inspect_hex_digit_into(--out, byte.bit_and(0xF))
+    --out
+
+  :fun non _inspect_hex_digit_into(out String'iso, digit U8)
+    if (digit <= 9) (
+      out.push_byte(digit + '0')
+    |
+      out.push_byte(digit + 'A' - 0xA)
+    )
+    --out
 
   :fun non _inspect_float_into(out String'iso, value F64) String'iso
     if (value < 0) (


### PR DESCRIPTION
Now, inspecting a `Bytes` instance will yield a representation that is source-code compatible with `Bytes` literals