### PR TITLE
Add `:inline always` declaration to mark functions as inlined.

### DIFF
--- a/core/Platform.savi
+++ b/core/Platform.savi
@@ -8,12 +8,30 @@
   :const is_ilp32 Bool: compiler intrinsic
   :const is_lp64 Bool: compiler intrinsic
   :const is_llp64 Bool: False // TODO: this is 64-bit windows, instead of lp64
-  :fun non is_32bit: @is_ilp32
-  :fun non is_64bit: @is_lp64 || @is_llp64
-  :fun non has_32bit_size: @is_32bit
-  :fun non has_64bit_size: @is_64bit
-  :fun non has_32bit_long: @is_ilp32 || @is_llp64
-  :fun non has_64bit_long: @is_lp64
+
+  :fun non is_32bit
+    :inline always
+    @is_ilp32
+
+  :fun non is_64bit
+    :inline always
+    @is_lp64 || @is_llp64
+
+  :fun non has_32bit_size
+    :inline always
+    @is_32bit
+
+  :fun non has_64bit_size
+    :inline always
+    @is_64bit
+
+  :fun non has_32bit_long
+    :inline always
+    @is_ilp32 || @is_llp64
+
+  :fun non has_64bit_long
+    :inline always
+    @is_lp64
 
   :const is_big_endian Bool: compiler intrinsic
   :const is_little_endian Bool: compiler intrinsic

--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -396,6 +396,12 @@
   :body optional
 
 // TODO: Document this.
+:declarator inline
+  :intrinsic
+  :context function
+  :keyword always
+
+// TODO: Document this.
 :declarator yields
   :intrinsic
   :context function

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -413,6 +413,7 @@ class Savi::Program
       :ffi,
       :field,
       :hygienic,
+      :inline,
       :is,
       :it,
       :let,

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -277,7 +277,10 @@ module Savi::Program::Intrinsic
           terms["name"].as(AST::Identifier),
           nil,
           terms["type"]?.as(AST::Term?),
-        ).tap(&.add_tag(:constant))
+        ).tap do |f|
+          f.add_tag(:constant)
+          f.add_tag(:inline)
+        end
 
         scope.current_type.functions << function
 
@@ -437,6 +440,8 @@ module Savi::Program::Intrinsic
     # Declarations within a function definition.
     when "function"
       case declarator.name.value
+      when "inline"
+        scope.current_function.add_tag(:inline)
       when "yields"
         scope.current_function.yield_out = terms["out"]?.as(AST::Term?)
         scope.current_function.yield_in  = terms["in"]?.as(AST::Term?)
@@ -497,6 +502,7 @@ module Savi::Program::Intrinsic
       # An FFI type's functions should be tagged as "ffi" and body removed.
       scope.current_type.functions.each { |f|
         f.add_tag(:ffi)
+        f.add_tag(:inline)
         ffi_link_name = f.ident.value
         ffi_link_name = ffi_link_name[0...-1] if ffi_link_name.ends_with?("!")
         f.metadata[:ffi_link_name] = ffi_link_name


### PR DESCRIPTION
Also implicitly mark FFI functions and `:const` "functions" as inlined.

Also update `CodeGen` to run minimal optimizations (such as honoring
"always inline" function attributes) even when not in release mode.