### PR TITLE
Fill out missing read/write native integer methods in `Bytes`/`ByteStream`.

### DIFF
--- a/packages/spec/ByteStream/Writer.Spec.savi
+++ b/packages/spec/ByteStream/Writer.Spec.savi
@@ -20,6 +20,31 @@
     // After flush, now the data can be read.
     assert: read.extract_all == b"Hello, World!"
 
+  :it "writes U16, U32, and U64 values in native byte order"
+    read = ByteStream.Reader.new
+    write = ByteStream.Writer.to_reader(read)
+
+    // Write some data.
+    write.push_native_u16(0x0123)
+    write.push_native_u16(0x4567)
+    write.push_native_u32(0x01234567)
+    write.push_native_u32(0x89ABCDEF)
+    write.push_native_u64(0x012345678899AABB)
+    write.push_native_u64(0xCCDDEEFF76543210)
+
+    // Nothing is actually written until flush.
+    assert: read.bytes_ahead == 0
+    assert no_error: write.flush!
+    assert: read.bytes_ahead == 28
+
+    // After flush, now the data can be read.
+    assert: read.take_native_u16! == 0x0123
+    assert: read.take_native_u16! == 0x4567
+    assert: read.take_native_u32! == 0x01234567
+    assert: read.take_native_u32! == 0x89ABCDEF
+    assert: read.take_native_u64! == 0x012345678899AABB
+    assert: read.take_native_u64! == 0xCCDDEEFF76543210
+
   :it "efficiently groups individual bytes in the same chunk prior to flush"
     chunks = []
     write = ByteStream.Writer.new(_SinkToArray.new(chunks))

--- a/packages/src/ByteStream/Reader.savi
+++ b/packages/src/ByteStream/Reader.savi
@@ -257,14 +257,62 @@
     while (yield @_data[@_offset]!) (@_offset += 1)
     @
 
+  :: Read the byte at the offset currently pointed to by the cursor,
+  :: and advance the cursor 1 byte forward to point to the next byte.
+  :: Raises an error if the end of the byte stream is reached prior to that.
+  :fun ref take_byte! U8
+    value = @_data.read_byte!(@_offset)
+    @_offset += 1
+    value
+
+  :: Read a `U16` value at the offset currently pointed to by the cursor,
+  :: in native byte order, and advance the cursor past the value.
+  :: Raises an error if the end of the byte stream is reached prior to that.
+  ::
+  :: For protocols using a platform-independent byte order, leverage the
+  :: `U16.be_to_native` or `U16.le_to_native` methods to convert the value
+  :: from its protocol-defined byte order to the native byte order.
+  :fun ref take_native_u16! U16
+    value = @_data.read_native_u16!(@_offset)
+    @_offset += U16.byte_width.usize
+    value
+
+  :: Read a `U32` value at the offset currently pointed to by the cursor,
+  :: in native byte order, and advance the cursor past the value.
+  :: Raises an error if the end of the byte stream is reached prior to that.
+  ::
+  :: For protocols using a platform-independent byte order, leverage the
+  :: `U32.be_to_native` or `U32.le_to_native` methods to convert the value
+  :: from its protocol-defined byte order to the native byte order.
+  :fun ref take_native_u32! U32
+    value = @_data.read_native_u32!(@_offset)
+    @_offset += U32.byte_width.usize
+    value
+
+  :: Read a `U64` value at the offset currently pointed to by the cursor,
+  :: in native byte order, and advance the cursor past the value.
+  :: Raises an error if the end of the byte stream is reached prior to that.
+  ::
+  :: For protocols using a platform-independent byte order, leverage the
+  :: `U64.be_to_native` or `U64.le_to_native` methods to convert the value
+  :: from its protocol-defined byte order to the native byte order.
+  :fun ref take_native_u64! U64
+    value = @_data.read_native_u64!(@_offset)
+    @_offset += U64.byte_width.usize
+    value
+
+  // TODO: consider removing in favor of `take_byte!`
   :fun read_byte!(offset USize) U8
     @_data.read_byte!(@_mark_offset + offset)
 
+  // TODO: consider removing in favor of `take_native_u16!`
   :fun read_native_u16!(offset USize) U16
     @_data.read_native_u16!(@_mark_offset + offset)
 
+  // TODO: consider removing in favor of `take_native_u32!`
   :fun read_native_u32!(offset USize) U32
     @_data.read_native_u32!(@_mark_offset + offset)
 
+  // TODO: consider removing in favor of `take_native_u64!`
   :fun read_native_u64!(offset USize) U64
     @_data.read_native_u64!(@_mark_offset + offset)

--- a/packages/src/ByteStream/Writer.savi
+++ b/packages/src/ByteStream/Writer.savi
@@ -39,6 +39,27 @@
     @_current_chunk.push(byte)
     @
 
+  :: Write a `U16` value as bytes to the stream, in native byte order.
+  ::
+  :: For protocols using a platform-independent byte order, leverage the
+  :: `U16.native_to_be` or `U16.native_to_le` methods to convert the value
+  :: from its native byte order to the specified byte order first.
+  :fun ref push_native_u16(value): @_current_chunk.push_native_u16(value)
+
+  :: Write a `U32` value as bytes to the stream, in native byte order.
+  ::
+  :: For protocols using a platform-independent byte order, leverage the
+  :: `U32.native_to_be` or `U32.native_to_le` methods to convert the value
+  :: from its native byte order to the specified byte order first.
+  :fun ref push_native_u32(value): @_current_chunk.push_native_u32(value)
+
+  :: Write a `U64` value as bytes to the stream, in native byte order.
+  ::
+  :: For protocols using a platform-independent byte order, leverage the
+  :: `U64.native_to_be` or `U64.native_to_le` methods to convert the value
+  :: from its native byte order to the specified byte order first.
+  :fun ref push_native_u64(value): @_current_chunk.push_native_u64(value)
+
   :: Try to write all data that is currently buffered to the `target` sink.
   ::
   :: Raises an error if there is still some data buffered that could not yet be

--- a/packages/src/Savi/Bytes.savi
+++ b/packages/src/Savi/Bytes.savi
@@ -459,6 +459,25 @@
     if ((offset + U16.byte_width.usize) > @_size) error!
     CPointer(U16).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
 
+  :: Write a U16 as bytes starting at the given offset, in native byte order.
+  :: This is not suitable for protocols using a platform-independent byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fit a U16.
+  :: Use push_native_u16 instead if writing past the end is needed.
+  :fun ref write_native_u16!(offset USize, number U16)
+    if ((offset + U16.byte_width.usize) > @_size) error!
+    CPointer(U16).from_usize(@_ptr._offset(offset).usize)._unsafe
+      ._assign_at(0, number)
+    @
+
+  :: Add a U16 as bytes onto the end of the buffer, in native byte order.
+  :: This is not suitable for protocols using a platform-independent byte order.
+  :fun ref push_native_u16(number U16)
+    @reserve(@_size + U16.byte_width.usize)
+    CPointer(U16).from_usize(@_ptr._offset(@_size).usize)._unsafe
+      ._assign_at(0, number)
+    @_size += U16.byte_width.usize
+    @
+
   :: Read a U32 from the bytes at the given offset, with native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
   :: Raises an error if there aren't enough bytes at that offset to fill a U32.


### PR DESCRIPTION
Added methods:
- `ByteStream.Reader.take_byte!`
- `ByteStream.Reader.take_native_u16!`
- `ByteStream.Reader.take_native_u32!`
- `ByteStream.Reader.take_native_u64!`

- `ByteStream.Writer.push_native_u16`
- `ByteStream.Writer.push_native_u32`
- `ByteStream.Writer.push_native_u64`

- `Bytes.write_native_u16!`
- `Bytes.push_native_u16`

The following methods of `ByteStream.Reader` that do not make use of the cursor are being considered for removal, in favor of the new methods that use the cursor's current position and move the cursor forward:
- `ByteStream.Reader.read_byte!`
- `ByteStream.Reader.read_native_u16!`
- `ByteStream.Reader.read_native_u32!`
- `ByteStream.Reader.read_native_u64!`

They have not been removed in this commit, but they may be removed in the future to promote the cursor-based usage, unless adequate motivating use cases can be demonstrated.