### PR TITLE
Add `source_code_position_of_argument` support for `yield`.

### DIFF
--- a/spec/compiler/macros/source_code_position_of_argument_spec.cr
+++ b/spec/compiler/macros/source_code_position_of_argument_spec.cr
@@ -89,7 +89,7 @@ describe Savi::Compiler::Macros do
       SOURCE
 
       expected = <<-MSG
-      Expected this term to be the identifier of a parameter:
+      Expected this term to be the identifier of a parameter, or `yield`:
       from (example):4:
           bar SourceCodePosition = source_code_position_of_argument food
                                                                     ^~~~
@@ -102,6 +102,18 @@ describe Savi::Compiler::Macros do
 
       Savi.compiler.test_compile([source], :macros)
         .errors.map(&.message).join("\n").should eq expected
+    end
+
+    it "won't complain if the identifier is yield" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new (
+          foo String
+          bar SourceCodePosition = source_code_position_of_argument yield
+        )
+      SOURCE
+
+      Savi.compiler.test_compile([source], :macros).errors.should be_empty
     end
 
     it "complains if the macro isn't used as the default arg of a parameter" do

--- a/spec/compiler/verify.savi.spec.md
+++ b/spec/compiler/verify.savi.spec.md
@@ -70,6 +70,20 @@ This try block is unnecessary:
 
 ---
 
+It complains if trying to capture the source position of a yield block that is never yielded to:
+
+```savi
+  :fun non no_yield(pos = source_code_position_of_argument yield)
+    pos.string
+```
+```error
+This cannot collect the yield block source position, because the function does not yield:
+  :fun non no_yield(pos = source_code_position_of_argument yield)
+                                                           ^~~~~
+```
+
+---
+
 It complains if trying to take the stack address of a non-variable:
 
 ```savi

--- a/spec/language/semantics/source_code_spec.savi
+++ b/spec/language/semantics/source_code_spec.savi
@@ -5,8 +5,21 @@
     test["source_code_position_of_argument string"].pass =
       @source_code_position_of_argument_string(zero == 0) == "zero == 0"
 
+    test["source_code_position_of_argument yield without yield param"].pass =
+      @source_code_position_of_argument_yield -> (99) == "99"
+
+    test["source_code_position_of_argument yield with yield param"].pass =
+      @source_code_position_of_argument_yield -> (none | 99) == "99"
+
   :fun source_code_position_of_argument_string(
     arg Bool
     pos SourceCodePosition = source_code_position_of_argument arg
   )
+    pos.string
+
+  :fun source_code_position_of_argument_yield(
+    pos SourceCodePosition = source_code_position_of_argument yield
+  )
+    :yields None for I32
+    yield None
     pos.string

--- a/src/savi/ast/format.cr
+++ b/src/savi/ast/format.cr
@@ -232,7 +232,8 @@ class Savi::AST::Format < Savi::AST::Visitor
 
   # Check for unnecessary parens within the terms of a Relate.
   def observe_relate_term_parens(ctx, relate : AST::Relate)
-    return if relate.op.value == "." # don't look at dot-relations
+    # Don't look at dot-relations or arrow-relations.
+    return if relate.op.value == "." || relate.op.value == "->"
 
     [relate.lhs, relate.rhs].each { |term|
       # Only consider a term that is a parens group.

--- a/src/savi/compiler/classify.cr
+++ b/src/savi/compiler/classify.cr
@@ -128,6 +128,16 @@ module Savi::Compiler::Classify
       @analysis.no_value!(op)
     end
 
+    def touch(ctx, prefix : AST::Prefix)
+      term = prefix.term
+      case prefix.op.value
+      when "source_code_position_of_argument"
+        @analysis.no_value!(term) \
+          if term.is_a?(AST::Identifier) && term.value == "yield"
+      else
+      end
+    end
+
     def touch(ctx, group : AST::Group)
       case group.style
       when "(", ":"

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1609,7 +1609,12 @@ class Savi::Compiler::CodeGen
             params.terms.index { |o| foreign_refer[AST::Extract.param(o)[0]] == find_ref }
 
           # Now, generate a value representing the source code pos of that arg.
-          args << gen_source_code_pos(arg_exprs[found_index.not_nil!].not_nil!.pos)
+          if found_index
+            args << gen_source_code_pos(arg_exprs[found_index].not_nil!.pos)
+          else
+            # If there is no index of the arg, we must be referencing the yield.
+            args << gen_source_code_pos(call.yield_block.not_nil!.terms.last.pos)
+          end
         else
           gen_within_foreign_frame lhs_gtype, gfunc do
             func_frame.receiver_value = receiver

--- a/src/savi/compiler/macros.cr
+++ b/src/savi/compiler/macros.cr
@@ -827,11 +827,12 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
         unless term.is_a?(AST::Identifier)
 
     Error.at term,
-      "Expected this term to be the identifier of a parameter",
+      "Expected this term to be the identifier of a parameter, or `yield`",
         [{@func.params.not_nil!.pos,
           "it is supposed to refer to one of the parameters listed here"}] \
             unless AST::Extract.params(@func.params).map(&.first)
-              .find { |param| param.value == term.value }
+              .find { |param| param.value == term.value } \
+                || term.value == "yield"
 
     Error.at node,
       "Expected this macro to be used as the default argument of a parameter",


### PR DESCRIPTION
Writing `source_code_position_of_argument yield` will get the
source code position of the yield block result
instead of a normal argument index.