### PR TITLE
Add ability to load 3rd-party deps from the `deps` dir, by version.

### DIFF
--- a/examples/adventofcode/2018/manifest.savi
+++ b/examples/adventofcode/2018/manifest.savi
@@ -1,6 +1,6 @@
 :manifest "adventofcode-2018"
   :sources "src/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :dependency Map "TODO: specify version"
-  :dependency Time "TODO: specify version"
+  :dependency Spec v0
+  :dependency Map v0
+  :dependency Time v0

--- a/examples/http/manifest.savi
+++ b/examples/http/manifest.savi
@@ -1,8 +1,8 @@
 :manifest "http-example"
   :sources "src/*.savi"
 
-  :dependency HTTPServer "TODO: specify version"
-  :dependency TCP "TODO: specify version"
-  :dependency IO "TODO: specify version"
-  :transitive dependency ByteStream "TODO: specify version"
-  :transitive dependency OSError "TODO: specify version"
+  :dependency HTTPServer v0
+  :dependency TCP v0
+  :dependency IO v0
+  :transitive dependency ByteStream v0
+  :transitive dependency OSError v0

--- a/packages/ByteStream.manifest.savi
+++ b/packages/ByteStream.manifest.savi
@@ -5,5 +5,5 @@
   :copies ByteStream
   :sources "spec/ByteStream/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/DeterministicRandom.manifest.savi
+++ b/packages/DeterministicRandom.manifest.savi
@@ -1,11 +1,11 @@
 :manifest lib DeterministicRandom
   :sources "src/DeterministicRandom/**/*.savi"
 
-  :dependency Random "TODO: specify version"
+  :dependency Random v0
 
 :manifest bin "spec-DeterministicRandom"
   :copies DeterministicRandom
   :sources "spec/DeterministicRandom/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/HTTPServer.manifest.savi
+++ b/packages/HTTPServer.manifest.savi
@@ -1,11 +1,11 @@
 :manifest lib HTTPServer
   :sources "src/HTTPServer/**/*.savi"
 
-  :dependency ByteStream "TODO: specify version"
+  :dependency ByteStream v0
 
 :manifest bin "spec-HTTPServer"
   :copies HTTPServer
   :sources "spec/HTTPServer/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/IO.manifest.savi
+++ b/packages/IO.manifest.savi
@@ -1,5 +1,5 @@
 :manifest lib IO
   :sources "src/IO/**/*.savi"
 
-  :dependency ByteStream "TODO: specify version"
-  :dependency OSError "TODO: specify version"
+  :dependency ByteStream v0
+  :dependency OSError v0

--- a/packages/JSON.manifest.savi
+++ b/packages/JSON.manifest.savi
@@ -5,5 +5,5 @@
   :copies JSON
   :sources "spec/JSON/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/Map.manifest.savi
+++ b/packages/Map.manifest.savi
@@ -5,5 +5,5 @@
   :copies Map
   :sources "spec/Map/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/Random.manifest.savi
+++ b/packages/Random.manifest.savi
@@ -5,7 +5,7 @@
   :copies Random
   :sources "spec/Random/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0
 
-  :dependency DeterministicRandom "TODO: specify version"
+  :dependency DeterministicRandom v0

--- a/packages/Regex.manifest.savi
+++ b/packages/Regex.manifest.savi
@@ -5,5 +5,5 @@
   :copies Regex
   :sources "spec/Regex/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/Savi.manifest.savi
+++ b/packages/Savi.manifest.savi
@@ -1,5 +1,5 @@
 :manifest bin "spec-Savi"
   :sources "spec/Savi/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/Spec.manifest.savi
+++ b/packages/Spec.manifest.savi
@@ -1,7 +1,7 @@
 :manifest lib Spec
   :sources "src/Spec/**/*.savi"
 
-  :dependency Map "TODO: specify version"
+  :dependency Map v0
 
 :manifest bin "spec-Spec"
   :copies Spec

--- a/packages/StdIn.manifest.savi
+++ b/packages/StdIn.manifest.savi
@@ -1,6 +1,6 @@
 :manifest lib StdIn
   :sources "src/StdIn/**/*.savi"
 
-  :dependency ByteStream "TODO: specify version"
-  :dependency IO "TODO: specify version"
-  :transitive dependency OSError "TODO: specify version"
+  :dependency ByteStream v0
+  :dependency IO v0
+  :transitive dependency OSError v0

--- a/packages/TCP.manifest.savi
+++ b/packages/TCP.manifest.savi
@@ -1,13 +1,13 @@
 :manifest lib TCP
   :sources "src/TCP/**/*.savi"
 
-  :dependency ByteStream "TODO: specify version"
-  :dependency IO "TODO: specify version"
-  :dependency OSError "TODO: specify version"
+  :dependency ByteStream v0
+  :dependency IO v0
+  :dependency OSError v0
 
 :manifest bin "spec-TCP"
   :copies TCP
   :sources "spec/TCP/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/Time.manifest.savi
+++ b/packages/Time.manifest.savi
@@ -5,5 +5,5 @@
   :copies Time
   :sources "spec/Time/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/Unicode.manifest.savi
+++ b/packages/Unicode.manifest.savi
@@ -5,5 +5,5 @@
   :copies Unicode
   :sources "spec/Unicode/**/*.savi"
 
-  :dependency Spec "TODO: specify version"
-  :transitive dependency Map "TODO: specify version"
+  :dependency Spec v0
+  :transitive dependency Map v0

--- a/packages/src/Savi/declarators/declarators.savi
+++ b/packages/src/Savi/declarators/declarators.savi
@@ -502,7 +502,7 @@
   :begins manifest_dependency
 
   :term name Name
-  :term version String
+  :term version Name
 
 // TODO: Document this.
 :declarator transitive
@@ -512,7 +512,7 @@
 
   :keyword dependency
   :term name Name
-  :term version String
+  :term version Name
 
 // TODO: Document this.
 :declarator from

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
@@ -10,12 +10,12 @@ from ./manifest.savi:1:
 
 - this transitive dependency needs to be added:
   from ../../../packages/TCP.manifest.savi:4:
-  :dependency ByteStream "TODO: specify version"
+  :dependency ByteStream v0
               ^~~~~~~~~~
 
 - it is required by this existing dependency:
   from ./manifest.savi:4:
-  :dependency TCP "TODO: specify version"
+  :dependency TCP v0
               ^~~
 
 - run again with --fix to auto-fix this issue.
@@ -29,12 +29,12 @@ from ./manifest.savi:1:
 
 - this transitive dependency needs to be added:
   from ../../../packages/TCP.manifest.savi:5:
-  :dependency IO "TODO: specify version"
+  :dependency IO v0
               ^~
 
 - it is required by this existing dependency:
   from ./manifest.savi:4:
-  :dependency TCP "TODO: specify version"
+  :dependency TCP v0
               ^~~
 
 - run again with --fix to auto-fix this issue.
@@ -48,12 +48,12 @@ from ./manifest.savi:1:
 
 - this transitive dependency needs to be added:
   from ../../../packages/TCP.manifest.savi:6:
-  :dependency OSError "TODO: specify version"
+  :dependency OSError v0
               ^~~~~~~
 
 - it is required by this existing dependency:
   from ./manifest.savi:4:
-  :dependency TCP "TODO: specify version"
+  :dependency TCP v0
               ^~~
 
 - run again with --fix to auto-fix this issue.

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
@@ -1,10 +1,10 @@
 :manifest "example"
   :sources "main.savi"
 
-  :dependency TCP "TODO: specify version"
+  :dependency TCP v0
 
-  :transitive dependency ByteStream "TODO: specify version"
+  :transitive dependency ByteStream v0
 
-  :transitive dependency IO "TODO: specify version"
+  :transitive dependency IO v0
 
-  :transitive dependency OSError "TODO: specify version"
+  :transitive dependency OSError v0

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/manifest.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/manifest.savi
@@ -1,4 +1,4 @@
 :manifest "example"
   :sources "main.savi"
 
-  :dependency TCP "TODO: specify version"
+  :dependency TCP v0

--- a/spec/integration/run-stdin-from-file/manifest.savi
+++ b/spec/integration/run-stdin-from-file/manifest.savi
@@ -1,7 +1,7 @@
 :manifest "example"
   :sources "src/*.savi"
 
-  :dependency StdIn "TODO: specify version"
-  :dependency IO "TODO: specify version"
-  :transitive dependency ByteStream "TODO: specify version"
-  :transitive dependency OSError "TODO: specify version"
+  :dependency StdIn v0
+  :dependency IO v0
+  :transitive dependency ByteStream v0
+  :transitive dependency OSError v0

--- a/spec/integration/run-stdin-from-pipe-large/manifest.savi
+++ b/spec/integration/run-stdin-from-pipe-large/manifest.savi
@@ -1,7 +1,7 @@
 :manifest "example"
   :sources "src/*.savi"
 
-  :dependency StdIn "TODO: specify version"
-  :dependency IO "TODO: specify version"
-  :transitive dependency ByteStream "TODO: specify version"
-  :transitive dependency OSError "TODO: specify version"
+  :dependency StdIn v0
+  :dependency IO v0
+  :transitive dependency ByteStream v0
+  :transitive dependency OSError v0

--- a/spec/integration/run-stdin-from-pipe/manifest.savi
+++ b/spec/integration/run-stdin-from-pipe/manifest.savi
@@ -1,7 +1,7 @@
 :manifest "example"
   :sources "src/*.savi"
 
-  :dependency StdIn "TODO: specify version"
-  :dependency IO "TODO: specify version"
-  :transitive dependency ByteStream "TODO: specify version"
-  :transitive dependency OSError "TODO: specify version"
+  :dependency StdIn v0
+  :dependency IO v0
+  :transitive dependency ByteStream v0
+  :transitive dependency OSError v0

--- a/spec/integration/run-stdout/manifest.savi
+++ b/spec/integration/run-stdout/manifest.savi
@@ -1,4 +1,4 @@
 :manifest "example"
   :sources "src/*.savi"
 
-  :dependency ByteStream "TODO: specify version"
+  :dependency ByteStream v0

--- a/src/savi/compiler/context.cr
+++ b/src/savi/compiler/context.cr
@@ -89,7 +89,7 @@ class Savi::Compiler::Context
     return if @program.manifests.any?(&.name.pos.source.package.path.==(path))
 
     # Otherwise go ahead and load the manifests.
-    sources = compiler.source_service.get_manifest_sources_at_or_above(path)
+    sources = compiler.source_service.get_manifest_sources_at(path)
     docs = sources.map { |source| Parser.parse(source) }
     package = compile_package(sources.first.package, docs)
     self

--- a/src/savi/packaging/dependency.cr
+++ b/src/savi/packaging/dependency.cr
@@ -1,22 +1,21 @@
 struct Savi::Packaging::Dependency
   getter ast : AST::Declare
   getter name : AST::Identifier
-  getter version_node : AST::LiteralString
-  getter version_major : Int32
-  getter version_minor : Int32
-  getter version_patch : Int32
+  getter version : AST::Identifier
 
-  getter location_nodes = [] of AST::Identifier
+  getter location_nodes = [] of AST::LiteralString
   getter revision_nodes = [] of AST::Identifier
   getter depends_on_nodes = [] of AST::Identifier
 
-  def initialize(@ast, @name, @version_node, @transitive = false)
-    @version_major = 0 # TODO
-    @version_minor = 0 # TODO
-    @version_patch = 0 # TODO
+  def initialize(@ast, @name, @version, @transitive = false)
   end
 
   def transitive?
     @transitive
+  end
+
+  def accepts_version?(version : String)
+    expected = @version.value
+    version == expected || (version.starts_with?("#{expected}."))
   end
 end

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -159,13 +159,13 @@ module Savi::Program::Intrinsic
         scope.current_manifest.sources_paths << {path, [] of AST::LiteralString}
       when "dependency"
         name = terms["name"].as(AST::Identifier)
-        version = terms["version"].as(AST::LiteralString)
+        version = terms["version"].as(AST::Identifier)
         scope.current_manifest_dependency = dep =
           Packaging::Dependency.new(declare, name, version)
         scope.current_manifest.dependencies << dep
       when "transitive"
         name = terms["name"].as(AST::Identifier)
-        version = terms["version"].as(AST::LiteralString)
+        version = terms["version"].as(AST::Identifier)
         scope.current_manifest_dependency = dep =
           Packaging::Dependency.new(declare, name, version, transitive: true)
         scope.current_manifest.dependencies << dep
@@ -187,7 +187,7 @@ module Savi::Program::Intrinsic
     when "manifest_dependency"
       case declarator.name.value
       when "from"
-        location = terms["location"].as(AST::Identifier)
+        location = terms["location"].as(AST::LiteralString)
         scope.current_manifest_dependency.location_nodes << location
       when "lock"
         revision = terms["revision"].as(AST::Identifier)


### PR DESCRIPTION
This is part of https://github.com/savi-lang/savi/issues/44

---

Note that we don't yet have the `savi add` / `savi update` tooling in place that populates the `deps` directory, so currently to use this feature, you must populate the directory manually.

Note also that this PR is lacking any integration tests for this feature, because it's kind of incomplete at the moment, and the tests would need to change when the rest of the package management tooling are added.