### PR TITLE
Stabilize integration test error output across library versions.

### DIFF
--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.errors.txt
@@ -9,7 +9,7 @@ from ./manifest.savi:1:
           ^~~~~~~~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:4:
+  from ./deps/github:savi-lang/TCP/v0/manifest.savi:4:
   :dependency ByteStream v0
               ^~~~~~~~~~
 
@@ -28,7 +28,7 @@ from ./manifest.savi:4:
               ^~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:4:
+  from ./deps/github:savi-lang/TCP/v0/manifest.savi:4:
   :dependency ByteStream v0
               ^~~~~~~~~~
 
@@ -42,7 +42,7 @@ from ./manifest.savi:1:
           ^~~~~~~~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:7:
+  from ./deps/github:savi-lang/TCP/v0/manifest.savi:7:
   :dependency IO v0
               ^~
 
@@ -61,7 +61,7 @@ from ./manifest.savi:4:
               ^~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:7:
+  from ./deps/github:savi-lang/TCP/v0/manifest.savi:7:
   :dependency IO v0
               ^~
 
@@ -75,7 +75,7 @@ from ./manifest.savi:1:
           ^~~~~~~~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:12:
+  from ./deps/github:savi-lang/TCP/v0/manifest.savi:12:
   :dependency OSError v0
               ^~~~~~~
 
@@ -94,7 +94,7 @@ from ./manifest.savi:4:
               ^~~
 
 - this transitive dependency needs to be added:
-  from ./deps/github:savi-lang/TCP/v0.20220309.0/manifest.savi:12:
+  from ./deps/github:savi-lang/TCP/v0/manifest.savi:12:
   :dependency OSError v0
               ^~~~~~~
 

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.after.dir/manifest.savi
@@ -12,9 +12,8 @@
 
   :transitive dependency IO v0
     :from "github:savi-lang/IO"
-    :depends on OSError
     :depends on ByteStream
+    :depends on OSError
 
   :transitive dependency OSError v0
     :from "github:savi-lang/OSError"
-

--- a/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/main.savi
+++ b/spec/integration/fix-manifests-missing-transitive-deps/savi.fix.before.dir/main.savi
@@ -1,3 +1,3 @@
 :actor Main
   :new (env)
-    TCP.ConnectionEngine // just ensure the type name is reachable
+    TCP // just ensure the type name is reachable

--- a/spec/integration/run-one.sh
+++ b/spec/integration/run-one.sh
@@ -104,10 +104,19 @@ test_run_output() {
 if [ -d "$subdir/savi.fix.before.dir" ] \
 && [ -d "$subdir/savi.fix.after.dir" ] \
 && [ -f "$subdir/savi.errors.txt" ]; then
+  rm -rf "$subdir/deps"
   cp -r "$subdir/savi.fix.before.dir/"* $subdir/
   "$SAVI" deps update --cd "$subdir"
   cp -r "$subdir/savi.fix.before.dir/"* $subdir/
   cleanup_files=$(ls "$subdir/savi.fix.before.dir/"* | cut -d/ -f -1,3-)
+
+  # Convert dep version dirs to their short versions.
+  # This helps to stabilize file paths for testing error output,
+  # so that the error output doesn't change with each latest library version.
+  for versiondir in $(find "$subdir/deps" -name 'v*'); do
+    shortversiondir=$(echo $versiondir | sed s/$(basename $versiondir)/$(basename $versiondir | cut -d. -f1)/)
+    mv $versiondir $shortversiondir
+  done
 
   if ! test_error_output; then
     rm -rf ${cleanup_files}


### PR DESCRIPTION
In the integration test running script for auto-fix tests,
convert dep version dirs to their short versions.
This helps to stabilize file paths for testing error output,
so that the error output doesn't change with each latest library version.

---

This PR fixes an issue that caused the last two PRs to fail unnecessarily. I opted just to fix it in this followup PR.