### PR TITLE
Add `Unicode.codepoint_to_lowercase!` and `codepoint_to_uppercase!`.

### DIFF
--- a/packages/Unicode.manifest.savi
+++ b/packages/Unicode.manifest.savi
@@ -1,0 +1,9 @@
+:manifest lib Unicode
+  :sources "src/Unicode/**/*.savi"
+
+:manifest bin "spec-Unicode"
+  :copies Unicode
+  :sources "spec/Unicode/**/*.savi"
+
+  :dependency Spec "TODO: specify version"
+  :transitive dependency Map "TODO: specify version"

--- a/packages/spec/Savi/Numeric.Spec.savi
+++ b/packages/spec/Savi/Numeric.Spec.savi
@@ -352,6 +352,12 @@
     assert: U8[18].swap_bytes         == 18
     assert: U16[0x1234].swap_bytes    == 0x3412
     assert: U32[66052].swap_bytes     == 67240192
+    assert: U8[18].is_even
+    assert: !U8[18].is_odd
+    assert: !U8[17].is_even
+    assert: U8[17].is_odd
+    assert: U8[0].is_even
+    assert: !U8[0].is_odd
     assert: U8[18].leading_zero_bits  == 3
     assert: U8[18].trailing_zero_bits == 1
     assert: U8[18].total_one_bits     == 2

--- a/packages/spec/Unicode/Main.savi
+++ b/packages/spec/Unicode/Main.savi
@@ -1,0 +1,5 @@
+:actor Main
+  :new (env)
+    Spec.Process.run(env, [
+      Spec.Run(Unicode.Spec).new(env)
+    ])

--- a/packages/spec/Unicode/Unicode.Spec.savi
+++ b/packages/spec/Unicode/Unicode.Spec.savi
@@ -1,0 +1,826 @@
+:class Unicode.Spec
+  :is Spec
+  :const describes: "Unicode"
+
+  :it "converts a codepoint to lowercase or uppercase if possible"
+    // Note: the following two websites are useful when working on these tests:
+    // Search by pasted character: https://www.compart.com/en/unicode
+    // View codepoints as a table: https://unicode-table.com/en/
+
+    // 0x00...0x80 : ASCII / Basic Latin
+    assert error: Unicode.codepoint_to_lowercase!('@')
+    assert error: Unicode.codepoint_to_uppercase!('@')
+    assert:       Unicode.codepoint_to_lowercase!('A') == 'a'
+    assert error: Unicode.codepoint_to_uppercase!('A')
+    assert:       Unicode.codepoint_to_lowercase!('Z') == 'z'
+    assert error: Unicode.codepoint_to_uppercase!('Z')
+    assert error: Unicode.codepoint_to_lowercase!('[')
+    assert error: Unicode.codepoint_to_uppercase!('[')
+    assert error: Unicode.codepoint_to_lowercase!('`')
+    assert error: Unicode.codepoint_to_uppercase!('`')
+    assert error: Unicode.codepoint_to_lowercase!('a')
+    assert:       Unicode.codepoint_to_uppercase!('a') == 'A'
+    assert error: Unicode.codepoint_to_lowercase!('z')
+    assert:       Unicode.codepoint_to_uppercase!('z') == 'Z'
+    assert error: Unicode.codepoint_to_lowercase!('{')
+    assert error: Unicode.codepoint_to_uppercase!('{')
+
+    // 0x00xx : Latin-1 Supplement
+    assert error: Unicode.codepoint_to_lowercase!('¿')
+    assert error: Unicode.codepoint_to_uppercase!('¿')
+    assert:       Unicode.codepoint_to_lowercase!('À') == 'à'
+    assert error: Unicode.codepoint_to_uppercase!('À')
+    assert:       Unicode.codepoint_to_lowercase!('Ö') == 'ö'
+    assert error: Unicode.codepoint_to_uppercase!('Ö')
+    assert error: Unicode.codepoint_to_lowercase!('×')
+    assert error: Unicode.codepoint_to_uppercase!('×')
+    assert:       Unicode.codepoint_to_lowercase!('Ø') == 'ø'
+    assert error: Unicode.codepoint_to_uppercase!('Ø')
+    assert:       Unicode.codepoint_to_lowercase!('Þ') == 'þ'
+    assert error: Unicode.codepoint_to_uppercase!('Þ')
+    assert error: Unicode.codepoint_to_lowercase!('ß')
+    assert error: Unicode.codepoint_to_uppercase!('ß')
+    assert error: Unicode.codepoint_to_lowercase!('à')
+    assert:       Unicode.codepoint_to_uppercase!('à') == 'À'
+    assert error: Unicode.codepoint_to_lowercase!('ö')
+    assert:       Unicode.codepoint_to_uppercase!('ö') == 'Ö'
+    assert error: Unicode.codepoint_to_lowercase!('÷')
+    assert error: Unicode.codepoint_to_uppercase!('÷')
+    assert error: Unicode.codepoint_to_lowercase!('ø')
+    assert:       Unicode.codepoint_to_uppercase!('ø') == 'Ø'
+    assert error: Unicode.codepoint_to_lowercase!('þ')
+    assert:       Unicode.codepoint_to_uppercase!('þ') == 'Þ'
+    assert error: Unicode.codepoint_to_lowercase!('ÿ')
+    assert:       Unicode.codepoint_to_uppercase!('ÿ') == 'Ÿ'
+
+    // 0x01xx : Latin Extended-A and (part of) Extended-B
+    // 0x02xx : (part of) Latin Extended-B
+    assert:       Unicode.codepoint_to_lowercase!('Ā') == 'ā'
+    assert:       Unicode.codepoint_to_uppercase!('ā') == 'Ā'
+    assert:       Unicode.codepoint_to_lowercase!('Į') == 'į'
+    assert:       Unicode.codepoint_to_uppercase!('į') == 'Į'
+    assert error: Unicode.codepoint_to_lowercase!('İ')
+    assert error: Unicode.codepoint_to_uppercase!('İ')
+    assert:       Unicode.codepoint_to_uppercase!('ı') == 'I' // uses ASCII 'I' uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Ĳ') == 'ĳ'
+    assert:       Unicode.codepoint_to_uppercase!('ĳ') == 'Ĳ'
+    assert:       Unicode.codepoint_to_lowercase!('Ķ') == 'ķ'
+    assert:       Unicode.codepoint_to_uppercase!('ķ') == 'Ķ'
+    assert error: Unicode.codepoint_to_lowercase!('ĸ')
+    assert error: Unicode.codepoint_to_uppercase!('ĸ')
+    assert:       Unicode.codepoint_to_lowercase!('Ĺ') == 'ĺ'
+    assert:       Unicode.codepoint_to_uppercase!('ĺ') == 'Ĺ'
+    assert:       Unicode.codepoint_to_lowercase!('Ň') == 'ň'
+    assert:       Unicode.codepoint_to_uppercase!('ň') == 'Ň'
+    assert error: Unicode.codepoint_to_lowercase!('ŉ')
+    assert error: Unicode.codepoint_to_uppercase!('ŉ')
+    assert:       Unicode.codepoint_to_lowercase!('Ŋ') == 'ŋ'
+    assert:       Unicode.codepoint_to_uppercase!('ŋ') == 'Ŋ'
+    assert:       Unicode.codepoint_to_lowercase!('Ŷ') == 'ŷ'
+    assert:       Unicode.codepoint_to_uppercase!('ŷ') == 'Ŷ'
+    assert:       Unicode.codepoint_to_lowercase!('Ÿ') == 'ÿ'
+    assert:       Unicode.codepoint_to_uppercase!('ÿ') == 'Ÿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ź') == 'ź'
+    assert:       Unicode.codepoint_to_uppercase!('ź') == 'Ź'
+    assert:       Unicode.codepoint_to_lowercase!('Ž') == 'ž'
+    assert:       Unicode.codepoint_to_uppercase!('ž') == 'Ž'
+    assert error: Unicode.codepoint_to_lowercase!('ſ')
+    assert error: Unicode.codepoint_to_uppercase!('ſ')
+    assert:       Unicode.codepoint_to_lowercase!('Ɓ') == 'ɓ'
+    assert:       Unicode.codepoint_to_uppercase!('ɓ') == 'Ɓ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƃ') == 'ƃ'
+    assert:       Unicode.codepoint_to_uppercase!('ƃ') == 'Ƃ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɔ') == 'ɔ'
+    assert:       Unicode.codepoint_to_uppercase!('ɔ') == 'Ɔ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƈ') == 'ƈ'
+    assert:       Unicode.codepoint_to_uppercase!('ƈ') == 'Ƈ'
+    assert error: Unicode.codepoint_to_lowercase!('Ɖ')
+    assert error: Unicode.codepoint_to_uppercase!('Ɖ')
+    assert:       Unicode.codepoint_to_lowercase!('Ɗ') == 'ɗ'
+    assert:       Unicode.codepoint_to_uppercase!('ɗ') == 'Ɗ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƌ') == 'ƌ'
+    assert:       Unicode.codepoint_to_uppercase!('ƌ') == 'Ƌ'
+    assert error: Unicode.codepoint_to_lowercase!('ƍ')
+    assert error: Unicode.codepoint_to_uppercase!('ƍ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǝ') == 'ɘ'
+    assert:       Unicode.codepoint_to_uppercase!('ɘ') == 'Ǝ'
+    assert:       Unicode.codepoint_to_lowercase!('Ə') == 'ə'
+    assert:       Unicode.codepoint_to_uppercase!('ə') == 'Ə'
+    assert:       Unicode.codepoint_to_lowercase!('Ɛ') == 'ɛ'
+    assert:       Unicode.codepoint_to_uppercase!('ɛ') == 'Ɛ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƒ') == 'ƒ'
+    assert:       Unicode.codepoint_to_uppercase!('ƒ') == 'Ƒ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɠ') == 'ɠ'
+    assert:       Unicode.codepoint_to_uppercase!('ɠ') == 'Ɠ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɣ') == 'ɣ'
+    assert:       Unicode.codepoint_to_uppercase!('ɣ') == 'Ɣ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɩ') == 'ɩ'
+    assert:       Unicode.codepoint_to_uppercase!('ɩ') == 'Ɩ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɨ') == 'ɨ'
+    assert:       Unicode.codepoint_to_uppercase!('ɨ') == 'Ɨ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƙ') == 'ƙ'
+    assert:       Unicode.codepoint_to_uppercase!('ƙ') == 'Ƙ'
+    assert error: Unicode.codepoint_to_uppercase!('ƛ')
+    assert error: Unicode.codepoint_to_lowercase!('ƛ')
+    assert:       Unicode.codepoint_to_lowercase!('Ɯ') == 'ɯ'
+    assert:       Unicode.codepoint_to_uppercase!('ɯ') == 'Ɯ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɲ') == 'ɲ'
+    assert:       Unicode.codepoint_to_uppercase!('ɲ') == 'Ɲ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƞ') == 'ƞ'
+    assert:       Unicode.codepoint_to_uppercase!('ƞ') == 'Ƞ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɵ') == 'ɵ'
+    assert:       Unicode.codepoint_to_uppercase!('ɵ') == 'Ɵ'
+    assert:       Unicode.codepoint_to_lowercase!('Ơ') == 'ơ'
+    assert:       Unicode.codepoint_to_uppercase!('ơ') == 'Ơ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƥ') == 'ƥ'
+    assert:       Unicode.codepoint_to_uppercase!('ƥ') == 'Ƥ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʀ') == 'ʀ'
+    assert:       Unicode.codepoint_to_uppercase!('ʀ') == 'Ʀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƨ') == 'ƨ'
+    assert:       Unicode.codepoint_to_uppercase!('ƨ') == 'Ƨ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʃ') == 'ʃ'
+    assert:       Unicode.codepoint_to_uppercase!('ʃ') == 'Ʃ'
+    assert error: Unicode.codepoint_to_uppercase!('ƪ')
+    assert error: Unicode.codepoint_to_lowercase!('ƪ')
+    assert error: Unicode.codepoint_to_uppercase!('ƫ')
+    assert error: Unicode.codepoint_to_lowercase!('ƫ')
+    assert:       Unicode.codepoint_to_lowercase!('Ƭ') == 'ƭ'
+    assert:       Unicode.codepoint_to_uppercase!('ƭ') == 'Ƭ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʈ') == 'ʈ'
+    assert:       Unicode.codepoint_to_uppercase!('ʈ') == 'Ʈ'
+    assert:       Unicode.codepoint_to_lowercase!('Ư') == 'ư'
+    assert:       Unicode.codepoint_to_uppercase!('ư') == 'Ư'
+    assert:       Unicode.codepoint_to_lowercase!('Ʊ') == 'ʊ'
+    assert:       Unicode.codepoint_to_uppercase!('ʊ') == 'Ʊ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʋ') == 'ʋ'
+    assert:       Unicode.codepoint_to_uppercase!('ʋ') == 'Ʋ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƴ') == 'ƴ'
+    assert:       Unicode.codepoint_to_uppercase!('ƴ') == 'Ƴ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƶ') == 'ƶ'
+    assert:       Unicode.codepoint_to_uppercase!('ƶ') == 'Ƶ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʒ') == 'ʒ'
+    assert:       Unicode.codepoint_to_uppercase!('ʒ') == 'Ʒ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƹ') == 'ƹ'
+    assert:       Unicode.codepoint_to_uppercase!('ƹ') == 'Ƹ'
+    assert error: Unicode.codepoint_to_uppercase!('ƺ')
+    assert error: Unicode.codepoint_to_lowercase!('ƺ')
+    assert error: Unicode.codepoint_to_uppercase!('ƻ')
+    assert error: Unicode.codepoint_to_lowercase!('ƻ')
+    assert:       Unicode.codepoint_to_lowercase!('Ƽ') == 'ƽ'
+    assert:       Unicode.codepoint_to_uppercase!('ƽ') == 'Ƽ'
+    assert error: Unicode.codepoint_to_uppercase!('ƾ')
+    assert error: Unicode.codepoint_to_lowercase!('ƾ')
+    assert:       Unicode.codepoint_to_lowercase!('Ƿ') == 'ƿ'
+    assert:       Unicode.codepoint_to_uppercase!('ƿ') == 'Ƿ'
+    assert error: Unicode.codepoint_to_uppercase!('ǀ')
+    assert error: Unicode.codepoint_to_lowercase!('ǀ')
+    assert error: Unicode.codepoint_to_uppercase!('ǃ')
+    assert error: Unicode.codepoint_to_lowercase!('ǃ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǆ') == 'ǆ'
+    assert:       Unicode.codepoint_to_uppercase!('ǆ') == 'Ǆ'
+    assert error: Unicode.codepoint_to_uppercase!('ǅ')
+    assert error: Unicode.codepoint_to_lowercase!('ǅ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǉ') == 'ǉ'
+    assert:       Unicode.codepoint_to_uppercase!('ǉ') == 'Ǉ'
+    assert error: Unicode.codepoint_to_uppercase!('ǈ')
+    assert error: Unicode.codepoint_to_lowercase!('ǈ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǌ') == 'ǌ'
+    assert:       Unicode.codepoint_to_uppercase!('ǌ') == 'Ǌ'
+    assert error: Unicode.codepoint_to_uppercase!('ǋ')
+    assert error: Unicode.codepoint_to_lowercase!('ǋ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǎ') == 'ǎ'
+    assert:       Unicode.codepoint_to_uppercase!('ǎ') == 'Ǎ'
+    assert:       Unicode.codepoint_to_lowercase!('Ǜ') == 'ǜ'
+    assert:       Unicode.codepoint_to_uppercase!('ǜ') == 'Ǜ'
+    assert error: Unicode.codepoint_to_uppercase!('ǝ')
+    assert error: Unicode.codepoint_to_lowercase!('ǝ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǟ') == 'ǟ'
+    assert:       Unicode.codepoint_to_uppercase!('ǟ') == 'Ǟ'
+    assert:       Unicode.codepoint_to_lowercase!('Ǯ') == 'ǯ'
+    assert:       Unicode.codepoint_to_uppercase!('ǯ') == 'Ǯ'
+    assert error: Unicode.codepoint_to_uppercase!('ǰ')
+    assert error: Unicode.codepoint_to_lowercase!('ǰ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǳ') == 'ǳ'
+    assert:       Unicode.codepoint_to_uppercase!('ǳ') == 'Ǳ'
+    assert error: Unicode.codepoint_to_uppercase!('ǲ')
+    assert error: Unicode.codepoint_to_lowercase!('ǲ')
+    assert:       Unicode.codepoint_to_lowercase!('Ǵ') == 'ǵ'
+    assert:       Unicode.codepoint_to_uppercase!('ǵ') == 'Ǵ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƕ') == 'ƕ'
+    assert:       Unicode.codepoint_to_uppercase!('ƕ') == 'Ƕ'
+    assert:       Unicode.codepoint_to_lowercase!('Ǹ') == 'ǹ'
+    assert:       Unicode.codepoint_to_uppercase!('ǹ') == 'Ǹ'
+    assert:       Unicode.codepoint_to_lowercase!('Ȗ') == 'ȗ'
+    assert:       Unicode.codepoint_to_uppercase!('ȗ') == 'Ȗ'
+    assert:       Unicode.codepoint_to_lowercase!('Ș') == 'ș'
+    assert:       Unicode.codepoint_to_uppercase!('ș') == 'Ș'
+    assert:       Unicode.codepoint_to_lowercase!('Ȟ') == 'ȟ'
+    assert:       Unicode.codepoint_to_uppercase!('ȟ') == 'Ȟ'
+    assert error: Unicode.codepoint_to_uppercase!('ȡ')
+    assert error: Unicode.codepoint_to_lowercase!('ȡ')
+    assert:       Unicode.codepoint_to_lowercase!('Ȣ') == 'ȣ'
+    assert:       Unicode.codepoint_to_uppercase!('ȣ') == 'Ȣ'
+    assert:       Unicode.codepoint_to_lowercase!('Ȯ') == 'ȯ'
+    assert:       Unicode.codepoint_to_uppercase!('ȯ') == 'Ȯ'
+    assert:       Unicode.codepoint_to_lowercase!('Ȳ') == 'ȳ'
+    assert:       Unicode.codepoint_to_uppercase!('ȳ') == 'Ȳ'
+    assert error: Unicode.codepoint_to_uppercase!('ȴ')
+    assert error: Unicode.codepoint_to_lowercase!('ȴ')
+    assert error: Unicode.codepoint_to_uppercase!('ȹ')
+    assert error: Unicode.codepoint_to_lowercase!('ȹ')
+    assert:       Unicode.codepoint_to_lowercase!('Ⱥ') == 'ⱥ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱥ') == 'Ⱥ'
+    assert:       Unicode.codepoint_to_lowercase!('Ȼ') == 'ȼ'
+    assert:       Unicode.codepoint_to_uppercase!('ȼ') == 'Ȼ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƚ') == 'ƚ'
+    assert:       Unicode.codepoint_to_uppercase!('ƚ') == 'Ƚ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱦ') == 'ⱦ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱦ') == 'Ⱦ'
+    assert:       Unicode.codepoint_to_lowercase!('Ȿ') == 'ȿ'
+    assert:       Unicode.codepoint_to_uppercase!('ȿ') == 'Ȿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɀ') == 'ɀ'
+    assert:       Unicode.codepoint_to_uppercase!('ɀ') == 'Ɀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɂ') == 'ɂ'
+    assert:       Unicode.codepoint_to_uppercase!('ɂ') == 'Ɂ'
+    assert:       Unicode.codepoint_to_lowercase!('Ƀ') == 'ƀ'
+    assert:       Unicode.codepoint_to_uppercase!('ƀ') == 'Ƀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʉ') == 'ʉ'
+    assert:       Unicode.codepoint_to_uppercase!('ʉ') == 'Ʉ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʌ') == 'ʌ'
+    assert:       Unicode.codepoint_to_uppercase!('ʌ') == 'Ʌ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɇ') == 'ɇ'
+    assert:       Unicode.codepoint_to_uppercase!('ɇ') == 'Ɇ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɏ') == 'ɏ'
+    assert:       Unicode.codepoint_to_uppercase!('ɏ') == 'Ɏ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɐ') == 'ɐ'
+    assert:       Unicode.codepoint_to_uppercase!('ɐ') == 'Ɐ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɑ') == 'ɑ'
+    assert:       Unicode.codepoint_to_uppercase!('ɑ') == 'Ɑ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɒ') == 'ɒ'
+    assert:       Unicode.codepoint_to_uppercase!('ɒ') == 'Ɒ'
+    assert error: Unicode.codepoint_to_lowercase!('ɕ')
+    assert error: Unicode.codepoint_to_uppercase!('ɕ')
+    assert:       Unicode.codepoint_to_lowercase!('Ɜ') == 'ɜ'
+    assert:       Unicode.codepoint_to_uppercase!('ɜ') == 'Ɜ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɡ') == 'ɡ'
+    assert:       Unicode.codepoint_to_uppercase!('ɡ') == 'Ɡ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɥ') == 'ɥ'
+    assert:       Unicode.codepoint_to_uppercase!('ɥ') == 'Ɥ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɦ') == 'ɦ'
+    assert:       Unicode.codepoint_to_uppercase!('ɦ') == 'Ɦ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɪ') == 'ɪ'
+    assert:       Unicode.codepoint_to_uppercase!('ɪ') == 'Ɪ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɫ') == 'ɫ'
+    assert:       Unicode.codepoint_to_uppercase!('ɫ') == 'Ɫ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɬ') == 'ɬ'
+    assert:       Unicode.codepoint_to_uppercase!('ɬ') == 'Ɬ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɱ') == 'ɱ'
+    assert:       Unicode.codepoint_to_uppercase!('ɱ') == 'Ɱ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɽ') == 'ɽ'
+    assert:       Unicode.codepoint_to_uppercase!('ɽ') == 'Ɽ'
+    assert error: Unicode.codepoint_to_lowercase!('ʁ')
+    assert error: Unicode.codepoint_to_uppercase!('ʁ')
+    assert:       Unicode.codepoint_to_lowercase!('Ʂ') == 'ʂ'
+    assert:       Unicode.codepoint_to_uppercase!('ʂ') == 'Ʂ'
+    assert error: Unicode.codepoint_to_lowercase!('ʄ')
+    assert error: Unicode.codepoint_to_uppercase!('ʄ')
+    assert error: Unicode.codepoint_to_lowercase!('ʅ')
+    assert error: Unicode.codepoint_to_uppercase!('ʅ')
+    assert error: Unicode.codepoint_to_lowercase!('ʆ')
+    assert error: Unicode.codepoint_to_uppercase!('ʆ')
+    assert:       Unicode.codepoint_to_lowercase!('Ʇ') == 'ʇ'
+    assert:       Unicode.codepoint_to_uppercase!('ʇ') == 'Ʇ'
+    assert error: Unicode.codepoint_to_lowercase!('ʍ')
+    assert error: Unicode.codepoint_to_uppercase!('ʍ')
+    assert error: Unicode.codepoint_to_lowercase!('ʎ')
+    assert error: Unicode.codepoint_to_uppercase!('ʎ')
+    assert error: Unicode.codepoint_to_lowercase!('ʏ')
+    assert error: Unicode.codepoint_to_uppercase!('ʏ')
+    assert error: Unicode.codepoint_to_lowercase!('ʐ')
+    assert error: Unicode.codepoint_to_uppercase!('ʐ')
+    assert error: Unicode.codepoint_to_lowercase!('ʑ')
+    assert error: Unicode.codepoint_to_uppercase!('ʑ')
+    assert error: Unicode.codepoint_to_lowercase!('ʓ')
+    assert error: Unicode.codepoint_to_uppercase!('ʓ')
+    assert error: Unicode.codepoint_to_lowercase!('ʔ')
+    assert error: Unicode.codepoint_to_uppercase!('ʔ')
+    assert error: Unicode.codepoint_to_lowercase!('ʕ')
+    assert error: Unicode.codepoint_to_uppercase!('ʕ')
+    assert error: Unicode.codepoint_to_lowercase!('ʖ')
+    assert error: Unicode.codepoint_to_uppercase!('ʖ')
+    assert error: Unicode.codepoint_to_lowercase!('ʗ')
+    assert error: Unicode.codepoint_to_uppercase!('ʗ')
+    assert error: Unicode.codepoint_to_lowercase!('ʘ')
+    assert error: Unicode.codepoint_to_uppercase!('ʘ')
+    assert error: Unicode.codepoint_to_lowercase!('ʙ')
+    assert error: Unicode.codepoint_to_uppercase!('ʙ')
+    assert error: Unicode.codepoint_to_lowercase!('ʚ')
+    assert error: Unicode.codepoint_to_uppercase!('ʚ')
+    assert error: Unicode.codepoint_to_lowercase!('ʜ')
+    assert error: Unicode.codepoint_to_uppercase!('ʜ')
+    assert:       Unicode.codepoint_to_lowercase!('Ʝ') == 'ʝ'
+    assert:       Unicode.codepoint_to_uppercase!('ʝ') == 'Ʝ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʞ') == 'ʞ'
+    assert:       Unicode.codepoint_to_uppercase!('ʞ') == 'Ʞ'
+    assert error: Unicode.codepoint_to_lowercase!('ʟ')
+    assert error: Unicode.codepoint_to_uppercase!('ʟ')
+    assert error: Unicode.codepoint_to_lowercase!('ʠ')
+    assert error: Unicode.codepoint_to_uppercase!('ʠ')
+    assert error: Unicode.codepoint_to_lowercase!('ʯ')
+    assert error: Unicode.codepoint_to_uppercase!('ʯ')
+
+    // 0x03xx : Greek and Coptic
+    assert:       Unicode.codepoint_to_lowercase!('Ͱ') == 'ͱ'
+    assert:       Unicode.codepoint_to_uppercase!('ͱ') == 'Ͱ'
+    assert:       Unicode.codepoint_to_lowercase!('Ͳ') == 'ͳ'
+    assert:       Unicode.codepoint_to_uppercase!('ͳ') == 'Ͳ'
+    assert error: Unicode.codepoint_to_lowercase!('ʹ')
+    assert error: Unicode.codepoint_to_uppercase!('ʹ')
+    assert error: Unicode.codepoint_to_lowercase!('͵')
+    assert error: Unicode.codepoint_to_uppercase!('͵')
+    assert:       Unicode.codepoint_to_lowercase!('Ͷ') == 'ͷ'
+    assert:       Unicode.codepoint_to_uppercase!('ͷ') == 'Ͷ'
+    assert error: Unicode.codepoint_to_lowercase!('ͺ')
+    assert error: Unicode.codepoint_to_uppercase!('ͺ')
+    assert:       Unicode.codepoint_to_lowercase!('Ͻ') == 'ͻ'
+    assert:       Unicode.codepoint_to_uppercase!('ͻ') == 'Ͻ'
+    assert:       Unicode.codepoint_to_lowercase!('Ͼ') == 'ͼ'
+    assert:       Unicode.codepoint_to_uppercase!('ͼ') == 'Ͼ'
+    assert:       Unicode.codepoint_to_lowercase!('Ͽ') == 'ͽ'
+    assert:       Unicode.codepoint_to_uppercase!('ͽ') == 'Ͽ'
+    assert:       Unicode.codepoint_to_lowercase!('Ά') == 'ά'
+    assert:       Unicode.codepoint_to_uppercase!('ά') == 'Ά'
+    assert error: Unicode.codepoint_to_lowercase!('·')
+    assert error: Unicode.codepoint_to_uppercase!('·')
+    assert:       Unicode.codepoint_to_lowercase!('Έ') == 'έ'
+    assert:       Unicode.codepoint_to_uppercase!('έ') == 'Έ'
+    assert:       Unicode.codepoint_to_lowercase!('Ή') == 'ή'
+    assert:       Unicode.codepoint_to_uppercase!('ή') == 'Ή'
+    assert:       Unicode.codepoint_to_lowercase!('Ί') == 'ί'
+    assert:       Unicode.codepoint_to_uppercase!('ί') == 'Ί'
+    assert:       Unicode.codepoint_to_lowercase!('Ό') == 'ό'
+    assert:       Unicode.codepoint_to_uppercase!('ό') == 'Ό'
+    assert:       Unicode.codepoint_to_lowercase!('Ύ') == 'ύ'
+    assert:       Unicode.codepoint_to_uppercase!('ύ') == 'Ύ'
+    assert:       Unicode.codepoint_to_lowercase!('Ώ') == 'ώ'
+    assert:       Unicode.codepoint_to_uppercase!('ώ') == 'Ώ'
+    assert:       Unicode.codepoint_to_uppercase!('ΐ') == 'Ι' // uses main Iota uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Α') == 'α'
+    assert:       Unicode.codepoint_to_uppercase!('α') == 'Α'
+    assert:       Unicode.codepoint_to_uppercase!('ς') == 'Σ' // uses main Sigma uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Ω') == 'ω'
+    assert:       Unicode.codepoint_to_uppercase!('ω') == 'Ω'
+    assert:       Unicode.codepoint_to_lowercase!('Ϋ') == 'ϋ'
+    assert:       Unicode.codepoint_to_uppercase!('ϋ') == 'Ϋ'
+    assert:       Unicode.codepoint_to_uppercase!('ΰ') == 'Υ' // uses main Upsilon uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Ϗ') == 'ϗ'
+    assert:       Unicode.codepoint_to_uppercase!('ϗ') == 'Ϗ'
+    assert:       Unicode.codepoint_to_uppercase!('ϐ') == 'Β' // uses main Beta uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ϑ') == 'Θ' // uses main Theta uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ϕ') == 'Φ' // uses main Phi uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Ϙ') == 'ϙ'
+    assert:       Unicode.codepoint_to_uppercase!('ϙ') == 'Ϙ'
+    assert:       Unicode.codepoint_to_lowercase!('Ϡ') == 'ϡ'
+    assert:       Unicode.codepoint_to_uppercase!('ϡ') == 'Ϡ'
+    assert:       Unicode.codepoint_to_lowercase!('Ϣ') == 'ϣ'
+    assert:       Unicode.codepoint_to_uppercase!('ϣ') == 'Ϣ'
+    assert:       Unicode.codepoint_to_lowercase!('Ϯ') == 'ϯ'
+    assert:       Unicode.codepoint_to_uppercase!('ϯ') == 'Ϯ'
+    assert:       Unicode.codepoint_to_uppercase!('ϰ') == 'Κ' // uses main Kappa uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ϱ') == 'Ρ' // uses main Rho uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Ϲ') == 'ϲ'
+    assert:       Unicode.codepoint_to_uppercase!('ϲ') == 'Ϲ'
+    assert:       Unicode.codepoint_to_uppercase!('ϳ') == 'Ϳ' // uses main Jot uppercase
+    assert:       Unicode.codepoint_to_lowercase!('ϴ') == 'θ' // uses main Theta lowercase
+    assert:       Unicode.codepoint_to_uppercase!('ϵ') == 'Ε' // uses main Epsilon uppercase
+    assert error: Unicode.codepoint_to_lowercase!('϶')
+    assert error: Unicode.codepoint_to_uppercase!('϶')
+    assert:       Unicode.codepoint_to_lowercase!('Ϸ') == 'ϸ'
+    assert:       Unicode.codepoint_to_uppercase!('ϸ') == 'Ϸ'
+    assert:       Unicode.codepoint_to_lowercase!('Ϻ') == 'ϻ'
+    assert:       Unicode.codepoint_to_uppercase!('ϻ') == 'Ϻ'
+    assert error: Unicode.codepoint_to_lowercase!('ϼ')
+    assert error: Unicode.codepoint_to_uppercase!('ϼ')
+
+    // 0x05xx : Cyrillic Supplement and Armenian
+    assert:       Unicode.codepoint_to_lowercase!('Ѐ') == 'ѐ'
+    assert:       Unicode.codepoint_to_uppercase!('ѐ') == 'Ѐ'
+    assert:       Unicode.codepoint_to_lowercase!('Џ') == 'џ'
+    assert:       Unicode.codepoint_to_uppercase!('џ') == 'Џ'
+    assert:       Unicode.codepoint_to_lowercase!('А') == 'а'
+    assert:       Unicode.codepoint_to_uppercase!('а') == 'А'
+    assert:       Unicode.codepoint_to_lowercase!('Я') == 'я'
+    assert:       Unicode.codepoint_to_uppercase!('я') == 'Я'
+    assert:       Unicode.codepoint_to_lowercase!('Ѡ') == 'ѡ'
+    assert:       Unicode.codepoint_to_uppercase!('ѡ') == 'Ѡ'
+    assert error: Unicode.codepoint_to_lowercase!('҂')
+    assert error: Unicode.codepoint_to_uppercase!('҂')
+    assert:       Unicode.codepoint_to_lowercase!('Ҋ') == 'ҋ'
+    assert:       Unicode.codepoint_to_uppercase!('ҋ') == 'Ҋ'
+    assert:       Unicode.codepoint_to_lowercase!('Ҿ') == 'ҿ'
+    assert:       Unicode.codepoint_to_uppercase!('ҿ') == 'Ҿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ӏ') == 'ӏ'
+    assert:       Unicode.codepoint_to_uppercase!('ӏ') == 'Ӏ'
+    assert:       Unicode.codepoint_to_lowercase!('Ӂ') == 'ӂ'
+    assert:       Unicode.codepoint_to_uppercase!('ӂ') == 'Ӂ'
+    assert:       Unicode.codepoint_to_lowercase!('Ӎ') == 'ӎ'
+    assert:       Unicode.codepoint_to_uppercase!('ӎ') == 'Ӎ'
+    assert:       Unicode.codepoint_to_lowercase!('Ӑ') == 'ӑ'
+    assert:       Unicode.codepoint_to_uppercase!('ӑ') == 'Ӑ'
+    assert:       Unicode.codepoint_to_lowercase!('Ӿ') == 'ӿ'
+    assert:       Unicode.codepoint_to_uppercase!('ӿ') == 'Ӿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ԁ') == 'ԁ'
+    assert:       Unicode.codepoint_to_uppercase!('ԁ') == 'Ԁ'
+    assert:       Unicode.codepoint_to_lowercase!('Ԯ') == 'ԯ'
+    assert:       Unicode.codepoint_to_uppercase!('ԯ') == 'Ԯ'
+    assert:       Unicode.codepoint_to_lowercase!('Ա') == 'ա'
+    assert:       Unicode.codepoint_to_uppercase!('ա') == 'Ա'
+    assert:       Unicode.codepoint_to_lowercase!('Ֆ') == 'ֆ'
+    assert:       Unicode.codepoint_to_uppercase!('ֆ') == 'Ֆ'
+    assert error: Unicode.codepoint_to_lowercase!('՟')
+    assert error: Unicode.codepoint_to_uppercase!('՟')
+    assert error: Unicode.codepoint_to_lowercase!('ՠ')
+    assert error: Unicode.codepoint_to_uppercase!('ՠ')
+    assert error: Unicode.codepoint_to_lowercase!('և')
+    assert error: Unicode.codepoint_to_uppercase!('և')
+    assert error: Unicode.codepoint_to_lowercase!('ֈ')
+    assert error: Unicode.codepoint_to_uppercase!('ֈ')
+    assert error: Unicode.codepoint_to_lowercase!('֏')
+    assert error: Unicode.codepoint_to_uppercase!('֏')
+
+    // 0x10xx : Georgian
+    assert:       Unicode.codepoint_to_lowercase!('Ⴀ') == 'ა'
+    assert:       Unicode.codepoint_to_uppercase!('ა') == 'Ⴀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⴥ') == 'ჵ'
+    assert:       Unicode.codepoint_to_uppercase!('ჵ') == 'Ⴥ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⴥ') == 'ჵ'
+    assert:       Unicode.codepoint_to_uppercase!('ჵ') == 'Ⴥ'
+    assert error: Unicode.codepoint_to_lowercase!('ჶ')
+    assert error: Unicode.codepoint_to_uppercase!('ჶ')
+    assert:       Unicode.codepoint_to_lowercase!('Ⴧ') == 'ჷ'
+    assert:       Unicode.codepoint_to_uppercase!('ჷ') == 'Ⴧ'
+    assert error: Unicode.codepoint_to_lowercase!('ჸ')
+    assert error: Unicode.codepoint_to_uppercase!('ჸ')
+    assert:       Unicode.codepoint_to_lowercase!('Ⴭ') == 'ჽ'
+    assert:       Unicode.codepoint_to_uppercase!('ჽ') == 'Ⴭ'
+    assert error: Unicode.codepoint_to_lowercase!('ჾ')
+    assert error: Unicode.codepoint_to_uppercase!('ჾ')
+    assert error: Unicode.codepoint_to_lowercase!('ჿ')
+    assert error: Unicode.codepoint_to_uppercase!('ჿ')
+
+    // 0x13xx : Cherokee
+    assert:       Unicode.codepoint_to_lowercase!('Ꭰ') == 'ꭰ'
+    assert:       Unicode.codepoint_to_uppercase!('ꭰ') == 'Ꭰ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꮿ') == 'ꮿ'
+    assert:       Unicode.codepoint_to_uppercase!('ꮿ') == 'Ꮿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ᏸ') == 'ᏸ'
+    assert:       Unicode.codepoint_to_uppercase!('ᏸ') == 'Ᏸ'
+    assert:       Unicode.codepoint_to_lowercase!('Ᏽ') == 'ᏽ'
+    assert:       Unicode.codepoint_to_uppercase!('ᏽ') == 'Ᏽ'
+
+    // 0x1Cxx : Cyrillic Extended-C and Georgian Extended
+    assert:       Unicode.codepoint_to_uppercase!('ᲀ') == 'В' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲁ') == 'Д' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲂ') == 'О' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲃ') == 'С' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲄ') == 'Т' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲅ') == 'Т' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲆ') == 'Ъ' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲇ') == 'Ѣ' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ᲈ') == 'Ꙋ' // uses main uppercase
+    assert:       Unicode.codepoint_to_lowercase!('Ა') == 'ა' // uses main lowercase
+    assert:       Unicode.codepoint_to_lowercase!('Ჺ') == 'ჺ' // uses main lowercase
+    assert:       Unicode.codepoint_to_lowercase!('Ჽ') == 'ჽ' // uses main lowercase
+    assert:       Unicode.codepoint_to_lowercase!('Ჿ') == 'ჿ' // uses main lowercase
+    assert error: Unicode.codepoint_to_lowercase!('᳀')
+    assert error: Unicode.codepoint_to_uppercase!('᳀')
+
+    // 0x1Fxx : Greek Extended
+    assert:       Unicode.codepoint_to_lowercase!('Ἀ') == 'ἀ'
+    assert:       Unicode.codepoint_to_uppercase!('ἀ') == 'Ἀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἇ') == 'ἇ'
+    assert:       Unicode.codepoint_to_uppercase!('ἇ') == 'Ἇ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἐ') == 'ἐ'
+    assert:       Unicode.codepoint_to_uppercase!('ἐ') == 'Ἐ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἕ') == 'ἕ'
+    assert:       Unicode.codepoint_to_uppercase!('ἕ') == 'Ἕ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἠ') == 'ἠ'
+    assert:       Unicode.codepoint_to_uppercase!('ἠ') == 'Ἠ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἧ') == 'ἧ'
+    assert:       Unicode.codepoint_to_uppercase!('ἧ') == 'Ἧ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἰ') == 'ἰ'
+    assert:       Unicode.codepoint_to_uppercase!('ἰ') == 'Ἰ'
+    assert:       Unicode.codepoint_to_lowercase!('Ἷ') == 'ἷ'
+    assert:       Unicode.codepoint_to_uppercase!('ἷ') == 'Ἷ'
+    assert:       Unicode.codepoint_to_lowercase!('Ὀ') == 'ὀ'
+    assert:       Unicode.codepoint_to_uppercase!('ὀ') == 'Ὀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ὅ') == 'ὅ'
+    assert:       Unicode.codepoint_to_uppercase!('ὅ') == 'Ὅ'
+    assert error: Unicode.codepoint_to_lowercase!('ὐ')
+    assert error: Unicode.codepoint_to_uppercase!('ὐ')
+    assert:       Unicode.codepoint_to_lowercase!('Ὑ') == 'ὑ'
+    assert:       Unicode.codepoint_to_uppercase!('ὑ') == 'Ὑ'
+    assert error: Unicode.codepoint_to_lowercase!('ὖ')
+    assert error: Unicode.codepoint_to_uppercase!('ὖ')
+    assert:       Unicode.codepoint_to_lowercase!('Ὗ') == 'ὗ'
+    assert:       Unicode.codepoint_to_uppercase!('ὗ') == 'Ὗ'
+    assert:       Unicode.codepoint_to_lowercase!('Ὠ') == 'ὠ'
+    assert:       Unicode.codepoint_to_uppercase!('ὠ') == 'Ὠ'
+    assert:       Unicode.codepoint_to_lowercase!('Ὧ') == 'ὧ'
+    assert:       Unicode.codepoint_to_uppercase!('ὧ') == 'Ὧ'
+    assert error: Unicode.codepoint_to_lowercase!('ὰ')
+    assert error: Unicode.codepoint_to_uppercase!('ὰ')
+    assert error: Unicode.codepoint_to_lowercase!('ὼ')
+    assert error: Unicode.codepoint_to_uppercase!('ὼ')
+    assert:       Unicode.codepoint_to_lowercase!('ᾈ') == 'ᾀ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾀ') == 'ᾈ'
+    assert:       Unicode.codepoint_to_lowercase!('ᾏ') == 'ᾇ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾇ') == 'ᾏ'
+    assert:       Unicode.codepoint_to_lowercase!('ᾘ') == 'ᾐ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾐ') == 'ᾘ'
+    assert:       Unicode.codepoint_to_lowercase!('ᾟ') == 'ᾗ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾗ') == 'ᾟ'
+    assert:       Unicode.codepoint_to_lowercase!('ᾨ') == 'ᾠ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾠ') == 'ᾨ'
+    assert:       Unicode.codepoint_to_lowercase!('ᾯ') == 'ᾧ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾧ') == 'ᾯ'
+    assert:       Unicode.codepoint_to_lowercase!('Ᾰ') == 'ᾰ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾰ') == 'Ᾰ'
+    assert:       Unicode.codepoint_to_lowercase!('ᾼ') == 'ᾴ'
+    assert:       Unicode.codepoint_to_uppercase!('ᾴ') == 'ᾼ'
+    assert error: Unicode.codepoint_to_lowercase!('ᾶ')
+    assert error: Unicode.codepoint_to_uppercase!('ᾶ')
+    assert error: Unicode.codepoint_to_lowercase!('ᾷ')
+    assert error: Unicode.codepoint_to_uppercase!('ᾷ')
+    assert error: Unicode.codepoint_to_lowercase!('᾽')
+    assert error: Unicode.codepoint_to_uppercase!('᾽')
+    assert error: Unicode.codepoint_to_lowercase!('῁')
+    assert error: Unicode.codepoint_to_uppercase!('῁')
+    assert:       Unicode.codepoint_to_lowercase!('Ὴ') == 'ῂ'
+    assert:       Unicode.codepoint_to_uppercase!('ῂ') == 'Ὴ'
+    assert:       Unicode.codepoint_to_lowercase!('ῌ') == 'ῄ'
+    assert:       Unicode.codepoint_to_uppercase!('ῄ') == 'ῌ'
+    assert error: Unicode.codepoint_to_lowercase!('ῆ')
+    assert error: Unicode.codepoint_to_uppercase!('ῆ')
+    assert error: Unicode.codepoint_to_lowercase!('ῇ')
+    assert error: Unicode.codepoint_to_uppercase!('ῇ')
+    assert error: Unicode.codepoint_to_lowercase!('῍')
+    assert error: Unicode.codepoint_to_uppercase!('῍')
+    assert error: Unicode.codepoint_to_lowercase!('῏')
+    assert error: Unicode.codepoint_to_uppercase!('῏')
+    assert:       Unicode.codepoint_to_lowercase!('Ῐ') == 'ῐ'
+    assert:       Unicode.codepoint_to_uppercase!('ῐ') == 'Ῐ'
+    assert:       Unicode.codepoint_to_lowercase!('Ί') == 'ΐ'
+    assert:       Unicode.codepoint_to_uppercase!('ΐ') == 'Ί'
+    assert error: Unicode.codepoint_to_lowercase!('ῖ')
+    assert error: Unicode.codepoint_to_uppercase!('ῖ')
+    assert error: Unicode.codepoint_to_lowercase!('ῗ')
+    assert error: Unicode.codepoint_to_uppercase!('ῗ')
+    assert error: Unicode.codepoint_to_lowercase!('῝')
+    assert error: Unicode.codepoint_to_uppercase!('῝')
+    assert error: Unicode.codepoint_to_lowercase!('῟')
+    assert error: Unicode.codepoint_to_uppercase!('῟')
+    assert:       Unicode.codepoint_to_lowercase!('Ῠ') == 'ῠ'
+    assert:       Unicode.codepoint_to_uppercase!('ῠ') == 'Ῠ'
+    assert:       Unicode.codepoint_to_lowercase!('Ῡ') == 'ῡ'
+    assert:       Unicode.codepoint_to_uppercase!('ῡ') == 'Ῡ'
+    assert:       Unicode.codepoint_to_lowercase!('Ῥ') == 'ῥ'
+    assert:       Unicode.codepoint_to_uppercase!('ῥ') == 'Ῥ'
+    assert error: Unicode.codepoint_to_lowercase!('῭')
+    assert error: Unicode.codepoint_to_uppercase!('῭')
+    assert error: Unicode.codepoint_to_lowercase!('`')
+    assert error: Unicode.codepoint_to_uppercase!('`')
+
+    // 0x24xx : Enclosed Alphanumerics
+    assert:       Unicode.codepoint_to_lowercase!('Ⓐ') == 'ⓐ'
+    assert:       Unicode.codepoint_to_uppercase!('ⓐ') == 'Ⓐ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⓩ') == 'ⓩ'
+    assert:       Unicode.codepoint_to_uppercase!('ⓩ') == 'Ⓩ'
+    assert error: Unicode.codepoint_to_lowercase!('⓪')
+    assert error: Unicode.codepoint_to_uppercase!('⓪')
+
+    // 0x2Cxx : Glagolitic, Latin Extended-C, and Coptic
+    assert:       Unicode.codepoint_to_lowercase!('Ⰰ') == 'ⰰ'
+    assert:       Unicode.codepoint_to_uppercase!('ⰰ') == 'Ⰰ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱞ') == 'ⱞ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱞ') == 'Ⱞ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱡ') == 'ⱡ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱡ') == 'Ⱡ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɫ') == 'ɫ'
+    assert:       Unicode.codepoint_to_uppercase!('ɫ') == 'Ɫ'
+    assert:       Unicode.codepoint_to_lowercase!('Ᵽ') == 'ᵽ'
+    assert:       Unicode.codepoint_to_uppercase!('ᵽ') == 'Ᵽ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɽ') == 'ɽ'
+    assert:       Unicode.codepoint_to_uppercase!('ɽ') == 'Ɽ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱥ') == 'ⱥ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱥ') == 'Ⱥ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱦ') == 'ⱦ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱦ') == 'Ⱦ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱨ') == 'ⱨ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱨ') == 'Ⱨ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⱬ') == 'ⱬ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱬ') == 'Ⱬ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɑ') == 'ɑ'
+    assert:       Unicode.codepoint_to_uppercase!('ɑ') == 'Ɑ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɱ') == 'ɱ'
+    assert:       Unicode.codepoint_to_uppercase!('ɱ') == 'Ɱ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɐ') == 'ɐ'
+    assert:       Unicode.codepoint_to_uppercase!('ɐ') == 'Ɐ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɒ') == 'ɒ'
+    assert:       Unicode.codepoint_to_uppercase!('ɒ') == 'Ɒ'
+    assert error: Unicode.codepoint_to_lowercase!('ⱱ')
+    assert error: Unicode.codepoint_to_uppercase!('ⱱ')
+    assert:       Unicode.codepoint_to_lowercase!('Ⱳ') == 'ⱳ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱳ') == 'Ⱳ'
+    assert error: Unicode.codepoint_to_lowercase!('ⱴ')
+    assert error: Unicode.codepoint_to_uppercase!('ⱴ')
+    assert:       Unicode.codepoint_to_lowercase!('Ⱶ') == 'ⱶ'
+    assert:       Unicode.codepoint_to_uppercase!('ⱶ') == 'Ⱶ'
+    assert error: Unicode.codepoint_to_lowercase!('ⱷ')
+    assert error: Unicode.codepoint_to_uppercase!('ⱷ')
+    assert error: Unicode.codepoint_to_lowercase!('ⱼ')
+    assert error: Unicode.codepoint_to_uppercase!('ⱼ')
+    assert:       Unicode.codepoint_to_lowercase!('Ȿ') == 'ȿ'
+    assert:       Unicode.codepoint_to_uppercase!('ȿ') == 'Ȿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɀ') == 'ɀ'
+    assert:       Unicode.codepoint_to_uppercase!('ɀ') == 'Ɀ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⲁ') == 'ⲁ'
+    assert:       Unicode.codepoint_to_uppercase!('ⲁ') == 'Ⲁ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⳣ') == 'ⳣ'
+    assert:       Unicode.codepoint_to_uppercase!('ⳣ') == 'Ⳣ'
+    assert error: Unicode.codepoint_to_lowercase!('ⳤ')
+    assert error: Unicode.codepoint_to_uppercase!('ⳤ')
+    assert error: Unicode.codepoint_to_lowercase!('⳪')
+    assert error: Unicode.codepoint_to_uppercase!('⳪')
+    assert:       Unicode.codepoint_to_lowercase!('Ⳬ') == 'ⳬ'
+    assert:       Unicode.codepoint_to_uppercase!('ⳬ') == 'Ⳬ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⳮ') == 'ⳮ'
+    assert:       Unicode.codepoint_to_uppercase!('ⳮ') == 'Ⳮ'
+    assert:       Unicode.codepoint_to_lowercase!('Ⳳ') == 'ⳳ'
+    assert:       Unicode.codepoint_to_uppercase!('ⳳ') == 'Ⳳ'
+
+    // 0x2Dxx : Georgian Supplement
+    assert:       Unicode.codepoint_to_uppercase!('ⴀ') == 'Ⴀ' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ⴥ') == 'Ⴥ' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ⴧ') == 'Ⴧ' // uses main uppercase
+    assert:       Unicode.codepoint_to_uppercase!('ⴭ') == 'Ⴭ' // uses main uppercase
+
+    // 0xA6xx : Cyrillic Extended-C
+    assert:       Unicode.codepoint_to_lowercase!('Ꙁ') == 'ꙁ'
+    assert:       Unicode.codepoint_to_uppercase!('ꙁ') == 'Ꙁ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꙭ') == 'ꙭ'
+    assert:       Unicode.codepoint_to_uppercase!('ꙭ') == 'Ꙭ'
+    assert error: Unicode.codepoint_to_lowercase!('ꙮ')
+    assert error: Unicode.codepoint_to_uppercase!('ꙮ')
+    assert:       Unicode.codepoint_to_lowercase!('Ꚁ') == 'ꚁ'
+    assert:       Unicode.codepoint_to_uppercase!('ꚁ') == 'Ꚁ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꚛ') == 'ꚛ'
+    assert:       Unicode.codepoint_to_uppercase!('ꚛ') == 'Ꚛ'
+    assert error: Unicode.codepoint_to_lowercase!('ꚜ')
+    assert error: Unicode.codepoint_to_uppercase!('ꚜ')
+
+    // 0xA7xx : Latin Extended-D
+    assert:       Unicode.codepoint_to_lowercase!('Ꜣ') == 'ꜣ'
+    assert:       Unicode.codepoint_to_uppercase!('ꜣ') == 'Ꜣ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꜯ') == 'ꜯ'
+    assert:       Unicode.codepoint_to_uppercase!('ꜯ') == 'Ꜯ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꜳ') == 'ꜳ'
+    assert:       Unicode.codepoint_to_uppercase!('ꜳ') == 'Ꜳ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꝯ') == 'ꝯ'
+    assert:       Unicode.codepoint_to_uppercase!('ꝯ') == 'Ꝯ'
+    assert error: Unicode.codepoint_to_lowercase!('ꝱ')
+    assert error: Unicode.codepoint_to_uppercase!('ꝱ')
+    assert error: Unicode.codepoint_to_lowercase!('ꝸ')
+    assert error: Unicode.codepoint_to_uppercase!('ꝸ')
+    assert:       Unicode.codepoint_to_lowercase!('Ꝺ') == 'ꝺ'
+    assert:       Unicode.codepoint_to_uppercase!('ꝺ') == 'Ꝺ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꝼ') == 'ꝼ'
+    assert:       Unicode.codepoint_to_uppercase!('ꝼ') == 'Ꝼ'
+    assert:       Unicode.codepoint_to_lowercase!('Ᵹ') == 'ᵹ'
+    assert:       Unicode.codepoint_to_uppercase!('ᵹ') == 'Ᵹ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꝿ') == 'ꝿ'
+    assert:       Unicode.codepoint_to_uppercase!('ꝿ') == 'Ꝿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞇ') == 'ꞇ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞇ') == 'Ꞇ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞌ') == 'ꞌ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞌ') == 'Ꞌ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɥ') == 'ɥ'
+    assert:       Unicode.codepoint_to_uppercase!('ɥ') == 'Ɥ'
+    assert error: Unicode.codepoint_to_lowercase!('ꞎ')
+    assert error: Unicode.codepoint_to_uppercase!('ꞎ')
+    assert error: Unicode.codepoint_to_lowercase!('ꞏ')
+    assert error: Unicode.codepoint_to_uppercase!('ꞏ')
+    assert:       Unicode.codepoint_to_lowercase!('Ꞑ') == 'ꞑ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞑ') == 'Ꞑ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞓ') == 'ꞓ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞓ') == 'Ꞓ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞔ') == 'ꞔ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞔ') == 'Ꞔ'
+    assert error: Unicode.codepoint_to_lowercase!('ꞕ')
+    assert error: Unicode.codepoint_to_uppercase!('ꞕ')
+    assert:       Unicode.codepoint_to_lowercase!('Ꞗ') == 'ꞗ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞗ') == 'Ꞗ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞩ') == 'ꞩ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞩ') == 'Ꞩ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɦ') == 'ɦ'
+    assert:       Unicode.codepoint_to_uppercase!('ɦ') == 'Ɦ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɜ') == 'ɜ'
+    assert:       Unicode.codepoint_to_uppercase!('ɜ') == 'Ɜ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɡ') == 'ɡ'
+    assert:       Unicode.codepoint_to_uppercase!('ɡ') == 'Ɡ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɬ') == 'ɬ'
+    assert:       Unicode.codepoint_to_uppercase!('ɬ') == 'Ɬ'
+    assert:       Unicode.codepoint_to_lowercase!('Ɪ') == 'ɪ'
+    assert:       Unicode.codepoint_to_uppercase!('ɪ') == 'Ɪ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʞ') == 'ʞ'
+    assert:       Unicode.codepoint_to_uppercase!('ʞ') == 'Ʞ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʇ') == 'ʇ'
+    assert:       Unicode.codepoint_to_uppercase!('ʇ') == 'Ʇ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʝ') == 'ʝ'
+    assert:       Unicode.codepoint_to_uppercase!('ʝ') == 'Ʝ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꭓ') == 'ꭓ'
+    assert:       Unicode.codepoint_to_uppercase!('ꭓ') == 'Ꭓ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞵ') == 'ꞵ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞵ') == 'Ꞵ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꞿ') == 'ꞿ'
+    assert:       Unicode.codepoint_to_uppercase!('ꞿ') == 'Ꞿ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꟃ') == 'ꟃ'
+    assert:       Unicode.codepoint_to_uppercase!('ꟃ') == 'Ꟃ'
+    assert:       Unicode.codepoint_to_lowercase!('Ʂ') == 'ʂ'
+    assert:       Unicode.codepoint_to_uppercase!('ʂ') == 'Ʂ'
+    assert:       Unicode.codepoint_to_lowercase!('Ᶎ') == 'ᶎ'
+    assert:       Unicode.codepoint_to_uppercase!('ᶎ') == 'Ᶎ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꟈ') == 'ꟈ'
+    assert:       Unicode.codepoint_to_uppercase!('ꟈ') == 'Ꟈ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꟊ') == 'ꟊ'
+    assert:       Unicode.codepoint_to_uppercase!('ꟊ') == 'Ꟊ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꟶ') == 'ꟶ'
+    assert:       Unicode.codepoint_to_uppercase!('ꟶ') == 'Ꟶ'
+    assert error: Unicode.codepoint_to_lowercase!('ꟷ')
+    assert error: Unicode.codepoint_to_uppercase!('ꟷ')
+    assert error: Unicode.codepoint_to_lowercase!('ꟿ')
+    assert error: Unicode.codepoint_to_uppercase!('ꟿ')
+
+    // 0xABxx : Latin Extended-E and Cherokee
+    assert:       Unicode.codepoint_to_lowercase!('Ꭓ') == 'ꭓ'
+    assert:       Unicode.codepoint_to_uppercase!('ꭓ') == 'Ꭓ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꭰ') == 'ꭰ'
+    assert:       Unicode.codepoint_to_uppercase!('ꭰ') == 'Ꭰ'
+    assert:       Unicode.codepoint_to_lowercase!('Ꮿ') == 'ꮿ'
+    assert:       Unicode.codepoint_to_uppercase!('ꮿ') == 'Ꮿ'
+
+    // 0xFFxx : Halfwidth and Fullwidth Forms
+    assert error: Unicode.codepoint_to_lowercase!('＠')
+    assert error: Unicode.codepoint_to_uppercase!('＠')
+    assert:       Unicode.codepoint_to_lowercase!('Ａ') == 'ａ'
+    assert:       Unicode.codepoint_to_uppercase!('ａ') == 'Ａ'
+    assert:       Unicode.codepoint_to_lowercase!('Ｚ') == 'ｚ'
+    assert:       Unicode.codepoint_to_uppercase!('ｚ') == 'Ｚ'
+    assert error: Unicode.codepoint_to_lowercase!('［')
+    assert error: Unicode.codepoint_to_uppercase!('［')
+    assert error: Unicode.codepoint_to_lowercase!('｀')
+    assert error: Unicode.codepoint_to_uppercase!('｀')
+    assert error: Unicode.codepoint_to_lowercase!('｛')
+    assert error: Unicode.codepoint_to_uppercase!('｛')
+
+    // 0x104xx : Deseret and Osage
+    assert:       Unicode.codepoint_to_lowercase!('𐐀') == '𐐨'
+    assert:       Unicode.codepoint_to_uppercase!('𐐨') == '𐐀'
+    assert:       Unicode.codepoint_to_lowercase!('𐐧') == '𐑏'
+    assert:       Unicode.codepoint_to_uppercase!('𐑏') == '𐐧'
+    assert:       Unicode.codepoint_to_lowercase!('𐒰') == '𐓘'
+    assert:       Unicode.codepoint_to_uppercase!('𐓘') == '𐒰'
+    assert:       Unicode.codepoint_to_lowercase!('𐓓') == '𐓻'
+    assert:       Unicode.codepoint_to_uppercase!('𐓻') == '𐓓'
+
+    // 0x10Cxx : Old Hungarian
+    assert:       Unicode.codepoint_to_lowercase!('𐲀') == '𐳀'
+    assert:       Unicode.codepoint_to_uppercase!('𐳀') == '𐲀'
+    assert:       Unicode.codepoint_to_lowercase!('𐲲') == '𐳲'
+    assert:       Unicode.codepoint_to_uppercase!('𐳲') == '𐲲'
+    assert error: Unicode.codepoint_to_lowercase!('𐳺')
+    assert error: Unicode.codepoint_to_uppercase!('𐳺')
+
+    // 0x118xx : Warang Citi
+    assert:       Unicode.codepoint_to_lowercase!('𑢠') == '𑣀'
+    assert:       Unicode.codepoint_to_uppercase!('𑣀') == '𑢠'
+    assert:       Unicode.codepoint_to_lowercase!('𑢿') == '𑣟'
+    assert:       Unicode.codepoint_to_uppercase!('𑣟') == '𑢿'
+    assert error: Unicode.codepoint_to_lowercase!('𑣠')
+    assert error: Unicode.codepoint_to_uppercase!('𑣠')
+
+    // 0x16Exx : Medefaidrin
+    assert:       Unicode.codepoint_to_lowercase!('𖹀') == '𖹠'
+    assert:       Unicode.codepoint_to_uppercase!('𖹠') == '𖹀'
+    assert:       Unicode.codepoint_to_lowercase!('𖹟') == '𖹿'
+    assert:       Unicode.codepoint_to_uppercase!('𖹿') == '𖹟'
+    assert error: Unicode.codepoint_to_lowercase!('𖺀')
+    assert error: Unicode.codepoint_to_uppercase!('𖺀')
+
+    // 0x1E9xx : Adlam
+    assert:       Unicode.codepoint_to_lowercase!('𞤀') == '𞤢'
+    assert:       Unicode.codepoint_to_uppercase!('𞤢') == '𞤀'
+    assert:       Unicode.codepoint_to_lowercase!('𞤡') == '𞥃'
+    assert:       Unicode.codepoint_to_uppercase!('𞥃') == '𞤡'
+    assert error: Unicode.codepoint_to_lowercase!('𞥐')
+    assert error: Unicode.codepoint_to_uppercase!('𞥐')

--- a/packages/src/Savi/Integer.savi
+++ b/packages/src/Savi/Integer.savi
@@ -156,6 +156,12 @@
   :: because the bits shifted off the right side appear again on the left side.
   :fun val bit_rotr(bits U8) T
 
+  :: Return true if the value is even (its least significant bit is unset).
+  :fun val is_even Bool
+
+  :: Return true if the value is odd (its least significant bit is set).
+  :fun val is_odd Bool
+
   :: Count consecutive zero bits, starting with the most significant bit,
   :: until the first one bit is reached (or until the end of the bit sequence).
   :fun val leading_zero_bits U8
@@ -259,6 +265,8 @@
     @bit_shr(bits).bit_or(
       @bit_shl(@bit_width - bits)
     )
+  :fun val is_even Bool: @bit_and(@one) == @zero
+  :fun val is_odd Bool: @bit_and(@one) == @one
   :fun val leading_zero_bits U8: compiler intrinsic
   :fun val trailing_zero_bits U8: compiler intrinsic
   :fun val total_one_bits U8: compiler intrinsic

--- a/packages/src/Unicode/Unicode.savi
+++ b/packages/src/Unicode/Unicode.savi
@@ -1,0 +1,597 @@
+:module Unicode
+  :: Return the corresponding lowercase letter, if the given codepoint is an
+  :: uppercase letter that has such a corresponding lowercase letter.
+  :: Raises an error if it is not a letter, if it is already a lowercase letter,
+  :: or if it has no corresponding uppercase letter defined in the Unicode spec.
+  :fun codepoint_to_lowercase!(code U32) U32
+    @_case_info!(code) -! 0x8000_0000
+
+  :: Return the corresponding uppercase letter, if the given codepoint is an
+  :: lowercase letter that has such a corresponding uppercase letter.
+  :: Raises an error if it is not a letter, if it is already a uppercase letter,
+  :: or if it has no corresponding lowercase letter defined in the Unicode spec.
+  :fun codepoint_to_uppercase!(code U32) U32
+    other_code = @_case_info!(code)
+    error! unless (other_code < 0x8000_0000)
+    other_code
+
+  // These are functions used in the `_case_info!` method to distinguish
+  // between codes going "to lowercase" (from uppercase) and vice versa.
+  // The `_to_lower` method sets the most significant bit, but `_to_upper`
+  // does nothing - it is just there for readability/symmetry, or to allow
+  // us to change the representation later without changing those call sites.
+  :fun _to_lower(code U32) U32: code.bit_or(0x8000_0000)
+  :fun _to_upper(code U32) U32: code
+
+  :fun _case_info!(code U32) U32
+    // Fast path for ASCII
+    return @_case_info_00_ascii!(code) if (code < 0x80)
+
+    // Note: the following two websites are useful when working on this logic:
+    // Search by pasted character: https://www.compart.com/en/unicode
+    // View codepoints as a table: https://unicode-table.com/en/
+    chunk = code.bit_shr(8)
+    case chunk == (
+    | 0x00 | @_case_info_00_latin!(code)
+    | 0x01 | @_case_info_01_latin!(code)
+    | 0x02 | @_case_info_02_latin!(code)
+    | 0x03 | @_case_info_03_greek_and_coptic!(code)
+    | 0x04 | @_case_info_04_cyrillic!(code)
+    | 0x05 | @_case_info_05_cyrillic_and_armenian!(code)
+    | 0x10 | @_case_info_10_georgian!(code)
+    | 0x13 | @_case_info_13_cherokee!(code)
+    | 0x1C | @_case_info_1c_cyrillic_and_georgian!(code)
+    | 0x1D | @_case_info_1d_latin!(code)
+    | 0x1E | @_case_info_1e_latin!(code)
+    | 0x1F | @_case_info_1f_greek!(code)
+    | 0x24 | @_case_info_24_enclosed_latin!(code)
+    | 0x2C | @_case_info_2c_glagolitic_latin_and_coptic!(code)
+    | 0x2D | @_case_info_2d_georgian!(code)
+    | 0xA6 | @_case_info_a6_cyrillic!(code)
+    | 0xA7 | @_case_info_a7_latin!(code)
+    | 0xAB | @_case_info_ab_cherokee!(code)
+    | 0xFF | @_case_info_ff_latin_wide!(code)
+    | 0x104 | @_case_info_104_deseret_and_osage!(code)
+    | 0x10C | @_case_info_10c_old_hungarian!(code)
+    | 0x118 | @_case_info_118_warang_citi!(code)
+    | 0x16E | @_case_info_16e_medefaidrin!(code)
+    | 0x1E9 | @_case_info_1e9_adlam!(code)
+    | error!
+    )
+
+  :fun _case_info_00_ascii!(code U32) U32
+    // 0x00...0x80 : ASCII / Basic Latin
+    case (
+    | code <= 0x40 | error!
+    | code <= 0x5A | @_to_lower(code + 0x20)
+    | code <= 0x60 | error!
+    | code <= 0x7A | @_to_upper(code - 0x20)
+    |                error!
+    )
+
+  :fun _case_info_00_latin!(code U32) U32
+    // 0x00xx : Latin-1 Supplement
+    case (
+    | code <  0x00C0 | error!
+    | code <  0x00D7 | @_to_lower(code + 0x20)
+    | code == 0x00D7 | error!
+    | code <  0x00DF | @_to_lower(code + 0x20)
+    | code == 0x00DF | error!
+    | code <  0x00F7 | @_to_upper(code - 0x20)
+    | code == 0x00F7 | error!
+    | code <  0x00FF | @_to_upper(code - 0x20)
+    | code == 0x00FF | @_to_upper(0x0178)
+    | error! // unreachable
+    )
+
+  :fun _case_info_01_latin!(code U32) U32
+    // 0x01xx : Latin Extended-A and (part of) Extended-B
+    case (
+    | code <  0x0130 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0130 | error!
+    | code == 0x0131 | @_to_upper(0x0049)
+    | code <  0x0138 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0138 | error!
+    | code <  0x0149 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0149 | error!
+    | code <  0x0178 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0178 | @_to_lower(0x00FF)
+    | code <  0x017F | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x017F | error!
+    | code == 0x0180 | @_to_upper(0x0243)
+    | code == 0x0181 | @_to_lower(0x0253)
+    | code <  0x0186 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0186 | @_to_lower(0x0254)
+    | code <  0x0189 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0189 | error!
+    | code == 0x018A | @_to_lower(0x0257)
+    | code <  0x018D | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x018D | error!
+    | code == 0x018E | @_to_lower(0x0258)
+    | code == 0x018F | @_to_lower(0x0259)
+    | code == 0x0190 | @_to_lower(0x025B)
+    | code <  0x0193 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0193 | @_to_lower(0x0260)
+    | code == 0x0194 | @_to_lower(0x0263)
+    | code == 0x0195 | @_to_upper(0x01F6)
+    | code == 0x0196 | @_to_lower(0x0269)
+    | code == 0x0197 | @_to_lower(0x0268)
+    | code <  0x019A | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x019A | @_to_upper(0x023D)
+    | code == 0x019B | error!
+    | code == 0x019C | @_to_lower(0x026F)
+    | code == 0x019D | @_to_lower(0x0272)
+    | code == 0x019E | @_to_upper(0x0220)
+    | code == 0x019F | @_to_lower(0x0275)
+    | code <  0x01A6 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01A6 | @_to_lower(0x0280)
+    | code <  0x01A9 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01A9 | @_to_lower(0x0283)
+    | code <  0x01AC | error!
+    | code <  0x01AE | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01AE | @_to_lower(0x0288)
+    | code <  0x01B1 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01B1 | @_to_lower(0x028A)
+    | code == 0x01B2 | @_to_lower(0x028B)
+    | code <  0x01B7 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01B7 | @_to_lower(0x0292)
+    | code <  0x01BA | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0x01BC | error!
+    | code <  0x01BE | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01BF | @_to_upper(0x01F7)
+    | code <  0x01C4 | error!
+    | code == 0x01C4 | @_to_lower(0x01C6)
+    | code == 0x01C5 | error!
+    | code == 0x01C6 | @_to_upper(0x01C4)
+    | code == 0x01C7 | @_to_lower(0x01C9)
+    | code == 0x01C8 | error!
+    | code == 0x01C9 | @_to_upper(0x01C7)
+    | code == 0x01CA | @_to_lower(0x01CC)
+    | code == 0x01CB | error!
+    | code == 0x01CC | @_to_upper(0x01CA)
+    | code <  0x01DD | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01DD | error!
+    | code <  0x01F0 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01F0 | error!
+    | code == 0x01F1 | @_to_lower(0x01F3)
+    | code == 0x01F2 | error!
+    | code == 0x01F3 | @_to_upper(0x01F1)
+    | code <  0x01F6 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x01F6 | @_to_lower(0x0195)
+    | code == 0x01F7 | @_to_lower(0x01BF)
+    |                  if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    )
+
+  :fun _case_info_02_latin!(code U32) U32
+    // 0x02xx : (part of) Latin Extended-B
+    case (
+    | code <  0x0220 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0220 | @_to_lower(0x019E)
+    | code <  0x0222 | error!
+    | code <  0x0234 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0x023A | error!
+    | code == 0x023A | @_to_lower(0x2C65)
+    | code <  0x023D | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x023D | @_to_lower(0x019A)
+    | code == 0x023E | @_to_lower(0x2C66)
+    | code == 0x023F | @_to_upper(0x2C7E)
+    | code == 0x0240 | @_to_upper(0x2C7F)
+    | code <  0x0243 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0243 | @_to_lower(0x0180)
+    | code == 0x0244 | @_to_lower(0x0289)
+    | code == 0x0245 | @_to_lower(0x028C)
+    | code <  0x0250 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0250 | @_to_upper(0x2C6F)
+    | code == 0x0251 | @_to_upper(0x2C6D)
+    | code == 0x0252 | @_to_upper(0x2C70)
+    | code == 0x0253 | @_to_upper(0x0181)
+    | code == 0x0254 | @_to_upper(0x0186)
+    | code == 0x0257 | @_to_upper(0x018A)
+    | code == 0x0258 | @_to_upper(0x018E)
+    | code == 0x0259 | @_to_upper(0x018F)
+    | code == 0x025B | @_to_upper(0x0190)
+    | code == 0x025C | @_to_upper(0xA7AB)
+    | code == 0x0260 | @_to_upper(0x0193)
+    | code == 0x0261 | @_to_upper(0xA7AC)
+    | code == 0x0263 | @_to_upper(0x0194)
+    | code == 0x0265 | @_to_upper(0xA78D)
+    | code == 0x0266 | @_to_upper(0xA7AA)
+    | code == 0x0268 | @_to_upper(0x0197)
+    | code == 0x0269 | @_to_upper(0x0196)
+    | code == 0x026A | @_to_upper(0xA7AE)
+    | code == 0x026B | @_to_upper(0x2C62)
+    | code == 0x026C | @_to_upper(0xA7AD)
+    | code == 0x026F | @_to_upper(0x019C)
+    | code == 0x0271 | @_to_upper(0x2C6E)
+    | code == 0x0272 | @_to_upper(0x019D)
+    | code == 0x0275 | @_to_upper(0x019F)
+    | code == 0x027D | @_to_upper(0x2C64)
+    | code == 0x0280 | @_to_upper(0x01A6)
+    | code == 0x0282 | @_to_upper(0xA7C5)
+    | code == 0x0283 | @_to_upper(0x01A9)
+    | code == 0x0287 | @_to_upper(0xA7B1)
+    | code == 0x0288 | @_to_upper(0x01AE)
+    | code == 0x0289 | @_to_upper(0x0244)
+    | code == 0x028A | @_to_upper(0x01B1)
+    | code == 0x028B | @_to_upper(0x01B2)
+    | code == 0x028C | @_to_upper(0x0245)
+    | code == 0x0292 | @_to_upper(0x01B7)
+    | code == 0x029D | @_to_upper(0xA7B2)
+    | code == 0x029E | @_to_upper(0xA7B0)
+    | error! // (fills in the gaps between the preceding individual cases)
+    )
+
+  :fun _case_info_03_greek_and_coptic!(code U32) U32
+    // 0x03xx : Greek and Coptic
+    case (
+    | code < 0x0370 | error!
+    | code < 0x0386 |
+      case (
+      | code <  0x0374 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+      | code <  0x0376 | error!
+      | code <  0x0378 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+      | code <  0x037B | error!
+      | code <  0x037E | @_to_upper(code + 0x82)
+      | error!
+      )
+    | code < 0x0391 |
+      case (
+      | code == 0x0386 | @_to_lower(0x03AC)
+      | code == 0x0388 | @_to_lower(0x03AD)
+      | code == 0x0389 | @_to_lower(0x03AE)
+      | code == 0x038A | @_to_lower(0x03AF)
+      | code == 0x038C | @_to_lower(0x03CC)
+      | code == 0x038E | @_to_lower(0x03CD)
+      | code == 0x038F | @_to_lower(0x03CE)
+      | code == 0x0390 | @_to_upper(0x0399)
+      | error!
+      )
+    | code == 0x03A2 | error!
+    | code <  0x03AC | @_to_lower(code + 0x20)
+    | code <  0x03B1 |
+      case (
+      | code == 0x03AC | @_to_upper(0x0386)
+      | code == 0x03AD | @_to_upper(0x0388)
+      | code == 0x03AE | @_to_upper(0x0389)
+      | code == 0x03AF | @_to_upper(0x038A)
+      | code == 0x03B0 | @_to_upper(0x03A5)
+      | error!
+      )
+    | code == 0x03C2 | @_to_upper(0x03A3)
+    | code <  0x03CC | @_to_upper(code - 0x20)
+    | code <  0x03D8 |
+      case (
+      | code == 0x03CC | @_to_upper(0x038C)
+      | code == 0x03CD | @_to_upper(0x038E)
+      | code == 0x03CE | @_to_upper(0x038F)
+      | code == 0x03CF | @_to_lower(0x03D7)
+      | code == 0x03D0 | @_to_upper(0x0392)
+      | code == 0x03D1 | @_to_upper(0x0398)
+      | code == 0x03D5 | @_to_upper(0x03A6)
+      | code == 0x03D7 | @_to_upper(0x03CF)
+      | error!
+      )
+    | code < 0x03F0 |
+      if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | // 0x03F0...0x0400
+      case (
+      | code == 0x03F0 | @_to_upper(0x039A)
+      | code == 0x03F1 | @_to_upper(0x03A1)
+      | code == 0x03F2 | @_to_upper(0x03F9)
+      | code == 0x03F3 | @_to_upper(0x037F)
+      | code == 0x03F4 | @_to_lower(0x03B8)
+      | code == 0x03F5 | @_to_upper(0x0395)
+      | code == 0x03F6 | error!
+      | code <  0x03F9 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+      | code == 0x03F9 | @_to_lower(0x03F2)
+      | code <  0x03FC | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+      | code == 0x03FC | error!
+      | code <  0x0400 | @_to_lower(code - 0x82)
+      | error! // unreachable
+      )
+    )
+
+  :fun _case_info_04_cyrillic!(code U32) U32
+    // 0x04xx : Cyrillic
+    case (
+    | code <  0x0410 | @_to_lower(code + 0x50)
+    | code <  0x0430 | @_to_lower(code + 0x20)
+    | code <  0x0450 | @_to_upper(code - 0x20)
+    | code <  0x0460 | @_to_upper(code - 0x50)
+    | code <  0x0482 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0x048A | error!
+    | code <  0x04C0 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x04C0 | @_to_lower(0x4CF)
+    | code <  0x04CF | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x04CF | @_to_upper(0x04C0)
+    |                  if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    )
+
+  :fun _case_info_05_cyrillic_and_armenian!(code U32) U32
+    // 0x05xx : Cyrillic Supplement and Armenian
+    case (
+    | code <  0x0530 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x0530 | error!
+    | code <  0x0557 | @_to_lower(code + 0x30)
+    | code <  0x0561 | error!
+    | code <  0x0587 | @_to_upper(code - 0x30)
+    |                  error!
+    )
+
+  :fun _case_info_10_georgian!(code U32) U32
+    // 0x10xx : Georgian
+    case (
+    | code <  0x10A0 | error!
+    | code <  0x10C6 | @_to_lower(code + 0x30)
+    | code == 0x10C7 | @_to_lower(code + 0x30)
+    | code == 0x10CD | @_to_lower(code + 0x30)
+    | code <  0x10D0 | error!
+    | code <  0x10F6 | @_to_upper(code - 0x30)
+    | code == 0x10F7 | @_to_upper(code - 0x30)
+    | code == 0x10FD | @_to_upper(code - 0x30)
+    |                  error!
+    )
+
+  :fun _case_info_13_cherokee!(code U32) U32
+    // 0x13xx : Cherokee
+    case (
+    | code <  0x13A0 | error!
+    | code <  0x13F0 | @_to_lower(code + 0x97D0)
+    | code <  0x13F6 | @_to_lower(code + 0x8)
+    | code <  0x13F8 | error!
+    | code <  0x13FE | @_to_upper(code - 0x8)
+    |                  error!
+    )
+
+  :fun _case_info_1c_cyrillic_and_georgian!(code U32) U32
+    // 0x1Cxx : Cyrillic Extended-C and Georgian Extended
+    case (
+    | code <  0x1C80 | error!
+    | code == 0x1C80 | @_to_upper(0x0412)
+    | code == 0x1C81 | @_to_upper(0x0414)
+    | code == 0x1C82 | @_to_upper(0x041E)
+    | code == 0x1C83 | @_to_upper(0x0421)
+    | code == 0x1C84 | @_to_upper(0x0422)
+    | code == 0x1C85 | @_to_upper(0x0422)
+    | code == 0x1C86 | @_to_upper(0x042A)
+    | code == 0x1C87 | @_to_upper(0x0462)
+    | code == 0x1C88 | @_to_upper(0xA64A)
+    | code <  0x1C90 | error!
+    | code <  0x1CBB | @_to_lower(code - 0x0BC0)
+    | code <  0x1CBD | error!
+    | code <  0x1CC0 | @_to_lower(code - 0x0BC0)
+    |                  error!
+    )
+
+  :fun _case_info_1d_latin!(code U32) U32
+    // 0x1Dxx : Phonetic Extensions and Phonetic Extensions Supplement
+    case (
+    | code == 0x1D79 | @_to_upper(0xA77D)
+    | code == 0x1D7D | @_to_upper(0x2C63)
+    | code == 0x1D8E | @_to_upper(0xA7C6)
+    | error!
+    )
+
+  :fun _case_info_1e_latin!(code U32) U32
+    // 0x1Exx : Latin Extended Additional
+    case (
+    | code < 0x1E96 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code < 0x1EA0 | error!
+    |                 if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    )
+
+  :fun _case_info_1f_greek!(code U32) U32
+    // 0x1Fxx : Greek Extended
+    case (
+    | code <  0x1F08 | @_to_upper(code + 8)
+    | code <  0x1F10 | @_to_lower(code - 8)
+    | code <  0x1F16 | @_to_upper(code + 8)
+    | code <  0x1F18 | error!
+    | code <  0x1F1E | @_to_lower(code - 8)
+    | code <  0x1F20 | error!
+    | code <  0x1F28 | @_to_upper(code + 8)
+    | code <  0x1F30 | @_to_lower(code - 8)
+    | code <  0x1F38 | @_to_upper(code + 8)
+    | code <  0x1F40 | @_to_lower(code - 8)
+    | code <  0x1F46 | @_to_upper(code + 8)
+    | code <  0x1F48 | error!
+    | code <  0x1F4E | @_to_lower(code - 8)
+    | code <  0x1F58 | if code.is_odd (@_to_upper(code + 8) | error!)
+    | code <  0x1F60 | if code.is_odd (@_to_lower(code - 8) | error!)
+    | code <  0x1F68 | @_to_upper(code + 8)
+    | code <  0x1F70 | @_to_lower(code - 8)
+    | code <  0x1F80 | error!
+    | code <  0x1F88 | @_to_upper(code + 8)
+    | code <  0x1F90 | @_to_lower(code - 8)
+    | code <  0x1F98 | @_to_upper(code + 8)
+    | code <  0x1FA0 | @_to_lower(code - 8)
+    | code <  0x1FA8 | @_to_upper(code + 8)
+    | code <  0x1FB0 | @_to_lower(code - 8)
+    | code <  0x1FB5 | @_to_upper(code + 8)
+    | code <  0x1FB8 | error!
+    | code <  0x1FBD | @_to_lower(code - 8)
+    | code <  0x1FC2 | error!
+    | code <  0x1FC5 | @_to_upper(code + 8)
+    | code <  0x1FC8 | error!
+    | code <  0x1FCD | @_to_lower(code - 8)
+    | code <  0x1FD0 | error!
+    | code <  0x1FD4 | @_to_upper(code + 8)
+    | code <  0x1FD8 | error!
+    | code <  0x1FDC | @_to_lower(code - 8)
+    | code <  0x1FE0 | error!
+    | code <  0x1FE2 | @_to_upper(code + 8)
+    | code == 0x1FE5 | @_to_upper(0x1FEC)
+    | code <  0x1FE8 | error!
+    | code <  0x1FEA | @_to_lower(code - 8)
+    | code == 0x1FEC | @_to_lower(0x1FE5)
+    | error!
+    )
+
+  :fun _case_info_24_enclosed_latin!(code U32) U32
+    // 0x24xx : Enclosed Alphanumerics
+    case (
+    | code < 0x24B6 | error!
+    | code < 0x24D0 | @_to_lower(code + 0x1A)
+    | code < 0x24EA | @_to_upper(code - 0x1A)
+    |                 error!
+    )
+
+  :fun _case_info_2c_glagolitic_latin_and_coptic!(code U32) U32
+    // 0x2Cxx : Glagolitic, Latin Extended-C, and Coptic
+    case (
+    | code <  0x2C2F | @_to_lower(code + 0x30)
+    | code == 0x2C2F | error!
+    | code <  0x2C5F | @_to_upper(code - 0x30)
+    | code == 0x2C5F | error!
+    | code <  0x2C62 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x2C62 | @_to_lower(0x026B)
+    | code == 0x2C63 | @_to_lower(0x1D7D)
+    | code == 0x2C64 | @_to_lower(0x027D)
+    | code == 0x2C65 | @_to_upper(0x023A)
+    | code == 0x2C66 | @_to_upper(0x023E)
+    | code <  0x2C6D | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x2C6D | @_to_lower(0x0251)
+    | code == 0x2C6E | @_to_lower(0x0271)
+    | code == 0x2C6F | @_to_lower(0x0250)
+    | code == 0x2C70 | @_to_lower(0x0252)
+    | code == 0x2C71 | error!
+    | code <  0x2C74 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0x2C74 | error!
+    | code <  0x2C77 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0x2C7E | error!
+    | code == 0x2C7E | @_to_lower(0x023F)
+    | code == 0x2C7F | @_to_lower(0x0240)
+    | code <  0x2CE4 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0x2CEB | error!
+    | code <  0x2CEF | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0x2CF2 | error!
+    | code <  0x2CF4 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | error!
+    )
+
+  :fun _case_info_2d_georgian!(code U32) U32
+    // 0x2Dxx : Georgian Supplement
+    case (
+    | code <  0x2D26 | @_to_upper(code - 0x1C60)
+    | code == 0x2D27 | @_to_upper(code - 0x1C60)
+    | code == 0x2D2D | @_to_upper(code - 0x1C60)
+    |                  error!
+    )
+
+  :fun _case_info_a6_cyrillic!(code U32) U32
+    // 0xA6xx : Cyrillic Extended-C
+    case (
+    | code <  0xA640 | error!
+    | code <  0xA66E | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0xA680 | error!
+    | code <  0xA69C | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    |                  error!
+    )
+
+  :fun _case_info_a7_latin!(code U32) U32
+    // 0xA7xx : Latin Extended-D
+    case (
+    | code <  0xA722 | error!
+    | code <  0xA730 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0xA732 | error!
+    | code <  0xA770 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0xA779 | error!
+    | code <  0xA77D | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0xA77D | @_to_lower(0x1D79)
+    | code <  0xA788 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0xA78B | error!
+    | code <  0xA78D | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0xA78D | @_to_lower(0x0265)
+    | code <  0xA790 | error!
+    | code <  0xA794 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0xA794 | @_to_upper(0xA7C4)
+    | code == 0xA795 | error!
+    | code <  0xA7AA | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0xA7AA | @_to_lower(0x0266)
+    | code == 0xA7AB | @_to_lower(0x025C)
+    | code == 0xA7AC | @_to_lower(0x0261)
+    | code == 0xA7AD | @_to_lower(0x026C)
+    | code == 0xA7AE | @_to_lower(0x026A)
+    | code == 0xA7AF | error!
+    | code == 0xA7B0 | @_to_lower(0x029E)
+    | code == 0xA7B1 | @_to_lower(0x0287)
+    | code == 0xA7B2 | @_to_lower(0x029D)
+    | code == 0xA7B3 | @_to_lower(0xAB53)
+    | code <  0xA7C0 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0xA7C2 | error!
+    | code <  0xA7C4 | if code.is_even (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code == 0xA7C4 | @_to_lower(0xA794)
+    | code == 0xA7C5 | @_to_lower(0x0282)
+    | code == 0xA7C6 | @_to_lower(0x1D8E)
+    | code <  0xA7CB | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | code <  0xA7F5 | error!
+    | code <  0xA7F7 | if code.is_odd (@_to_lower(code + 1) | @_to_upper(code - 1))
+    | error!
+    )
+
+  :fun _case_info_ab_cherokee!(code U32) U32
+    // 0xABxx : Latin Extended-E and Cherokee
+    case (
+    | code == 0xAB53 | @_to_upper(0xA7B3)
+    | code <  0xAB70 | error!
+    | code <  0xABC0 | @_to_upper(code - 0x97D0)
+    |                  error!
+    )
+
+  :fun _case_info_ff_latin_wide!(code U32) U32
+    // 0xFFxx : Halfwidth and Fullwidth Forms
+    case (
+    | code < 0xFF21 | error!
+    | code < 0xFF3B | @_to_lower(code + 0x20)
+    | code < 0xFF41 | error!
+    | code < 0xFF5B | @_to_upper(code - 0x20)
+    | error!
+    )
+
+  :fun _case_info_104_deseret_and_osage!(code U32) U32
+    // 0x104xx : Deseret and Osage
+    case (
+    | code < 0x10428 | @_to_lower(code + 0x28)
+    | code < 0x10450 | @_to_upper(code - 0x28)
+    | code < 0x104B0 | error!
+    | code < 0x104D4 | @_to_lower(code + 0x28)
+    | code < 0x104D8 | error!
+    | code < 0x104FC | @_to_upper(code - 0x28)
+    | error!
+    )
+
+  :fun _case_info_10c_old_hungarian!(code U32) U32
+    // 0x10Cxx : Old Hungarian
+    case (
+    | code < 0x10C80 | error!
+    | code < 0x10CB3 | @_to_lower(code + 0x40)
+    | code < 0x10CC0 | error!
+    | code < 0x10CF3 | @_to_upper(code - 0x40)
+    | error!
+    )
+
+  :fun _case_info_118_warang_citi!(code U32) U32
+    // 0x118xx : Warang Citi
+    case (
+    | code < 0x118A0 | error!
+    | code < 0x118C0 | @_to_lower(code + 0x20)
+    | code < 0x118E0 | @_to_upper(code - 0x20)
+    | error!
+    )
+
+  :fun _case_info_16e_medefaidrin!(code U32) U32
+    // 0x16Exx : Medefaidrin
+    case (
+    | code < 0x16E40 | error!
+    | code < 0x16E60 | @_to_lower(code + 0x20)
+    | code < 0x16E80 | @_to_upper(code - 0x20)
+    | error!
+    )
+
+  :fun _case_info_1e9_adlam!(code U32) U32
+    // 0x1E9xx : Adlam
+    case (
+    | code < 0x1E922 | @_to_lower(code + 0x22)
+    | code < 0x1E944 | @_to_upper(code - 0x22)
+    | error!
+    )


### PR DESCRIPTION
These methods expose Unicode-compliant mappings for codepoints
that have corresponding uppercase or lowercase letters.

This will be the foundation of future work for changing
the case of words in a `String`.