### PR TITLE
Add the `savi init lib` and `savi init bin` commands.

### DIFF
--- a/src/savi/init.cr
+++ b/src/savi/init.cr
@@ -1,0 +1,101 @@
+require "file_utils"
+
+module Savi::Init
+  module Lib
+    def self.run(name : String) : Bool
+      unless /\A[A-Z][\w\d]*\z/ =~ name
+        STDERR.puts "Please name your library using a valid type name, " +
+          "starting with an uppercase letter."
+        return false
+      end
+
+      Init.with_files([
+        {"manifest.savi", [
+          ":manifest lib #{name}",
+          "  :sources \"src/*.savi\"",
+          "",
+          ":manifest bin \"spec\"",
+          "  :copies #{name}",
+          "  :sources \"spec/*.savi\"",
+          "",
+          "  :dependency Spec v0",
+          "    :from \"github:savi-lang/Spec\"",
+          "    :depends on Map",
+          "",
+          "  :transitive dependency Map v0",
+          "    :from \"github:savi-lang/Map\"",
+          "",
+        ].join("\n")},
+
+        {"src/#{name}.savi", [
+          ":module #{name}",
+          "  :fun placeholder",
+          "    True",
+          "",
+        ].join("\n")},
+
+        {"spec/Main.savi", [
+          ":actor Main",
+          "  :new (env Env)",
+          "    Spec.Process.run(env, [",
+          "      Spec.Run(#{name}.Spec).new(env)",
+          "    ])",
+          "",
+        ].join("\n")},
+
+        {"spec/#{name}.Spec.savi", [
+          ":class #{name}.Spec",
+          "  :is Spec",
+          "  :const describes: \"#{name}\"",
+          "",
+          "  :it \"has a placeholder method for demonstrating testing\"",
+          "    assert: #{name}.placeholder == True",
+          "",
+        ].join("\n")},
+      ])
+    end
+  end
+
+  module Bin
+    def self.run(name : String) : Bool
+      Init.with_files([
+        {"manifest.savi", [
+          ":manifest bin #{name.inspect}",
+          "  :sources \"src/*.savi\"",
+          "",
+        ].join("\n")},
+
+        {"src/Main.savi", [
+          ":actor Main",
+          "  :new (env Env)",
+          "    env.out.print(\"Hello, World!\")",
+          "",
+        ].join("\n")},
+      ])
+    end
+  end
+
+  def self.with_files(files : Array({String, String})) : Bool
+    existing_names = files.map(&.first).select { |name| File.exists?(name) }
+    case existing_names.size
+    when 0
+      files.each { |name, content|
+        puts "Creating #{name}"
+        FileUtils.mkdir_p(File.dirname(name))
+        File.write(name, content)
+      }
+      true
+    when 1
+      STDERR.puts "A file named #{existing_names.first.inspect} already exists."
+      STDERR.puts
+      STDERR.puts "Please delete it before continuing."
+      false
+    else
+      STDERR.puts "The following files already exist:"
+      existing_names.each { |name| STDERR.puts "- #{name}"}
+      STDERR.puts
+      STDERR.puts "Please delete them before continuing."
+      false
+    end
+  end
+end

--- a/src/savi/packaging/remote_service.cr
+++ b/src/savi/packaging/remote_service.cr
@@ -126,7 +126,7 @@ module Savi::Packaging::RemoteService
 
       # Fast exit if there's nothing new to be downloaded.
       return if download_list.empty?
-      puts "Downloading new library versions from GitHub..."
+      STDERR.puts "Downloading new library versions from GitHub..."
 
       # Spawn the sub-processes to shallow-clone the specified versions.
       process_list = download_list.map { |dep, version|
@@ -152,7 +152,7 @@ module Savi::Packaging::RemoteService
           next
         end
 
-        puts "Downloaded #{dep.name.value} #{version}"
+        STDERR.puts "Downloaded #{dep.name.value} #{version}"
       }
     end
 
@@ -167,7 +167,7 @@ module Savi::Packaging::RemoteService
       cached_location = @@location_cache[dep_name]?
       return cached_location if cached_location
 
-      puts "Finding a remote location for the #{dep_name} library..."
+      STDERR.puts "Finding a remote location for the #{dep_name} library..."
 
       # Choose a random temporary directory name.
       tmp_dir = File.join(Dir.tempdir, "savi-library-index-#{Random::Secure.hex}")
@@ -210,7 +210,7 @@ module Savi::Packaging::RemoteService
       case locations.size
       when 1
         location = locations.first
-        puts "Found a known location: #{location}"
+        STDERR.puts "Found a known location: #{location}"
         @@location_cache[dep_name] = location
         return location
       when 0


### PR DESCRIPTION
Running `savi init lib Example` will create a new library project named `Example` in the current directory, including a placeholder module under `src` and a mostly-empty (but runnable) test suite under `spec`.

Running `savi init bin my-thing` will create a new executable binary project named `my-thing` in the current directory, including a simple `src/Main.savi` that prints "Hello, World!".

Resolves #236.