### PR TITLE
Add the `savi deps add` command.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -503,6 +503,11 @@
 
   :term name Name
   :term version Name
+    :: This is not truly optional, but we have a "nice error" later
+    :: that can be auto-fixed by auto-specifying the latest version,
+    :: so here in the declarator we allow it to be optional so that
+    :: it can reach the later step of having a "nice error".
+    :optional
 
 // TODO: Document this.
 :declarator transitive

--- a/main.cr
+++ b/main.cr
@@ -147,6 +147,31 @@ module Savi
             Cli.compile options, opts.backtrace
           end
         end
+        sub "add" do
+          desc "add a dependency"
+          usage "savi deps add NAME [options]"
+          help short: "-h"
+          argument "name", type: String, required: true, desc: "Name of the dependency to add"
+          option "-b", "--backtrace", desc: "Show backtrace on error", type: Bool, default: false
+          option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
+          option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
+          option "-C", "--cd=DIR", desc: "Change the working directory"
+          option "--for=MANIFEST", desc: "Specify the manifest to add the dependency to"
+          option "--from=LOCATION", desc: "Specify the location to fetch the dependency from"
+          run do |opts, args|
+            options = Savi::Compiler::Options.new
+            options.print_perf = true if opts.print_perf
+            options.auto_fix = true if opts.fix
+            options.manifest_name = opts.for.not_nil! if opts.for
+            options.deps_update = args.name
+            options.deps_add = args.name
+            options.deps_add_location = opts.from.not_nil! if opts.from
+            options.target_pass = :load # stop after the :load pass is done
+            options.auto_fix = true # auto-fix changes due to updated deps
+            Dir.cd(opts.cd.not_nil!) if opts.cd
+            Cli.compile options, opts.backtrace
+          end
+        end
       end
       sub "compilerspec" do
         desc "run compiler specs"

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -18,6 +18,17 @@ class Savi::Compiler
     # dependency name will be updated, along with all its dependencies.
     property deps_update : String?
 
+    # If set, we will add a dependency with the given name.
+    property deps_add : String?
+
+    # If set, specifies the location that the dependency named in `deps_add`
+    # should be fetched from when it is time to fetch it.
+    # If left unset, then the central `savi-lang/library-index` GitHub repo
+    # will be used to try to look up a known location for that name.
+    # If that search fails to find exactly one location, an error will be
+    # given prompting the user to specify an explicit location next time.
+    property deps_add_location : String?
+
     def initialize(
       @release = false,
       @no_debug = false,

--- a/src/savi/packaging/dependency.cr
+++ b/src/savi/packaging/dependency.cr
@@ -1,7 +1,7 @@
 struct Savi::Packaging::Dependency
   getter ast : AST::Declare
   getter name : AST::Identifier
-  getter version : AST::Identifier
+  getter version : AST::Identifier?
 
   getter location_nodes = [] of AST::LiteralString
   getter revision_nodes = [] of AST::Identifier
@@ -15,7 +15,11 @@ struct Savi::Packaging::Dependency
   end
 
   def accepts_version?(version : String)
-    expected = @version.value
+    expected = @version.try(&.value)
+
+    # If no version was specified, then every version is acceptable.
+    return true unless expected
+
     version == expected || (version.starts_with?("#{expected}."))
   end
 

--- a/src/savi/packaging/remote_service.cr
+++ b/src/savi/packaging/remote_service.cr
@@ -1,4 +1,13 @@
+require "file_utils"
+
 module Savi::Packaging::RemoteService
+  def self.find_location_for(ctx, dep_name : String) : String?
+    GitHub.find_location_for(ctx, dep_name)
+  end
+
+  GITHUB_LIBRARY_INDEX_REPO_BASE_URL =
+    "https://raw.githubusercontent.com/savi-lang/library-index"
+
   def self.update_all(ctx, deps : Array(Dependency), into_dirname : String)
     deps.group_by(&.location_scheme).each { |scheme, scheme_deps|
       case scheme
@@ -59,30 +68,39 @@ module Savi::Packaging::RemoteService
         # Get tag names from the sorted output of the process.
         sorted_tags = output.to_s.each_line.map(&.split("refs/tags/", 2).last).to_a
         if sorted_tags.empty?
+          hints = [
+            {dep.location_nodes.first.pos,
+              "this repository had no commits tagged in it"},
+          ]
+          dep.version.try { |version_node|
+            hints << {version_node.pos,
+              "please tag a commit with a version tag starting with " +
+                  version_node.value.inspect}
+          }
+
           ctx.error_at dep.name,
-            "No remote versions were found for this dependency", [
-              {dep.location_nodes.first.pos,
-                "this repository had no commits tagged in it"},
-              {dep.version.pos,
-                "please tag a commit with a version tag starting with " +
-                  dep.version.value.inspect},
-            ]
+            "No remote versions were found for this dependency", hints
           next
         end
 
         # Find the first version in the sorted tags that meets the requirement.
         version = sorted_tags.find { |tag| dep.accepts_version?(tag) }
         if !version
+          hints = [
+            {dep.location_nodes.first.pos,
+              "this repository had no matching commit tags in it"},
+          ]
+          dep.version.try { |version_node|
+            hints << {version_node.pos,
+              "please tag a commit with a version tag starting with " +
+                  version_node.value.inspect}
+          }
+          sorted_tags.each { |tag|
+            hints << {Source::Pos.none, "this tag was found, but didn't match: #{tag}"}
+          }
+
           ctx.error_at dep.name,
-            "No matching remote version was found for this dependency", [
-              {dep.location_nodes.first.pos,
-                "this repository had no matching commit tags in it"},
-              {dep.version.pos,
-                "please tag a commit with a version tag starting with " +
-                  dep.version.value.inspect},
-            ] + sorted_tags.map { |tag|
-              {Source::Pos.none, "this tag was found, but didn't match: #{tag}"}
-            }.to_a
+            "No matching remote version was found for this dependency", hints
           next
         end
 
@@ -108,7 +126,7 @@ module Savi::Packaging::RemoteService
 
       # Fast exit if there's nothing new to be downloaded.
       return if download_list.empty?
-      puts "Downloading new package versions from GitHub..."
+      puts "Downloading new library versions from GitHub..."
 
       # Spawn the sub-processes to shallow-clone the specified versions.
       process_list = download_list.map { |dep, version|
@@ -136,6 +154,83 @@ module Savi::Packaging::RemoteService
 
         puts "Downloaded #{dep.name.value} #{version}"
       }
+    end
+
+    COMMAND_GIT_CLONE_MINIMAL =
+      %w{git clone --depth=1 --bare --filter=blob:none}
+
+    @@location_cache = {} of String => String
+    def self.find_location_for(ctx, dep_name : String) : String?
+      # If we already have a cached location in this same compiler invocation,
+      # we should not look up the location again. We may run this several
+      # times in a loop when iterating through auto-fix cycles.
+      cached_location = @@location_cache[dep_name]?
+      return cached_location if cached_location
+
+      puts "Finding a remote location for the #{dep_name} library..."
+
+      # Choose a random temporary directory name.
+      tmp_dir = File.join(Dir.tempdir, "savi-library-index-#{Random::Secure.hex}")
+
+      # Clone the git repo minimally into the temporary directory, without
+      # actually downloading the full history or the full set of files.
+      # In the next step we'll get only the one file we care about.
+      clone_args = COMMAND_GIT_CLONE_MINIMAL.dup
+      clone_args << "https://github.com/savi-lang/library-index.git"
+      clone_args << tmp_dir
+      clone_process = Process.new("/usr/bin/env", clone_args)
+      if !clone_process.wait.success?
+        ctx.error_at Source::Pos.none, "Failed to reach the remote library index", [
+          {Source::Pos.none, "please check your internet connectivity, or try again later"},
+        ]
+        return
+      end
+
+      # Use the bare repo to show the one file we care about - the text file
+      # that indicates the known location(s) of the given library name.
+      show_output = IO::Memory.new
+      show_args = ["git"]
+      show_args << "--git-dir=#{tmp_dir}"
+      show_args << "show"
+      show_args << "HEAD:by-lib-name/#{dep_name}.txt"
+      show_process = Process.new("/usr/bin/env", show_args, output: show_output)
+      if !show_process.wait.success?
+        ctx.error_at Source::Pos.none, "The library #{dep_name.inspect} isn't known in the remote library index", [
+          {Source::Pos.none, "please check your spelling, or specify an " + \
+            "explicit location using an option like the following:"},
+          {Source::Pos.none, "--from github:some-user/some-repo"},
+        ]
+        return
+      end
+
+      # Read the location list from the file.
+      # If there is just one location name, use it (and save it in the cache).
+      # Otherwise print an error asking for an explicit location.
+      locations = show_output.to_s.each_line.to_a.reject(&.empty?)
+      case locations.size
+      when 1
+        location = locations.first
+        puts "Found a known location: #{location}"
+        @@location_cache[dep_name] = location
+        return location
+      when 0
+        ctx.error_at Source::Pos.none, "The library #{dep_name.inspect} isn't known in the remote library index", [
+          {Source::Pos.none, "please check your spelling, or specify an " + \
+            "explicit location using an option like the following:"},
+          {Source::Pos.none, "--from github:some-user/some-repo"},
+        ]
+      else
+        ctx.error_at Source::Pos.none, "The library #{dep_name.inspect} has multiple known locations", [
+          {Source::Pos.none, "please use one of the following explicit locations:"},
+        ] + locations.map { |location|
+          {Source::Pos.none, "--from #{location}"}
+        }
+      end
+
+    ensure
+      # Clean up after ourselves.
+      # Ensure that the temporary directory gets deleted, if it exists.
+      FileUtils.rm_rf(tmp_dir) if tmp_dir
     end
   end
 end

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -159,13 +159,13 @@ module Savi::Program::Intrinsic
         scope.current_manifest.sources_paths << {path, [] of AST::LiteralString}
       when "dependency"
         name = terms["name"].as(AST::Identifier)
-        version = terms["version"].as(AST::Identifier)
+        version = terms["version"]?.try(&.as(AST::Identifier))
         scope.current_manifest_dependency = dep =
           Packaging::Dependency.new(declare, name, version)
         scope.current_manifest.dependencies << dep
       when "transitive"
         name = terms["name"].as(AST::Identifier)
-        version = terms["version"].as(AST::Identifier)
+        version = terms["version"]?.try(&.as(AST::Identifier))
         scope.current_manifest_dependency = dep =
           Packaging::Dependency.new(declare, name, version, transitive: true)
         scope.current_manifest.dependencies << dep

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -255,6 +255,10 @@ struct Savi::Source::Pos
     )
   end
 
+  def end_point_as_pos
+    Pos.point(source, finish)
+  end
+
   def next_line_start_as_pos
     index = source.content.byte_index('\n', finish) || source.content.bytesize
     Pos.point(source, index)
@@ -264,6 +268,14 @@ struct Savi::Source::Pos
     new_start = source.content.byte_rindex('\n', start).try(&.+(1)) || 0
     new_finish = source.content.byte_index('\n', finish).try(&.+(1)) || source.content.bytesize
     Pos.index_range(source, new_start, new_finish)
+  end
+
+  def from_start_until_start_of(other_pos : Source::Pos)
+    raise "#{other_pos} is not in the same source file as #{self}" \
+      unless other_pos.source == source
+    raise "#{other_pos} does not come after #{self}" \
+      unless other_pos.start > start
+    Pos.index_range(source, start, other_pos.start)
   end
 
   def get_indent


### PR DESCRIPTION
Running `savi deps add TCP` will:
- look up the location of the `TCP` library,
- download that library to the local `deps` subdirectory
- list all the transitive dependencies for it,
- download all the transitive dependencies
- update the manifest to include the new `TCP` dependency
- update the manifest to include any new transitive dependencies.

This is part of #44.