### PR TITLE
Fix debug info generation for a pointer to a Savi `:struct` value.

### DIFF
--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
@@ -9,7 +9,7 @@ from ./manifest.savi:1:
           ^~~~~~~~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220304.0/manifest.savi:4:
+  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:4:
   :dependency ByteStream v0
               ^~~~~~~~~~
 
@@ -28,7 +28,7 @@ from ./manifest.savi:4:
               ^~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220304.0/manifest.savi:4:
+  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:4:
   :dependency ByteStream v0
               ^~~~~~~~~~
 
@@ -42,7 +42,7 @@ from ./manifest.savi:1:
           ^~~~~~~~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220304.0/manifest.savi:7:
+  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:7:
   :dependency IO v0
               ^~
 
@@ -61,7 +61,7 @@ from ./manifest.savi:4:
               ^~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220304.0/manifest.savi:7:
+  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:7:
   :dependency IO v0
               ^~
 
@@ -75,7 +75,7 @@ from ./manifest.savi:1:
           ^~~~~~~~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220304.0/manifest.savi:12:
+  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:12:
   :dependency OSError v0
               ^~~~~~~
 
@@ -84,6 +84,8 @@ from ./manifest.savi:1:
   :dependency TCP v0
               ^~~
 
+- run again with --fix to auto-fix this issue.
+
 ---
 
 A `:depends on` declaration is missing from this dependency:
@@ -92,7 +94,7 @@ from ./manifest.savi:4:
               ^~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220304.0/manifest.savi:12:
+  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:12:
   :dependency OSError v0
               ^~~~~~~
 

--- a/src/savi/compiler/code_gen/debug_info.cr
+++ b/src/savi/compiler/code_gen/debug_info.cr
@@ -297,7 +297,11 @@ class Savi::Compiler::CodeGen
             ),
           )
         elsif t.llvm_use_type(ctx) == :struct_value
-          di_create_fields_struct_type(t, llvm_type)
+          if llvm_type.kind == LLVM::Type::Kind::Pointer
+            di_create_object_struct_pointer_type(t, llvm_type)
+          else
+            di_create_fields_struct_type(t, llvm_type)
+          end
         elsif t.llvm_use_type(ctx) == :struct_ptr
           di_create_object_struct_pointer_type(t, llvm_type)
         elsif t.llvm_use_type(ctx) == :struct_ptr_opaque

--- a/src/savi/compiler/manifests.cr
+++ b/src/savi/compiler/manifests.cr
@@ -338,7 +338,7 @@ class Savi::Compiler::Manifests
   private def check_transitive_deps(ctx, manifest, dep, dep_manifest)
     dep_manifest.dependencies.each { |dep_dep|
       # Check that the transitive dependency has been loaded.
-      if !@manifests_by_name.has_key?(dep_dep.name.value)
+      if !manifest.dependencies.any?(&.name.value.==(dep_dep.name.value))
         can_fix = dep_dep.location_nodes.any?
         fix_lines = ["\n"]
         fix_lines << "  :transitive dependency #{dep_dep.name.value} #{dep_dep.version.try(&.value)}"


### PR DESCRIPTION
This was causing a compiler crash in some `:struct` constructors, where the "self" reference was being used for passing to field init functions.