### PR TITLE
Add `:depends on` declarations to dependencies in manifests.

### DIFF
--- a/examples/adventofcode/2018/manifest.savi
+++ b/examples/adventofcode/2018/manifest.savi
@@ -2,5 +2,6 @@
   :sources "src/*.savi"
 
   :dependency Spec v0
+    :depends on Map
   :dependency Map v0
   :dependency Time v0

--- a/examples/http/manifest.savi
+++ b/examples/http/manifest.savi
@@ -2,7 +2,17 @@
   :sources "src/*.savi"
 
   :dependency HTTPServer v0
+    :depends on ByteStream
+
   :dependency TCP v0
+    :depends on ByteStream
+    :depends on IO
+    :depends on OSError
+
   :dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
+
   :transitive dependency ByteStream v0
+
   :transitive dependency OSError v0

--- a/packages/ByteStream.manifest.savi
+++ b/packages/ByteStream.manifest.savi
@@ -6,4 +6,6 @@
   :sources "spec/ByteStream/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/DeterministicRandom.manifest.savi
+++ b/packages/DeterministicRandom.manifest.savi
@@ -8,4 +8,6 @@
   :sources "spec/DeterministicRandom/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/HTTPServer.manifest.savi
+++ b/packages/HTTPServer.manifest.savi
@@ -8,4 +8,6 @@
   :sources "spec/HTTPServer/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/JSON.manifest.savi
+++ b/packages/JSON.manifest.savi
@@ -6,4 +6,6 @@
   :sources "spec/JSON/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/Map.manifest.savi
+++ b/packages/Map.manifest.savi
@@ -6,4 +6,6 @@
   :sources "spec/Map/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/Random.manifest.savi
+++ b/packages/Random.manifest.savi
@@ -5,7 +5,10 @@
   :copies Random
   :sources "spec/Random/**/*.savi"
 
-  :dependency Spec v0
-  :transitive dependency Map v0
-
   :dependency DeterministicRandom v0
+    :depends on Random
+
+  :dependency Spec v0
+    :depends on Map
+
+  :transitive dependency Map v0

--- a/packages/Regex.manifest.savi
+++ b/packages/Regex.manifest.savi
@@ -6,4 +6,6 @@
   :sources "spec/Regex/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/Savi.manifest.savi
+++ b/packages/Savi.manifest.savi
@@ -2,4 +2,6 @@
   :sources "spec/Savi/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/StdIn.manifest.savi
+++ b/packages/StdIn.manifest.savi
@@ -2,5 +2,9 @@
   :sources "src/StdIn/**/*.savi"
 
   :dependency ByteStream v0
+
   :dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
+
   :transitive dependency OSError v0

--- a/packages/TCP.manifest.savi
+++ b/packages/TCP.manifest.savi
@@ -2,7 +2,11 @@
   :sources "src/TCP/**/*.savi"
 
   :dependency ByteStream v0
+
   :dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
+
   :dependency OSError v0
 
 :manifest bin "spec-TCP"
@@ -10,4 +14,6 @@
   :sources "spec/TCP/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/Time.manifest.savi
+++ b/packages/Time.manifest.savi
@@ -6,4 +6,6 @@
   :sources "spec/Time/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/packages/Unicode.manifest.savi
+++ b/packages/Unicode.manifest.savi
@@ -6,4 +6,6 @@
   :sources "spec/Unicode/**/*.savi"
 
   :dependency Spec v0
+    :depends on Map
+
   :transitive dependency Map v0

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
@@ -22,20 +22,15 @@ from ./manifest.savi:1:
 
 ---
 
-A transitive dependency is missing from this manifest:
-from ./manifest.savi:1:
-:manifest "example"
-          ^~~~~~~~~
-
-- this transitive dependency needs to be added:
-  from ../../../packages/TCP.manifest.savi:5:
-  :dependency IO v0
-              ^~
-
-- it is required by this existing dependency:
-  from ./manifest.savi:4:
+A `:depends on` declaration is missing from this dependency:
+from ./manifest.savi:4:
   :dependency TCP v0
               ^~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:4:
+  :dependency ByteStream v0
+              ^~~~~~~~~~
 
 - run again with --fix to auto-fix this issue.
 
@@ -48,6 +43,39 @@ from ./manifest.savi:1:
 
 - this transitive dependency needs to be added:
   from ../../../packages/TCP.manifest.savi:6:
+  :dependency IO v0
+              ^~
+
+- it is required by this existing dependency:
+  from ./manifest.savi:4:
+  :dependency TCP v0
+              ^~~
+
+- run again with --fix to auto-fix this issue.
+
+---
+
+A `:depends on` declaration is missing from this dependency:
+from ./manifest.savi:4:
+  :dependency TCP v0
+              ^~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:6:
+  :dependency IO v0
+              ^~
+
+- run again with --fix to auto-fix this issue.
+
+---
+
+A transitive dependency is missing from this manifest:
+from ./manifest.savi:1:
+:manifest "example"
+          ^~~~~~~~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:10:
   :dependency OSError v0
               ^~~~~~~
 
@@ -55,5 +83,19 @@ from ./manifest.savi:1:
   from ./manifest.savi:4:
   :dependency TCP v0
               ^~~
+
+- run again with --fix to auto-fix this issue.
+
+---
+
+A `:depends on` declaration is missing from this dependency:
+from ./manifest.savi:4:
+  :dependency TCP v0
+              ^~~
+
+- this transitive dependency needs to be added:
+  from ../../../packages/TCP.manifest.savi:10:
+  :dependency OSError v0
+              ^~~~~~~
 
 - run again with --fix to auto-fix this issue.

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
@@ -2,9 +2,14 @@
   :sources "main.savi"
 
   :dependency TCP v0
+    :depends on ByteStream
+    :depends on IO
+    :depends on OSError
 
   :transitive dependency ByteStream v0
 
   :transitive dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
 
   :transitive dependency OSError v0

--- a/spec/integration/run-stdin-from-file/manifest.savi
+++ b/spec/integration/run-stdin-from-file/manifest.savi
@@ -2,6 +2,14 @@
   :sources "src/*.savi"
 
   :dependency StdIn v0
+    :depends on ByteStream
+    :depends on IO
+    :depends on OSError
+
   :dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
+
   :transitive dependency ByteStream v0
+
   :transitive dependency OSError v0

--- a/spec/integration/run-stdin-from-pipe-large/manifest.savi
+++ b/spec/integration/run-stdin-from-pipe-large/manifest.savi
@@ -2,6 +2,14 @@
   :sources "src/*.savi"
 
   :dependency StdIn v0
+    :depends on ByteStream
+    :depends on IO
+    :depends on OSError
+
   :dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
+
   :transitive dependency ByteStream v0
+
   :transitive dependency OSError v0

--- a/spec/integration/run-stdin-from-pipe/manifest.savi
+++ b/spec/integration/run-stdin-from-pipe/manifest.savi
@@ -2,6 +2,14 @@
   :sources "src/*.savi"
 
   :dependency StdIn v0
+    :depends on ByteStream
+    :depends on IO
+    :depends on OSError
+
   :dependency IO v0
+    :depends on ByteStream
+    :depends on OSError
+
   :transitive dependency ByteStream v0
+
   :transitive dependency OSError v0

--- a/src/savi/packaging/dependency.cr
+++ b/src/savi/packaging/dependency.cr
@@ -36,4 +36,8 @@ struct Savi::Packaging::Dependency
 
     location.split(":", 2).last
   end
+
+  def append_pos
+    ast.span_pos(ast.pos.source).next_line_start_as_pos
+  end
 end

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -193,7 +193,7 @@ module Savi::Program::Intrinsic
         revision = terms["revision"].as(AST::Identifier)
         scope.current_manifest_dependency.revision_nodes << revision
       when "depends"
-        name = terms["name"].as(AST::Identifier)
+        name = terms["other"].as(AST::Identifier)
         scope.current_manifest_dependency.depends_on_nodes << name
       else
         raise NotImplementedError.new(declarator.pretty_inspect)

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -260,6 +260,12 @@ struct Savi::Source::Pos
     Pos.point(source, index)
   end
 
+  def whole_containing_lines_as_pos
+    new_start = source.content.byte_rindex('\n', start).try(&.+(1)) || 0
+    new_finish = source.content.byte_index('\n', finish).try(&.+(1)) || source.content.bytesize
+    Pos.index_range(source, new_start, new_finish)
+  end
+
   def get_indent
     match = /\G[ \t]+/.match_at_byte_index(source.content, line_start)
     new_finish = match ? match.byte_end(0) : line_start


### PR DESCRIPTION
These declarations will be automatically populated by `savi deps update`,
and they will be required when compiling.

This is part of https://github.com/savi-lang/savi/issues/44