### PR TITLE
Add more `Platform` constants, and decide on `is_` name convention.

### DIFF
--- a/core/Integer.savi
+++ b/core/Integer.savi
@@ -272,10 +272,10 @@
   :fun val total_one_bits U8: compiler intrinsic
   :fun val reverse_bits @: compiler intrinsic
   :fun val swap_bytes @: compiler intrinsic
-  :fun val native_to_be @: if Platform.big_endian (@ | @swap_bytes)
-  :fun val native_to_le @: if Platform.little_endian (@ | @swap_bytes)
-  :fun val be_to_native @: if Platform.big_endian (@ | @swap_bytes)
-  :fun val le_to_native @: if Platform.little_endian (@ | @swap_bytes)
+  :fun val native_to_be @: if Platform.is_big_endian (@ | @swap_bytes)
+  :fun val native_to_le @: if Platform.is_little_endian (@ | @swap_bytes)
+  :fun val be_to_native @: if Platform.is_big_endian (@ | @swap_bytes)
+  :fun val le_to_native @: if Platform.is_little_endian (@ | @swap_bytes)
 
   :is Integer.Countable(@)
   :fun val times

--- a/core/Platform.savi
+++ b/core/Platform.savi
@@ -1,7 +1,27 @@
 :module Platform
-  :const ilp32 Bool: compiler intrinsic
-  :const lp64 Bool: compiler intrinsic
-  :const llp64 Bool: False // TODO: this is 65-but windows, instead of lp64
-  :const windows Bool: False // TODO: True on windows
-  :const big_endian Bool: compiler intrinsic
-  :const little_endian Bool: compiler intrinsic
+  :const is_linux Bool: compiler intrinsic
+  :const is_bsd Bool: compiler intrinsic
+  :const is_macos Bool: compiler intrinsic
+  :const is_posix Bool: True // TODO: False on windows
+  :const is_windows Bool: False // TODO: True on windows
+
+  :const is_ilp32 Bool: compiler intrinsic
+  :const is_lp64 Bool: compiler intrinsic
+  :const is_llp64 Bool: False // TODO: this is 64-bit windows, instead of lp64
+  :fun non is_32bit: @is_ilp32
+  :fun non is_64bit: @is_lp64 || @is_llp64
+  :fun non has_32bit_size: @is_32bit
+  :fun non has_64bit_size: @is_64bit
+  :fun non has_32bit_long: @is_ilp32 || @is_llp64
+  :fun non has_64bit_long: @is_lp64
+
+  :const is_big_endian Bool: compiler intrinsic
+  :const is_little_endian Bool: compiler intrinsic
+
+  // TODO: Remove these after libraries have been updated to use the new names.
+  :fun non ilp32 Bool: @is_ilp32
+  :fun non lp64 Bool: @is_lp64
+  :fun non llp64 Bool: @is_llp64
+  :fun non windows Bool: @is_windows
+  :fun non big_endian Bool: @is_big_endian
+  :fun non little_endian Bool: @is_little_endian

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -15,7 +15,7 @@
     assert: F64.bit_width == 64
 
   :it "returns a platform-dependent bit width for USize and ISize"
-    if Platform.lp64 (
+    if Platform.has_64bit_size (
       assert: USize.bit_width == 64
       assert: ISize.bit_width == 64
     |
@@ -61,7 +61,7 @@
     assert: I32[-2147483648]          == 2147483648
     assert: I64[-9223372036854775808] == 9223372036854775808
 
-    if Platform.lp64 (
+    if Platform.has_64bit_size (
       assert: USize[-1]                   == 0xFFFF_FFFF_FFFF_FFFF
       assert: ISize[-9223372036854775808] == 9223372036854775808
     |
@@ -107,7 +107,7 @@
     assert: I16  .max_value == 0x7FFF
     assert: I32  .max_value == 0x7FFF_FFFF
     assert: I64  .max_value == 0x7FFF_FFFF_FFFF_FFFF
-    if Platform.lp64 (
+    if Platform.has_64bit_size (
       assert: USize.max_value == 0xFFFF_FFFF_FFFF_FFFF
       assert: ISize.max_value == 0x7FFF_FFFF_FFFF_FFFF
     |
@@ -124,7 +124,7 @@
     assert: I16  .min_value == 0x8000
     assert: I32  .min_value == 0x8000_0000
     assert: I64  .min_value == 0x8000_0000_0000_0000
-    if Platform.lp64 (
+    if Platform.has_64bit_size (
       assert: USize.min_value == 0
       assert: ISize.min_value == 0x8000_0000_0000_0000
     |
@@ -512,13 +512,13 @@
     u16 = U16[0x1234]
     u16_swapped = U16[0x3412]
 
-    if (Platform.little_endian) (
+    if Platform.is_little_endian (
       assert: u16.native_to_be == u16_swapped
       assert: u16.native_to_le == u16
       assert: u16.be_to_native == u16_swapped
       assert: u16.le_to_native == u16
     )
-    if (Platform.big_endian) (
+    if Platform.is_big_endian (
       assert: u16.native_to_be == u16
       assert: u16.native_to_le == u16_swapped
       assert: u16.be_to_native == u16
@@ -529,13 +529,13 @@
     u32 = U32[0x1234_5678]
     u32_swapped = U32[0x7856_3412]
 
-    if (Platform.little_endian) (
+    if Platform.is_little_endian (
       assert: u32.native_to_be == u32_swapped
       assert: u32.native_to_le == u32
       assert: u32.be_to_native == u32_swapped
       assert: u32.le_to_native == u32
     )
-    if (Platform.big_endian) (
+    if Platform.is_big_endian (
       assert: u32.native_to_be == u32
       assert: u32.native_to_le == u32_swapped
       assert: u32.be_to_native == u32
@@ -546,13 +546,13 @@
     u64 = U64[0x1234_5678_9ABC_DEF0]
     u64_swapped = U64[0xF0DE_BC9A_7856_3412]
 
-    if (Platform.little_endian) (
+    if Platform.is_little_endian (
       assert: u64.native_to_be == u64_swapped
       assert: u64.native_to_le == u64
       assert: u64.be_to_native == u64_swapped
       assert: u64.le_to_native == u64
     )
-    if (Platform.big_endian) (
+    if Platform.is_big_endian (
       assert: u64.native_to_be == u64
       assert: u64.native_to_le == u64_swapped
       assert: u64.be_to_native == u64

--- a/spec/core/Platform.Spec.savi
+++ b/spec/core/Platform.Spec.savi
@@ -2,11 +2,50 @@
   :is Spec
   :const describes: "Platform"
 
-  :it "returns True for exactly one of {ilp32, lp64, llp64}"
+  :it "returns True for exactly one of {is_linux, is_bsd, is_macos, is_windows}"
     assert: U8[1] == U8[0] +
-      if Platform.ilp32 (1 | 0) +
-      if Platform.lp64  (1 | 0) +
-      if Platform.llp64 (1 | 0)
+      if Platform.is_linux   (1 | 0) +
+      if Platform.is_bsd     (1 | 0) +
+      if Platform.is_macos   (1 | 0) +
+      if Platform.is_windows (1 | 0)
+
+  :it "returns True for is_posix on POSIX platforms"
+    if Platform.is_linux   (assert: Platform.is_posix)
+    if Platform.is_bsd     (assert: Platform.is_posix)
+    if Platform.is_macos   (assert: Platform.is_posix)
+    if Platform.is_windows (assert: Platform.is_posix.not)
+
+  :it "returns True for exactly one of {is_ilp32, is_lp64, is_llp64}"
+    assert: U8[1] == U8[0] +
+      if Platform.is_ilp32 (1 | 0) +
+      if Platform.is_lp64  (1 | 0) +
+      if Platform.is_llp64 (1 | 0)
+
+  :it "correctly identifies 64 bit vs 32 bit platform information"
+    if Platform.is_ilp32 (
+      assert: Platform.is_32bit
+      assert: Platform.is_64bit.not
+      assert: Platform.has_32bit_size
+      assert: Platform.has_64bit_size.not
+      assert: Platform.has_32bit_long
+      assert: Platform.has_64bit_long.not
+    )
+    if Platform.is_lp64 (
+      assert: Platform.is_32bit.not
+      assert: Platform.is_64bit
+      assert: Platform.has_32bit_size.not
+      assert: Platform.has_64bit_size
+      assert: Platform.has_32bit_long.not
+      assert: Platform.has_64bit_long
+    )
+    if Platform.is_llp64 (
+      assert: Platform.is_32bit.not
+      assert: Platform.is_64bit
+      assert: Platform.has_32bit_size.not
+      assert: Platform.has_64bit_size
+      assert: Platform.has_32bit_long
+      assert: Platform.has_64bit_long.not
+    )
 
   :it "is either big or little endian"
-    assert: Platform.big_endian == !Platform.little_endian
+    assert: Platform.is_big_endian != Platform.is_little_endian

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -937,15 +937,23 @@ class Savi::Compiler::CodeGen
     gen_func_start(llvm_func, gtype, gfunc)
     params = llvm_func.params
 
+    target = Target.new(@target_machine.triple)
+
     @builder.ret \
       case gfunc.func.ident.value
-      when "ilp32"
+      when "is_linux"
+        gen_bool(target.linux?)
+      when "is_bsd"
+        gen_bool(target.bsd?)
+      when "is_macos"
+        gen_bool(target.macos?)
+      when "is_ilp32"
         gen_bool(abi_size_of(@isize) == 4)
-      when "lp64"
+      when "is_lp64"
         gen_bool(abi_size_of(@isize) == 8)
-      when "big_endian"
+      when "is_big_endian"
         gen_bool(@target_machine.data_layout.big_endian?)
-      when "little_endian"
+      when "is_little_endian"
         gen_bool(@target_machine.data_layout.little_endian?)
       else
         raise NotImplementedError.new(gfunc.func.ident.value)


### PR DESCRIPTION
Existing constants that did not follow the new name convention
have been retained for now as wrappers for the new `is_` names.

The old names are now deprecated and can be removed once libraries
are updated to use the new names.