### PR TITLE
Change LLVM generation to use private linkage by default.

### DIFF
--- a/main.cr
+++ b/main.cr
@@ -19,6 +19,7 @@ module Savi
       option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
       option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
       option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
+      option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
       option "-C", "--cd=DIR", desc: "Change the working directory"
       option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
@@ -29,6 +30,7 @@ module Savi
           print_perf: opts.print_perf,
         )
         options.llvm_ir = true if opts.llvm_ir
+        options.llvm_keep_fns = true if opts.llvm_keep_fns
         options.auto_fix = true if opts.fix
         options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
         Dir.cd(opts.cd.not_nil!) if opts.cd
@@ -77,6 +79,7 @@ module Savi
         option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
         option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
         option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
+        option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-C", "--cd=DIR", desc: "Change the working directory"
         option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
@@ -87,6 +90,7 @@ module Savi
             print_perf: opts.print_perf,
           )
           options.llvm_ir = true if opts.llvm_ir
+          options.llvm_keep_fns = true if opts.llvm_keep_fns
           options.auto_fix = true if opts.fix
           options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
           options.manifest_name = args.name.not_nil! if args.name
@@ -105,6 +109,7 @@ module Savi
         option "--fix", desc: "Auto-fix compile errors where possible", type: Bool, default: false
         option "--no-debug", desc: "Compile without debug info", type: Bool, default: false
         option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
+        option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-C", "--cd=DIR", desc: "Change the working directory"
         run do |opts, args|
@@ -114,6 +119,7 @@ module Savi
             print_perf: opts.print_perf,
           )
           options.llvm_ir = true if opts.llvm_ir
+          options.llvm_keep_fns = true if opts.llvm_keep_fns
           options.auto_fix = true if opts.fix
           options.manifest_name = args.name.not_nil! if args.name
           Dir.cd(opts.cd.not_nil!) if opts.cd

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -9,6 +9,7 @@ class Savi::Compiler
     property print_perf
     property skip_manifest
     property llvm_ir = false
+    property llvm_keep_fns = false
     property auto_fix = false
     property manifest_name : String?
     property target_pass : Symbol?

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -406,7 +406,7 @@ class Savi::Compiler::CodeGen::PonyRT
     type_def = gtype.type_def
 
     desc = g.mod.globals.add(gtype.desc_type, "#{type_def.llvm_name}.DESC")
-    desc.linkage = LLVM::Linkage::LinkerPrivate
+    desc.linkage = LLVM::Linkage::Private
     desc.global_constant = true
     desc
   end


### PR DESCRIPTION
This will allow unused functions to be omitted in the LLVM IR,
since we are instructing LLVM that the function can only be used
privately (ruling out any potential linked use that LLVM can't see).

However, it's sometimes useful to override this behavior while
looking at optimized LLVM IR, to make it easier to find a function
that may have been inlined into all its call sites and subsequently
removed from the module after all call sites were removed.
Thus, a `--llvm-keep-fns` flag was added to instruct the compiler
to use external linkage for functions, ensuring that every function
will appear in the emitted LLVM IR.