### PR TITLE
Add `:ffimodule` declarator, deprecating `:ffi` declarator.

### DIFF
--- a/core/AsioEvent.savi
+++ b/core/AsioEvent.savi
@@ -49,7 +49,7 @@
     if !@get_disposable(event) @unsubscribe(event)
     event
 
-:ffi LibPonyAsioEvent
+:ffimodule LibPonyAsioEvent
   :fun pony_asio_event_create(
     owner AsioEventNotify
     fd U32, flags U32, nsec U64, noisy Bool

--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -1,5 +1,5 @@
 // TODO: Get rid of this hack:
-:ffi InspectLibC
+:ffimodule InspectLibC
   :fun puts(string CPointer(U8)) I32
   :fun strlen(string CPointer(U8)) I32
   :fun variadic snprintf(buffer CPointer(U8), buffer_size I32, fmt CPointer(U8)) I32

--- a/core/LibPony.savi
+++ b/core/LibPony.savi
@@ -1,4 +1,4 @@
-:ffi LibPony
+:ffimodule LibPony
   :fun pony_exitcode(code I32) None
   :fun pony_os_stdout() CPointer(None)'ref
   :fun pony_os_stderr() CPointer(None)'ref

--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -281,6 +281,15 @@
     :default non
   :term name_and_params NameMaybeWithParams
 
+:: This declarator is deprecated - use `:ffimodule` instead.
+:declarator ffi
+  :intrinsic
+  :begins ffi
+
+  :term cap enum (iso, val, ref, box, tag, non)
+    :default non
+  :term name_and_params NameMaybeWithParams
+
 :: Declare a static singleton object exposing unsafe foreign functions (C-FFI).
 ::
 :: An `:ffi` declaration is similar to a `:module` in that it cannot be
@@ -291,7 +300,7 @@
 ::
 :: Each function signature in an `:ffi` declaration should directly correspond
 :: to a function exposed by a foreign package which is linked to the program.
-:declarator ffi
+:declarator ffimodule
   :intrinsic
   :begins ffi
 

--- a/docs/intro-vs-pony.md
+++ b/docs/intro-vs-pony.md
@@ -545,10 +545,10 @@ Generic functions are not yet in Savi. See [this ticket](https://github.com/savi
 
 #### FFI Block
 
-While in Pony we use `@` to mark that we are calling a C function, in Savi we declare an `:ffi` type:
+While in Pony we use `@` to mark that we are calling a C function, in Savi we declare an `:ffimodule` type:
 
 ```savi
-:ffi LibC
+:ffimodule LibC
   :fun puts(string CPointer(U8)) I32
 ```
 
@@ -557,7 +557,7 @@ In the example above you see that we are declaring plain functions. You need to 
 To use a variadic function from C (one which can accept additional arguments that have no specific type requirements), add the word `variadic` to the declaration:
 
 ```savi
-:ffi LibC
+:ffimodule LibC
   :fun variadic printf(format CPointer(U8)) I32
 ```
 
@@ -565,7 +565,7 @@ Note that on some platforms, variadic functions use a different calling conventi
 
 #### Usage example
 
-In Savi, all FFI functions are namespaced by the `:ffi` type name you declared, so you can call them just like a method of a type is called:
+In Savi, all FFI functions are namespaced by the `:ffimodule` type name you declared, so you can call them just like a method of a type is called:
 ```savi
 :class Greeting
   :let message String

--- a/examples/verona/src/main.savi
+++ b/examples/verona/src/main.savi
@@ -1,4 +1,4 @@
-:ffi LibC
+:ffimodule LibC
   :fun variadic printf(format CPointer(U8)) I32
 
 :class Greeting

--- a/spec/compiler/ffigen.savi.spec.md
+++ b/spec/compiler/ffigen.savi.spec.md
@@ -8,7 +8,7 @@ It generates C bindings for a basic function.
 unsigned sleep(unsigned seconds);
 ```
 ```savi
-:ffi LibExample
+:ffimodule LibExample
   :fun sleep(
     seconds U32
   ) U32
@@ -28,7 +28,7 @@ It picks up block-style comments as documentation.
 unsigned sleep(unsigned seconds);
 ```
 ```savi
-:ffi LibExample
+:ffimodule LibExample
   :: Sleep for the given number of seconds.
   ::
   :: Returns the number of seconds remaining in the sleep, if the sleep was
@@ -46,7 +46,7 @@ It handles functions with no arguments.
 int rand(void);
 ```
 ```savi
-:ffi LibExample
+:ffimodule LibExample
   :fun rand I32
 ```
 
@@ -58,7 +58,7 @@ It handles functions with no return value.
 void srand(unsigned int seed);
 ```
 ```savi
-:ffi LibExample
+:ffimodule LibExample
   :fun srand(
     seed U32
   )

--- a/spec/compiler/namespace.savi.spec.md
+++ b/spec/compiler/namespace.savi.spec.md
@@ -22,7 +22,7 @@ This type's name conflicts with a mandatory built-in type:
 It won't complain about sharing the name of a private built-in type.
 
 ```savi
-:ffi LibPony // also defined in core Savi, but private, so no conflict here
+:ffimodule LibPony // also defined in core Savi, but private, so no conflict here
 ```
 
 ---

--- a/spec/language/micro_test/micro_test.savi
+++ b/spec/language/micro_test/micro_test.savi
@@ -1,4 +1,4 @@
-:ffi LibC
+:ffimodule LibC
   :fun variadic printf(format CPointer(U8)) I32
 
 :class MicroTest

--- a/src/savi/ffi_gen.cr
+++ b/src/savi/ffi_gen.cr
@@ -15,7 +15,7 @@ class Savi::FFIGen
   end
 
   def emit(io : IO)
-    io.puts ":ffi #{@savi_name}"
+    io.puts ":ffimodule #{@savi_name}"
     emit_function_decls(io)
   end
 

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -47,7 +47,7 @@ module Savi::Program::Intrinsic
           type_alias.target = body.terms.first
         }
       when "actor", "class", "struct", "trait",
-           "numeric", "enum", "module", "ffi"
+           "numeric", "enum", "module", "ffi", "ffimodule"
         name, params =
           AST::Extract.name_and_params(terms["name_and_params"].not_nil!)
 
@@ -87,7 +87,7 @@ module Savi::Program::Intrinsic
         when "module"
           type.add_tag(:singleton)
           type.add_tag(:ignores_cap)
-        when "ffi"
+        when "ffi", "ffimodule"
           type.add_tag(:singleton)
           type.add_tag(:ignores_cap)
           type.add_tag(:private)
@@ -200,7 +200,7 @@ module Savi::Program::Intrinsic
       end
 
     # Declarations within a type definition.
-    when "type", "type_singleton", "ffi"
+    when "type", "type_singleton", "ffi", "ffimodule"
       case declarator.name.value
       when "it"
         name = terms["name"].as(AST::LiteralString)
@@ -493,7 +493,7 @@ module Savi::Program::Intrinsic
 
       scope.current_package.types << scope.current_type
       scope.current_type = nil
-    when "ffi"
+    when "ffi", "ffimodule"
       # An FFI type's functions should be tagged as "ffi" and body removed.
       scope.current_type.functions.each { |f|
         f.add_tag(:ffi)


### PR DESCRIPTION
In a later step we will also deprecate the `:ffimodule` declarator
and bring back `:ffi` as a declarator at the function level
instead of at the type level.