### PR TITLE
Add `--llvm-ir` flag to emit LLVM IR to a file.

### DIFF
--- a/main.cr
+++ b/main.cr
@@ -18,7 +18,7 @@ module Savi
       option "-r", "--release", desc: "Compile in release mode", type: Bool, default: false
       option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
       option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
-      option "--print-ir", desc: "Print generated LLVM IR", type: Bool, default: false
+      option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
       option "-C", "--cd=DIR", desc: "Change the working directory"
       option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
@@ -26,9 +26,9 @@ module Savi
         options = Savi::Compiler::Options.new(
           release: opts.release,
           no_debug: opts.no_debug,
-          print_ir: opts.print_ir,
           print_perf: opts.print_perf,
         )
+        options.llvm_ir = true if opts.llvm_ir
         options.auto_fix = true if opts.fix
         options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
         Dir.cd(opts.cd.not_nil!) if opts.cd
@@ -53,14 +53,12 @@ module Savi
         option "-r", "--release", desc: "Compile in release mode", type: Bool, default: false
         option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
         option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
-        option "--print-ir", desc: "Print generated LLVM IR", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-C", "--cd=DIR", desc: "Change the working directory"
         run do |opts, args|
           options = Savi::Compiler::Options.new(
             release: opts.release,
             no_debug: opts.no_debug,
-            print_ir: opts.print_ir,
             print_perf: opts.print_perf,
           )
           options.auto_fix = true if opts.fix
@@ -78,7 +76,7 @@ module Savi
         option "-r", "--release", desc: "Compile in release mode", type: Bool, default: false
         option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
         option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
-        option "--print-ir", desc: "Print generated LLVM IR", type: Bool, default: false
+        option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-C", "--cd=DIR", desc: "Change the working directory"
         option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
@@ -86,9 +84,9 @@ module Savi
           options = Savi::Compiler::Options.new(
             release: opts.release,
             no_debug: opts.no_debug,
-            print_ir: opts.print_ir,
             print_perf: opts.print_perf,
           )
+          options.llvm_ir = true if opts.llvm_ir
           options.auto_fix = true if opts.fix
           options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
           options.manifest_name = args.name.not_nil! if args.name
@@ -106,16 +104,16 @@ module Savi
         option "-r", "--release", desc: "Compile in release mode", type: Bool, default: false
         option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
         option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
-        option "--print-ir", desc: "Print generated LLVM IR", type: Bool, default: false
+        option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-C", "--cd=DIR", desc: "Change the working directory"
         run do |opts, args|
           options = Savi::Compiler::Options.new(
             release: opts.release,
             no_debug: opts.no_debug,
-            print_ir: opts.print_ir,
             print_perf: opts.print_perf,
           )
+          options.llvm_ir = true if opts.llvm_ir
           options.auto_fix = true if opts.fix
           options.manifest_name = args.name.not_nil! if args.name
           Dir.cd(opts.cd.not_nil!) if opts.cd

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -6,9 +6,9 @@ class Savi::Compiler
   class Options
     property release
     property no_debug
-    property print_ir
     property print_perf
     property skip_manifest
+    property llvm_ir = false
     property auto_fix = false
     property manifest_name : String?
     property target_pass : Symbol?
@@ -32,7 +32,6 @@ class Savi::Compiler
     def initialize(
       @release = false,
       @no_debug = false,
-      @print_ir = false,
       @print_perf = false,
       @skip_manifest = false,
       @manifest_name = nil,

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -13,13 +13,17 @@ require "llvm"
 # !! This pass has the side-effect of writing files to disk.
 #
 class Savi::Compiler::Binary
+  def self.path_for(ctx)
+    ctx.manifests.root.not_nil!.bin_path
+  end
+
   def self.run(ctx)
     new.run(ctx)
   end
 
   def run(ctx)
     target = Target.new(ctx.code_gen.target_machine.triple)
-    bin_path = ctx.manifests.root.not_nil!.bin_path
+    bin_path = Binary.path_for(ctx)
 
     # Compile a temporary binary object file, that we will remove after we
     # use it in the linker invocation to create the final binary.

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -383,8 +383,12 @@ class Savi::Compiler::CodeGen
     begin
       @mod.verify
     rescue ex
-      @mod.dump
-      raise ex
+      @mod.print_to_file("#{Binary.path_for(ctx)}.ll")
+      Error.at Source::Pos.none, "LLVM #{ex.message}", [
+        {Source::Pos.none,
+          "please submit an issue ticket with this failure output and attach " +
+          "the dumped LLVM IR file located at: #{Binary.path_for(ctx)}.ll"}
+      ]
     end
 
     if ctx.options.release
@@ -406,7 +410,7 @@ class Savi::Compiler::CodeGen
       mod_pass_manager.run @mod
     end
 
-    @mod.dump if ctx.options.print_ir
+    @mod.print_to_file("#{Binary.path_for(ctx)}.ll") if ctx.options.llvm_ir
   end
 
   def gen_wrapper


### PR DESCRIPTION
This commit also removes the `--print-ir` flag which printed to stdout.

The LLVM IR is always so huge that it is inconvenient to work with
unless pasted into a file and opened in a text editor.

This change removes that middle manual step and emits directly to
a file whose name is the same as the emitted binary name, but with
a suffix of `.ll`.

This commit also changes the behavior of LLVM Module Verification bugs.
For the same reasons, it will write to a file instead of stdout.
It also now has a message asking the user to open an issue ticket
with the failure output as well as the emitted `.ll` file.