### PR TITLE
Fetch deps from GitHub using git+HTTPS, not git+SSH.

### DIFF
--- a/src/savi/packaging/remote_service.cr
+++ b/src/savi/packaging/remote_service.cr
@@ -37,7 +37,7 @@ module Savi::Packaging::RemoteService
         repo_name = dep.location_without_scheme
         output = IO::Memory.new
         args = COMMAND_GIT_REMOTE_SORTED_TAGS.dup
-        args << "git@github.com:#{repo_name}.git"
+        args << "https://github.com/:#{repo_name}.git"
         process = Process.new("/usr/bin/env", args, output: output)
         {dep, process, output}
       }


### PR DESCRIPTION
It's not guaranteed that the machine we're using for `savi deps update`
has an SSH key configured with GitHub access, but HTTPS transport
should always work, and allows anonymous pulling of public repos.

This should have been using git+HTTPS from the start.
Using git+SSH was a mistake that I'm fixing now.

---

In the future we may need to do some extra work to support private repos (when Savi starts seeing some commercial use),
but for now we can expect that all repos are public, and optimize for the public case.