### PR TITLE
Add `stack_address_of_variable` macro.

### DIFF
--- a/spec/compiler/macros/stack_address_of_variable_spec.cr
+++ b/spec/compiler/macros/stack_address_of_variable_spec.cr
@@ -1,0 +1,69 @@
+describe Savi::Compiler::Macros do
+  describe "stack_address_of_variable" do
+    it "is transformed into a prefix" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new (env Env)
+          foo = 99
+          stack_address_of_variable foo
+      SOURCE
+
+      ctx = Savi.compiler.test_compile([source], :macros)
+      ctx.errors.should be_empty
+
+      func = ctx.namespace.find_func!(ctx, source, "Main", "new")
+      func.body.not_nil!.to_a.should eq [:group, ":",
+        [:relate, [:ident, "foo"], [:op, "="], [:integer, 99]],
+        [:group, "(", [:prefix, [:op, "stack_address_of_variable"], [:ident, "foo"]]],
+      ]
+    end
+
+    it "complains if there are too many terms" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new (env Env)
+          foo = 99
+          bar = 100
+          stack_address_of_variable foo bar
+      SOURCE
+
+      expected = <<-MSG
+      This macro has too many terms:
+      from (example):5:
+          stack_address_of_variable foo bar
+          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      - this term is the local variable whose stack address should be captured:
+        from (example):5:
+          stack_address_of_variable foo bar
+                                    ^~~
+
+      - this is an excessive term:
+        from (example):5:
+          stack_address_of_variable foo bar
+                                        ^~~
+      MSG
+
+      Savi.compiler.test_compile([source], :macros)
+        .errors.map(&.message).join("\n").should eq expected
+    end
+
+    it "complains if the term isn't an identifier" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new (env Env)
+          stack_address_of_variable 99
+      SOURCE
+
+      expected = <<-MSG
+      Expected this term to be an identifier:
+      from (example):3:
+          stack_address_of_variable 99
+                                    ^~
+      MSG
+
+      Savi.compiler.test_compile([source], :macros)
+        .errors.map(&.message).join("\n").should eq expected
+    end
+  end
+end

--- a/spec/compiler/verify.savi.spec.md
+++ b/spec/compiler/verify.savi.spec.md
@@ -70,6 +70,21 @@ This try block is unnecessary:
 
 ---
 
+It complains if trying to take the stack address of a non-variable:
+
+```savi
+    foo = 99
+    stack_address_of_variable foo
+    stack_address_of_variable String
+```
+```error
+This is not a local variable, so it has no stack address:
+    stack_address_of_variable String
+                              ^~~~~~
+```
+
+---
+
 It complains when an async function declares or tries to yield:
 
 ```savi

--- a/spec/language/semantics/stack_address_of_variable_spec.savi
+++ b/spec/language/semantics/stack_address_of_variable_spec.savi
@@ -1,0 +1,15 @@
+:module StackAddressOfVariableSpec
+  :fun run(test MicroTest)
+    foo = 99
+    bar = 99
+    foo_addr = stack_address_of_variable foo
+    bar_addr = stack_address_of_variable bar
+    foo_addr_2 = stack_address_of_variable foo
+
+    test["stack_address_of_variable foo not null"].pass = foo_addr.is_not_null
+
+    test["stack_address_of_variable foo != bar"].pass =
+      foo_addr.usize != bar_addr.usize
+
+    test["stack_address_of_variable foo == foo"].pass =
+      foo_addr.usize == foo_addr_2.usize

--- a/spec/language/semantics/test.savi
+++ b/spec/language/semantics/test.savi
@@ -15,6 +15,7 @@
     WhileSpec.run(test)
     ReturnSpec.run(test)
     YieldingCallSpec.run(test)
+    StackAddressOfVariableSpec.run(test)
     ReflectionSpec.run(test)
     SourceCodeSpec.run(test)
     DisplacingAssignmentSpec.run(test)

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -2492,6 +2492,8 @@ class Savi::Compiler::CodeGen
       gen_yield(expr)
     when AST::Prefix
       case expr.op.value
+      when "stack_address_of_variable"
+        gen_stack_address_of_variable(expr, expr.term)
       when "reflection_of_type"
         gen_reflection_of_type(expr, expr.term)
       when "reflection_of_runtime_type_name"
@@ -3035,6 +3037,14 @@ class Savi::Compiler::CodeGen
 
       @source_code_pos_globals[pos] = global
     end
+  end
+
+  def gen_stack_address_of_variable(expr, term_expr)
+    ref = func_frame.refer[term_expr].as Refer::Local
+
+    alloca = func_frame.current_locals[ref]
+
+    alloca
   end
 
   def gen_reflection_of_type(expr, term_expr)

--- a/src/savi/compiler/infer/info.cr
+++ b/src/savi/compiler/infer/info.cr
@@ -474,6 +474,22 @@ module Savi::Compiler::Infer
     end
   end
 
+  class StackAddressOfVariable < DynamicInfo
+    getter variable_type : Info
+
+    def describe_kind : String; "variable address" end
+
+    def initialize(@pos, @layer_index, @variable_type)
+    end
+
+    def resolve_span!(ctx : Context, infer : Visitor) : Span
+      infer.core_savi_type_span(ctx, "CPointer")
+        .combine_mt(infer.resolve(ctx, @variable_type)) { |target_mt, arg_mt|
+          MetaType.new(ReifiedType.new(target_mt.single!.link, [arg_mt]))
+        }
+    end
+  end
+
   class ReflectionOfType < DynamicInfo
     getter reflect_type : Info
 

--- a/src/savi/compiler/macros.cr
+++ b/src/savi/compiler/macros.cr
@@ -134,6 +134,12 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
         "the parameter whose argument source code should be captured",
       ])
       visit_source_code_position_of_argument(node)
+    elsif Util.match_ident?(node, 0, "stack_address_of_variable")
+      Util.require_terms(node, [
+        nil,
+        "the local variable whose stack address should be captured",
+      ])
+      visit_stack_address_of_variable(node)
     elsif Util.match_ident?(node, 0, "reflection_of_type")
       Util.require_terms(node, [
         nil,
@@ -840,6 +846,21 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
             unless AST::Extract.params(@func.params).map(&.last).includes?(node)
 
     op = AST::Operator.new("source_code_position_of_argument").from(orig)
+
+    AST::Group.new("(", [
+      AST::Prefix.new(op, term).from(node),
+    ] of AST::Term).from(node)
+  end
+
+  def visit_stack_address_of_variable(node : AST::Group)
+    orig = node.terms[0]
+    term = node.terms[1]
+
+    Error.at term,
+      "Expected this term to be an identifier" \
+        unless term.is_a?(AST::Identifier)
+
+    op = AST::Operator.new("stack_address_of_variable").from(orig)
 
     AST::Group.new("(", [
       AST::Prefix.new(op, term).from(node),

--- a/src/savi/compiler/pre_infer.cr
+++ b/src/savi/compiler/pre_infer.cr
@@ -505,6 +505,8 @@ module Savi::Compiler::PreInfer
       case node.op.value
       when "source_code_position_of_argument"
         @analysis[node] = Infer::FixedPrelude.new(node.pos, layer(node), "SourceCodePosition")
+      when "stack_address_of_variable"
+        @analysis[node] = Infer::StackAddressOfVariable.new(node.pos, layer(node), @analysis[node.term])
       when "reflection_of_type"
         @analysis[node] = Infer::ReflectionOfType.new(node.pos, layer(node), @analysis[node.term])
       when "reflection_of_runtime_type_name"

--- a/src/savi/compiler/pre_t_infer.cr
+++ b/src/savi/compiler/pre_t_infer.cr
@@ -506,6 +506,8 @@ module Savi::Compiler::PreTInfer
       case node.op.value
       when "source_code_position_of_argument"
         @analysis[node] = TInfer::FixedPrelude.new(node.pos, layer(node), "SourceCodePosition")
+      when "stack_address_of_variable"
+        @analysis[node] = TInfer::StackAddressOfVariable.new(node.pos, layer(node), @analysis[node.term])
       when "reflection_of_type"
         @analysis[node] = TInfer::ReflectionOfType.new(node.pos, layer(node), @analysis[node.term])
       when "reflection_of_runtime_type_name"

--- a/src/savi/compiler/t_infer/info.cr
+++ b/src/savi/compiler/t_infer/info.cr
@@ -443,6 +443,22 @@ module Savi::Compiler::TInfer
     end
   end
 
+  class StackAddressOfVariable < DynamicInfo
+    getter variable_type : Info
+
+    def describe_kind : String; "variable address" end
+
+    def initialize(@pos, @layer_index, @variable_type)
+    end
+
+    def resolve_span!(ctx : Context, infer : Visitor) : Span
+      infer.core_savi_type_span(ctx, "CPointer")
+        .combine_mt(infer.resolve(ctx, @variable_type)) { |target_mt, arg_mt|
+          MetaType.new(ReifiedType.new(target_mt.single!.link, [arg_mt]))
+        }
+    end
+  end
+
   class ReflectionOfType < DynamicInfo
     getter reflect_type : Info
 


### PR DESCRIPTION
This is meant to be used with FFI calls that have
so-called "out parameters" that write into the local variable.