### PR TITLE
BREAKING CHANGE: `:member` names in an `:enum` get an automatic prefix.

### DIFF
--- a/core/Bool.savi
+++ b/core/Bool.savi
@@ -1,7 +1,7 @@
 :enum Bool
   :const bit_width U8: 1
-  :member False: 0
-  :member True: 1
+  :member noprefix False: 0
+  :member noprefix True: 1
   :fun val is_true: @
   :fun val is_false: @invert
   :fun val not: @invert

--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -466,6 +466,8 @@
   :intrinsic
   :context type_enum
 
+  :term noprefix enum (noprefix)
+    :optional
   :term name Name
   :body required
 

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE-crystal
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE-crystal
@@ -1,0 +1,15 @@
+Parts of this source code are based on code from `crystal`, whose license is:
+
+Copyright 2012-2019 Manas Technology Solutions.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE.md
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE.md
@@ -1,0 +1,11 @@
+Copyright 2019 Joe Eli McIlvain
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/manifest.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/manifest.savi
@@ -1,0 +1,3 @@
+:manifest lib Time
+  :sources "src/*.savi"
+

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Duration.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Duration.savi
@@ -1,0 +1,520 @@
+:struct val Time.Duration
+  :is Comparable(Time.Duration)
+
+  :: The total number of seconds in the duration.
+  :let total_seconds U64
+  :: The number of nanoseconds past the second.
+  :let nanosecond U32
+
+  :: An internal-only direct constructor.
+  :new val _new(@total_seconds, @nanosecond)
+
+  :: The maximum duration representable by this data type.
+  :fun non max_value: @_new(U64.max_value, Time._nanoseconds_per_second - 1)
+
+  :: The minimum duration representable by this data type (a.k.a `zero`).
+  :fun non min_value: @_new(0, 0)
+
+  :: A duration of zero length.
+  :fun non zero: @_new(0, 0)
+
+  :: Represent a duration of the given number of nanoseconds.
+  :new nanoseconds(n U64):
+    if (n < 1000000000) (
+      @total_seconds = 0
+      @nanosecond = n.u32
+    |
+      @total_seconds = n / 1000000000
+      @nanosecond = (n % 1000000000).u32
+    )
+
+  :: Represent a duration of the given number of microseconds.
+  :new microseconds(n U64)
+    if (n < 1000000) (
+      @total_seconds = 0
+      @nanosecond = n.u32 * 1000
+    |
+      @total_seconds = n / 1000000
+      @nanosecond = (n % 1000000).u32 * 1000
+    )
+
+  :: Represent a duration of the given number of milliseconds.
+  :new milliseconds(n U64)
+    if (n < 1000) (
+      @total_seconds = 0
+      @nanosecond = n.u32 * 1000000
+    |
+      @total_seconds = n / 1000
+      @nanosecond = (n % 1000).u32 * 1000000
+    )
+
+  :: Represent a duration of the given number of seconds.
+  :new seconds(n)
+    @total_seconds = n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of minutes.
+  :new minutes(n)
+    @total_seconds = Time._seconds_per_minute * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of hours.
+  :new hours(n)
+    @total_seconds = Time._seconds_per_hour * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of days.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :new days(n)
+    @total_seconds = Time._seconds_per_day * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of 7-day weeks.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :new weeks(n)
+    @total_seconds = Time._seconds_per_day * 7 * n
+    @nanosecond = 0
+
+  :: Return the total number of complete weeks in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_weeks: @total_seconds / (Time._seconds_per_day * 7)
+
+  :: Return the total number of complete days in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_days: @total_seconds / Time._seconds_per_day
+
+  :: Return the total number of complete hours in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  :fun total_hours: @total_seconds / Time._seconds_per_hour
+
+  :: Return the total number of complete minutes in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  :fun total_minutes: @total_seconds / Time._seconds_per_minute
+
+  :: Return the total number of complete milliseconds in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_milliseconds!
+    (@total_seconds *! 1000) +! (@nanosecond / 1000000).u64
+
+  :: Return the total number of complete microseconds in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_microseconds!
+    (@total_seconds *! 1000000) +! (@nanosecond / 1000).u64
+
+  :: Return the total number of nanoseconds in the duration.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_nanoseconds!
+    (@total_seconds *! 1000000000) +! @nanosecond.u64
+
+  :: Return the total number of complete weeks in the duration.
+  :: The remainder of the duration (beyond those weeks) is also returned.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_weeks_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / (Time._seconds_per_day * 7)
+      @_new(
+        @total_seconds % (Time._seconds_per_day * 7)
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete days in the duration.
+  :: The remainder of the duration (beyond those days) is also returned.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_days_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_day
+      @_new(
+        @total_seconds % Time._seconds_per_day
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete hours in the duration.
+  :: The remainder of the duration (beyond those hours) is also returned.
+  :fun total_hours_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_hour
+      @_new(
+        @total_seconds % Time._seconds_per_hour
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete minutes in the duration.
+  :: The remainder of the duration (beyond those minutes) is also returned.
+  :fun total_minutes_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_minute
+      @_new(
+        @total_seconds % Time._seconds_per_minute
+        @nanosecond
+      )
+    )
+
+  :: Print the duration for human inspection (the format is subject to change).
+  :fun inspect_into(output String'iso)
+    weeks_result = @total_weeks_with_remainder
+    days_result = weeks_result.tail.total_days_with_remainder
+    hours_result = days_result.tail.total_hours_with_remainder
+    minutes_result = hours_result.tail.total_minutes_with_remainder
+
+    weeks = weeks_result.head
+    days = days_result.head
+    hours = hours_result.head
+    minutes = minutes_result.head
+    seconds = minutes_result.tail.total_seconds
+    nanoseconds = minutes_result.tail.nanosecond
+
+    printed_anything = False
+    output << "Time.Duration("
+
+    if (weeks > 0) (
+      output = Inspect.into(--output, weeks), output << " weeks"
+      printed_anything = True
+    )
+
+    if (days > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, days), output << " days"
+      printed_anything = True
+    )
+
+    if (hours > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, hours), output << " hours"
+      printed_anything = True
+    )
+
+    if (minutes > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, minutes), output << " minutes"
+      printed_anything = True
+    )
+
+    if (seconds > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, seconds), output << " seconds"
+      printed_anything = True
+    )
+
+    if (nanoseconds > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, nanoseconds), output << " nanoseconds"
+      printed_anything = True
+    )
+
+    output << ")"
+    --output
+
+  :: Return True if the given duration is exactly equivalent to this one.
+  :fun "=="(other Time.Duration'box)
+    @total_seconds == other.total_seconds
+    && @nanosecond == other.nanosecond
+
+  :: Return True if the given duration is less than (earlier than) this one.
+  :fun "<"(other Time.Duration'box)
+    @total_seconds < other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond < other.nanosecond)
+
+  :: Return True if the given duration is greater than (later than) this one.
+  :fun ">"(other Time.Duration'box)
+    @total_seconds > other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond > other.nanosecond)
+
+  :: Add the given duration to this one and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use the `+!` method instead.
+  :fun "+"(other Time.Duration'box)
+    total = @total_seconds + other.total_seconds
+    nanos = @nanosecond + other.nanosecond
+    while (nanos >= Time._nanoseconds_per_second) (
+      nanos -= Time._nanoseconds_per_second
+      total += 1
+    )
+    @_new(total, nanos)
+
+  :: Add the given duration to this one and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow semantics are desired, use the `+` method instead.
+  :fun "+!"(other Time.Duration'box)
+    total = @total_seconds +! other.total_seconds
+    nanos = @nanosecond + other.nanosecond
+    while (nanos >= Time._nanoseconds_per_second) (
+      nanos -= Time._nanoseconds_per_second
+      total = total +! 1
+    )
+    @_new(total, nanos)
+
+  :: Subtract the given duration from this one and return the result.
+  ::
+  :: Uses wrap-around underflow semantics if the result is less than `zero`.
+  :: If an error on underflow is desired, use the `-!` method instead.
+  :fun "-"(other Time.Duration'box)
+    total = @total_seconds, other_total = other.total_seconds
+    nanos = @nanosecond,    other_nanos = other.nanosecond
+    while (nanos < other_nanos) (
+      nanos += Time._nanoseconds_per_second
+      total -= 1
+    )
+    @_new(total - other_total, nanos - other_nanos)
+
+  :: Subtract the given duration from this one and return the result.
+  ::
+  :: Raises an error if the result would be less than `zero`.
+  :: If wrap-around underflow semantics is desired, use the `-` method instead.
+  :fun "-!"(other Time.Duration'box)
+    total = @total_seconds, other_total = other.total_seconds
+    nanos = @nanosecond,    other_nanos = other.nanosecond
+    while (nanos < other_nanos) (
+      nanos += Time._nanoseconds_per_second
+      total = total -! 1
+    )
+    @_new(total -! other_total, nanos - other_nanos)
+
+  :: Add the given number of weeks to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_weeks!` instead.
+  :fun plus_weeks(n)
+    @_new(
+      @total_seconds + Time._seconds_per_day * 7 * n
+      @nanosecond
+    )
+
+  :: Add the given number of weeks to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_weeks` instead.
+  :fun plus_weeks!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_day * 7 *! n
+      @nanosecond
+    )
+
+  :: Add the given number of days to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_days!` instead.
+  :fun plus_days(n)
+    @_new(
+      @total_seconds + Time._seconds_per_day * n
+      @nanosecond
+    )
+
+  :: Add the given number of days to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_days` instead.
+  :fun plus_days!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_day *! n
+      @nanosecond
+    )
+
+  :: Add the given number of hours to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_hours!` instead.
+  :fun plus_hours(n)
+    @_new(
+      @total_seconds + Time._seconds_per_hour * n
+      @nanosecond
+    )
+
+  :: Add the given number of hours to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_hours` instead.
+  :fun plus_hours!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_hour *! n
+      @nanosecond
+    )
+
+  :: Add the given number of minutes to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_minutes!` instead.
+  :fun plus_minutes(n)
+    @_new(
+      @total_seconds + Time._seconds_per_minute * n
+      @nanosecond
+    )
+
+  :: Add the given number of minutes to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_minutes` instead.
+  :fun plus_minutes!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_minute *! n
+      @nanosecond
+    )
+
+  :: Add the given number of seconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_seconds!` instead.
+  :fun plus_seconds(n)
+    @_new(
+      @total_seconds + n
+      @nanosecond
+    )
+
+  :: Add the given number of seconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_seconds` instead.
+  :fun plus_seconds!(n)
+    @_new(
+      @total_seconds +! n
+      @nanosecond
+    )
+
+  :: Add the given milliseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_milliseconds!` instead.
+  :fun plus_milliseconds(n): @ + @milliseconds(n)
+
+  :: Add the given milliseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_milliseconds` instead.
+  :fun plus_milliseconds!(n): @ +! @milliseconds(n)
+
+  :: Add the given microseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_microseconds!` instead.
+  :fun plus_microseconds(n): @ + @microseconds(n)
+
+  :: Add the given microseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_microseconds` instead.
+  :fun plus_microseconds!(n): @ +! @microseconds(n)
+
+  :: Add the given nanoseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_nanoseconds!` instead.
+  :fun plus_nanoseconds(n): @ + @nanoseconds(n)
+
+  :: Add the given nanoseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_nanoseconds` instead.
+  :fun plus_nanoseconds!(n): @ +! @nanoseconds(n)
+
+  :: Subtract the given weeks from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_weeks!` instead.
+  :fun minus_weeks(n): @ - @weeks(n)
+
+  :: Subtract the given weeks from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_weeks` instead.
+  :fun minus_weeks!(n): @ -! @weeks(n)
+
+  :: Subtract the given days from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_days!` instead.
+  :fun minus_days(n): @ - @days(n)
+
+  :: Subtract the given days from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_days` instead.
+  :fun minus_days!(n): @ -! @days(n)
+
+  :: Subtract the given hours from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_hours!` instead.
+  :fun minus_hours(n): @ - @hours(n)
+
+  :: Subtract the given hours from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_hours` instead.
+  :fun minus_hours!(n): @ -! @hours(n)
+
+  :: Subtract the given minutes from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_minutes!` instead.
+  :fun minus_minutes(n): @ - @minutes(n)
+
+  :: Subtract the given minutes from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_minutes` instead.
+  :fun minus_minutes!(n): @ -! @minutes(n)
+
+  :: Subtract the given seconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_seconds!` instead.
+  :fun minus_seconds(n): @ - @seconds(n)
+
+  :: Subtract the given seconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_seconds` instead.
+  :fun minus_seconds!(n): @ -! @seconds(n)
+
+  :: Subtract the given milliseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_milliseconds!` instead.
+  :fun minus_milliseconds(n): @ - @milliseconds(n)
+
+  :: Subtract the given milliseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_milliseconds` instead.
+  :fun minus_milliseconds!(n): @ -! @milliseconds(n)
+
+  :: Subtract the given microseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_microseconds!` instead.
+  :fun minus_microseconds(n): @ - @microseconds(n)
+
+  :: Subtract the given microseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_microseconds` instead.
+  :fun minus_microseconds!(n): @ -! @microseconds(n)
+
+  :: Subtract the given nanoseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_nanoseconds!` instead.
+  :fun minus_nanoseconds(n): @ - @nanoseconds(n)
+
+  :: Subtract the given nanoseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_nanoseconds` instead.
+  :fun minus_nanoseconds!(n): @ -! @nanoseconds(n)

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Formatter.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Formatter.savi
@@ -1,0 +1,463 @@
+:struct Time.Formatter
+  :const month_names Array(String)'val: [
+    "January"
+    "February"
+    "March"
+    "April"
+    "May"
+    "June"
+    "July"
+    "August"
+    "September"
+    "October"
+    "November"
+    "December"
+  ]
+
+  :const day_names Array(String)'val: [
+    "Sunday"
+    "Monday"
+    "Tuesday"
+    "Wednesday"
+    "Thursday"
+    "Friday"
+    "Saturday"
+  ]
+
+  :let pattern String'box
+  :new (@pattern)
+
+  :fun format(time Time'box, out String'iso = String.new_iso)
+    i USize = 0
+    original_out_size = out.size
+    is_bad_format = False
+
+    while (i < @pattern.size()) (
+      try (
+        char U8 = @pattern.byte_at!(i)
+
+        ok = True
+
+        if (char == '%') (
+          char = @pattern.byte_at!(i + 1)
+          case (
+          | char == 'a' | out = @short_day_name(time, --out)
+          | char == 'A' | out = @day_name(time, --out)
+          | (char == 'b') || (char == 'h') | out = @short_month_name(time, --out)
+          | char == 'c' | out = @date_and_time(time, --out)
+          | char == 'B' | out = @month_name(time, --out)
+          | char == 'C' | out = @year_divided_by_100(time, --out)
+          | char == 'd' | out = @day_of_month_zero_padded(time, --out)
+          | (char == 'D') || (char == 'x') | out = @date(time, --out)
+          | char == 'e' | out = @day_of_month_blank_padded(time, --out)
+          | char == 'F' | out = @year_month_day(time, --out)
+          | char == 'g' | out = @calendar_week_year_modulo100(time, --out)
+          | char == 'G' | out = @calendar_week_year(time, --out)
+          | char == 'H' | out = @hour_24_zero_padded(time, --out)
+          | char == 'I' | out = @hour_12_zero_padded(time, --out)
+          | char == 'j' | out = @day_of_year_zero_padded(time, --out)
+          | char == 'k' | out = @hour_24_blank_padded(time, --out)
+          | char == 'l' | out = @hour_12_blank_padded(time, --out)
+          | char == 'L' | out = @milliseconds(time, --out)
+          | char == 'm' | out = @month_zero_padded(time, --out)
+          | char == 'M' | out = @minute(time, --out)
+          | char == 'N' | out = @second_fraction(time, --out)
+          | char == 'p' | out << @am_pm(time)
+          | char == 'P' | out << @am_pm_upcase(time)
+          | char == 'r' | out = @twelve_hour_time(time, --out)
+          | char == 'R' | out = @twenty_four_hour_time(time, --out)
+          | char == 's' | out = @unix_seconds(time, --out)
+          | char == 'S' | out = @second(time, --out)
+          | (char == 'T') || (char == 'X') | out = @twenty_four_hour_time_with_seconds(time, --out)
+          | char == 'u' | out = @day_of_week_monday_1_7(time, --out)
+          | char == 'V' | out = @calendar_week_week(time, --out)
+          | char == 'w' | out = @day_of_week_sunday_0_6(time, --out)
+          | char == 'y' | out = @year_modulo_100(time, --out)
+          | char == 'Y' | out = @year(time, --out)
+          | char == 'z' | out = @time_zone(time, False, --out)
+          | char == '_' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'm' | out << @month_blank_padded(time)
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte('_')
+            )
+            if ok (i += 1)
+          | char == '-' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'd' | out << @day_of_month(time)
+            | char == 'm' | out << @month(time)
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte('-')
+            )
+            if ok (i += 1)
+          | char == '^' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'a' | out << @short_day_name_upcase(time)
+            | char == 'A' | out << @day_name_upcase(time)
+            | (char == 'b') || (char == 'h') | out << @short_month_name_upcase(time)
+            | char == 'B' | out << @month_name_upcase(time)
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte('^')
+            )
+            if ok (i += 1)
+          | char == ':' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'z' | out << @time_zone_colon(time)
+            | char == ':' |
+              char = @pattern.byte_at!(i + 3)
+              case (
+              | char == 'z' | out << @time_zone_colon_with_seconds(time)
+              |
+                ok = False
+                out.push_byte('%')
+                out.push_byte(':')
+                out.push_byte(':')
+              )
+              if ok (i += 1)
+            |
+              out.push_byte('%')
+              out.push_byte(':')
+            )
+            if ok (i += 1)
+          | (char == '3') || (char == '6') || (char == '9') |
+            digit_char = char
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'N' |
+              case (
+              | digit_char == '3' | out << @milliseconds(time)
+              | digit_char == '6' | out << @microseconds(time)
+              | digit_char == '9' | out << @nanoseconds(time)
+              )
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte(digit_char)
+            )
+            if ok (i += 1)
+          | char == '%' |
+            out.push_byte('%')
+          |
+            out.push_byte('%')
+            out.push_byte(char)
+          )
+          i += 1
+        |
+          out.push_byte(char)
+        )
+        i += 1
+      |
+        is_bad_format = True
+      )
+    )
+
+    // If the format was bad, we undo all of the stuff we may have written
+    // by trimming the output string to its original size before we started.
+    if is_bad_format (
+      out.trim_in_place(0, original_out_size.isize)
+    )
+
+    --out
+
+  :fun date_and_time(time Time'box, out String'iso = String.new_iso)
+    out << @short_day_name(time)
+    out.push_byte(' ')
+    out << @short_month_name(time)
+    out.push_byte(' ')
+    out << @day_of_month_blank_padded(time)
+    out.push_byte(' ')
+    out << @twenty_four_hour_time_with_seconds(time)
+    out.push_byte(' ')
+    out << @year(time)
+    --out
+
+  :fun date(time Time'box, out String'iso = String.new_iso)
+    out << @month_zero_padded(time)
+    out.push_byte('/')
+    out << @day_of_month_zero_padded(time)
+    out.push_byte('/')
+    out << @year_modulo_100(time)
+    --out
+
+  :fun year_month_day(time Time'box, out String'iso = String.new_iso)
+    out << @year(time)
+    out.push_byte('-')
+    out << @month_zero_padded(time)
+    out.push_byte('-')
+    out << @day_of_month_zero_padded(time)
+    --out
+
+  :fun twelve_hour_time(time Time'box, out String'iso = String.new_iso)
+    out << @hour_12_zero_padded(time)
+    out.push_byte(':')
+    out << @minute(time)
+    out.push_byte(':')
+    out << @second(time)
+    out.push_byte(' ')
+    out << @am_pm_upcase(time)
+    --out
+
+  :fun twenty_four_hour_time(time Time'box, out String'iso = String.new_iso)
+    out << @hour_24_zero_padded(time)
+    out.push_byte(':')
+    out << @minute(time)
+    --out
+
+  :fun twenty_four_hour_time_with_seconds(time Time'box, out String'iso = String.new_iso)
+    out << @hour_24_zero_padded(time)
+    out.push_byte(':')
+    out << @minute(time)
+    out.push_byte(':')
+    out << @second(time)
+    --out
+
+  :fun year(time Time'box, out String'iso = String.new_iso)
+    @pad4(time.year.u64, '0', --out)
+
+  :fun year_modulo_100(time Time'box, out String'iso = String.new_iso)
+    @pad2((time.year % 100).u64, '0', --out)
+
+  :fun year_divided_by_100(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, (time.year / 100).u32)
+
+  :fun full_or_short_year(time Time'box, out String'iso = String.new_iso)
+    @year(time, --out)
+
+  :fun calendar_week_year(time Time'box, out String'iso = String.new_iso)
+    try (
+      calendar_week_0 = time.calendar_week()[0]!
+      out = @pad4(calendar_week_0, '0', --out)
+    )
+    --out
+
+  :fun calendar_week_year_modulo100(time Time'box, out String'iso = String.new_iso)
+    try (
+      calendar_week_0 = time.calendar_week()[0]!
+      out = @pad2(calendar_week_0 % 100, '0', --out)
+    )
+    --out
+
+  :fun month(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.month)
+
+  :fun month_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.month.u64, '0', --out)
+
+  :fun month_blank_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.month.u64, ' ', --out)
+
+  :fun month_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_month_name(time)
+    --out
+
+  :fun month_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // get_month_name.upcase
+    --out
+
+  :fun short_month_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_short_month_name(time)
+    --out
+
+  :fun short_month_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // get_short_month_name.upcase
+    --out
+
+  :fun calendar_week_week(time Time'box, out String'iso = String.new_iso)
+    try (
+      calendar_week_1 = time.calendar_week()[1]!
+      out = @pad2(calendar_week_1, '0', --out)
+    )
+    --out
+
+  :fun day_of_month(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.day)
+
+  :fun day_of_month_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.day.u64, '0', --out)
+
+  :fun day_of_month_blank_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.day.u64, ' ', --out)
+
+  :fun day_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_day_name(time)
+    --out
+
+  :fun day_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // @get_day_name(time).upcase
+    ""
+
+  :fun short_day_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_short_day_name(time)
+    --out
+
+  :fun short_day_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // get_short_day_name.upcase
+    ""
+
+  :fun short_day_name_with_comma(time Time'box, out String'iso = String.new_iso)
+    out << @short_day_name(time)
+    out.push_byte(',')
+    out.push_byte(' ')
+    --out
+
+  :fun day_of_year_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad3(time.day_of_year, '0', --out)
+
+  :fun hour_24_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.hour.u64, '0', --out)
+
+  :fun hour_24_blank_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.hour.u64, ' ', --out)
+
+  :fun hour_12_zero_padded(time Time'box, out String'iso = String.new_iso)
+    h = (time.hour % 12).u64
+    @pad2(if (h == 0) (12 | h), '0', --out)
+
+  :fun hour_12_blank_padded(time Time'box, out String'iso = String.new_iso)
+    h = (time.hour % 12).u64
+    @pad2(if (h == 0) (12 | h), ' ', --out)
+
+  :fun minute(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.minute.u64, '0', --out)
+
+  :fun second(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.second.u64, '0', --out)
+
+  :fun milliseconds(time Time'box, out String'iso = String.new_iso)
+    @pad3((time.nanosecond / 1000000).u64, '0', --out)
+
+  :fun microseconds(time Time'box, out String'iso = String.new_iso)
+    @pad6((time.nanosecond / 1000).u64, '0', --out)
+
+  :fun nanoseconds(time Time'box, out String'iso = String.new_iso)
+    @pad9(time.nanosecond.u64, '0', --out)
+
+  :fun second_fraction(time Time'box, out String'iso = String.new_iso)
+    @nanoseconds(time, --out)
+
+  :fun second_fraction!(
+    time Time'box
+    fraction_digits I32 = 9
+    out String'iso = String.new_iso
+  )
+    case (
+    | fraction_digits == 0 |
+    | fraction_digits == 3 |
+      out.push_byte('.')
+      out = @milliseconds(time, --out)
+    | fraction_digits == 6 |
+      out.push_byte('.')
+      out = @microseconds(time, --out)
+    | fraction_digits == 9 |
+      out.push_byte('.')
+      out = @nanoseconds(time, --out)
+    |
+      error!
+    )
+    --out
+
+  :fun am_pm(time Time'box) String
+    if (time.hour < 12) ("am" | "pm")
+
+  :fun am_pm_upcase(time Time'box) String
+    if (time.hour < 12) ("AM" | "PM")
+
+  :fun day_of_week_monday_1_7(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.day_of_week.u64)
+
+  :fun day_of_week_sunday_0_6(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.day_of_week.u64 % 7)
+
+  :fun unix_seconds(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.to_unix)
+
+  :fun time_zone(time Time'box, with_seconds = False, out String'iso = String.new_iso)
+    // TODO
+    // time_zone_offset(format_seconds: with_seconds)
+    --out
+
+  // def time_zone_z_or_offset(**options)
+  //   if time.utc?
+  //     io << 'Z'
+  //   else
+  //     time_zone_offset(**options)
+  //   end
+  // end
+
+  // def time_zone_offset(force_colon = false, allow_colon = true, format_seconds = false, parse_seconds = true)
+  //   time.zone.format(io, with_colon: force_colon, with_seconds: format_seconds)
+  // end
+
+  :fun time_zone_colon(time Time'box, with_seconds = False, out String'iso = String.new_iso)
+    // TODO
+    // time_zone_offset(force_colon: true, format_seconds: with_seconds)
+    --out
+
+  :fun time_zone_colon_with_seconds(time Time'box, out String'iso = String.new_iso)
+    @time_zone_colon(time, True, --out)
+
+  :fun time_zone_gmt(time Time'box, out String'iso = String.new_iso)
+    out << "GMT"
+    --out
+
+  :fun time_zone_rfc2822(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // time_zone_offset(allow_colon: false)
+    --out
+
+  // def time_zone_gmt_or_rfc2822(**options)
+  //   if time.utc? || time.location.name == "UT" || time.location.name == "GMT"
+  //     time_zone_gmt
+  //   else
+  //     time_zone_rfc2822
+  //   end
+  // end
+
+  :fun get_month_name(time Time'box) String
+    try (@month_names[time.month.usize - 1]! | "")
+
+  :fun get_short_month_name(time Time'box) String
+    @get_month_name(time).substring(0, 3)
+
+  :fun get_day_name(time Time'box) String
+    try (@day_names[time.day_of_week.usize % 7]! | "")
+
+  :fun get_short_day_name(time Time'box) String
+    @get_day_name(time).substring(0, 3)
+
+  :fun pad2(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 10) out.push_byte(padding)
+    Inspect.into(--out, value)
+
+  :fun pad3(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 100) out.push_byte(padding)
+    @pad2(value, padding, --out)
+
+  :fun pad4(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 1000) out.push_byte(padding)
+    @pad3(value, padding, --out)
+
+  :fun pad6(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 100000) out.push_byte(padding)
+    if (value < 10000) out.push_byte(padding)
+    @pad4(value, padding, --out)
+
+  :fun pad9(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 100000000) out.push_byte(padding)
+    if (value < 10000000) out.push_byte(padding)
+    if (value < 1000000) out.push_byte(padding)
+    @pad6(value, padding, --out)

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Measure.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Measure.savi
@@ -1,0 +1,149 @@
+:: A collection of functions relating to measuring intervals of time elapsed
+:: during some portion of the program's execution.
+:module Time.Measure
+  :: Measure the interval in nanoseconds that elapse in the given yield block.
+  :fun nanoseconds
+    :yields None for None
+    prior = @current_nanoseconds
+    yield None
+    @current_nanoseconds - prior
+
+  :: Measure the interval in microseconds that elapse in the given yield block.
+  :fun microseconds
+    :yields None for None
+    prior = @current_microseconds
+    yield None
+    @current_microseconds - prior
+
+  :: Measure the interval in milliseconds that elapse in the given yield block.
+  :fun milliseconds
+    :yields None for None
+    prior = @current_milliseconds
+    yield None
+    @current_milliseconds - prior
+
+  :: Get the current monotonic non-adjusted nanosecond count.
+  ::
+  :: This number is not guaranteed to have any particular relationship to the
+  :: current wall clock time - it is more likely to be related to system uptime,
+  :: although there is no particular guarantee of that relationship either.
+  :: For wall clock time, call `Time.now` instead.
+  ::
+  :: Being monotonic and non-adjusted, this is suitable for calculating
+  :: time intervals using subtraction with wrap-around underflow semantics.
+  :: That is, because the underlying count will wrap around on overflow,
+  :: subtraction of two values across time should wrap around on underflow
+  :: to properly account for the case of two values that straddle an overflow.
+  :: See `nanoseconds` function for an example of how to measure time.
+  ::
+  :: This function is intended to be used for asynchronous timing measurements.
+  :: For synchronous timing measurements, use the `nanoseconds` function,
+  :: which handles the timing measurement for you around the given yield block.
+  :fun current_nanoseconds U64
+    case (
+    | Platform.is_windows |
+      0 // TODO: Windows support
+    | Platform.is_macos |
+      // MacOS gives us a count of total uptime "ticks" since the OS booted.
+      // We don't know how long a "tick" is without asking the operating system,
+      // so we ask it for the timebase and multiple/divide to get nanoseconds.
+      timebase = Pair(U32, U32).new(0, 0)
+      timebase_res = _FFI.mach_timebase_info(stack_address_of_variable timebase)
+      return 0 if (timebase_res != 0)
+      _FFI.mach_absolute_time
+      * timebase.first.u64
+      / timebase.last.u64
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair, which we combine. We choose the monotonic clock.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.monotonic
+        stack_address_of_variable pair
+      )
+      pair.first.u64 * 1000000000 + pair.last.u64
+    )
+
+  :: Get the current monotonic non-adjusted microsecond count.
+  ::
+  :: This number is not guaranteed to have any particular relationship to the
+  :: current wall clock time - it is more likely to be related to system uptime,
+  :: although there is no particular guarantee of that relationship either.
+  :: For wall clock time, call `Time.now` instead.
+  ::
+  :: Being monotonic and non-adjusted, this is suitable for calculating
+  :: time intervals using subtraction with wrap-around underflow semantics.
+  :: That is, because the underlying count will wrap around on overflow,
+  :: subtraction of two values across time should wrap around on underflow
+  :: to properly account for the case of two values that straddle an overflow.
+  :: See `microseconds` function for an example of how to measure time.
+  ::
+  :: This function is intended to be used for asynchronous timing measurements.
+  :: For synchronous timing measurements, use the `microseconds` function,
+  :: which handles the timing measurement for you around the given yield block.
+  :fun current_microseconds U64
+    case (
+    | Platform.is_windows |
+      0 // TODO: Windows support
+    | Platform.is_macos |
+      // MacOS gives us a count of total uptime "ticks" since the OS booted.
+      // We don't know how long a "tick" is without asking the operating system,
+      // so we ask it for the timebase and multiple/divide to get microseconds.
+      timebase = Pair(U32, U32).new(0, 0)
+      timebase_res = _FFI.mach_timebase_info(stack_address_of_variable timebase)
+      return 0 if (timebase_res != 0)
+      _FFI.mach_absolute_time
+      * timebase.first.u64
+      / (timebase.last.u64 * 1000)
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair, which we combine. We choose the monotonic clock.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.monotonic
+        stack_address_of_variable pair
+      )
+      pair.first.u64 * 1000000 + pair.last.u64 / 1000
+    )
+
+  :: Get the current monotonic non-adjusted millisecond count.
+  ::
+  :: This number is not guaranteed to have any particular relationship to the
+  :: current wall clock time - it is more likely to be related to system uptime,
+  :: although there is no particular guarantee of that relationship either.
+  :: For wall clock time, call `Time.now` instead.
+  ::
+  :: Being monotonic and non-adjusted, this is suitable for calculating
+  :: time intervals using subtraction with wrap-around underflow semantics.
+  :: That is, because the underlying count will wrap around on overflow,
+  :: subtraction of two values across time should wrap around on underflow
+  :: to properly account for the case of two values that straddle an overflow.
+  :: See `milliseconds` function for an example of how to measure time.
+  ::
+  :: This function is intended to be used for asynchronous timing measurements.
+  :: For synchronous timing measurements, use the `milliseconds` function,
+  :: which handles the timing measurement for you around the given yield block.
+  :fun current_milliseconds U64
+    case (
+    | Platform.is_windows |
+      0 // TODO: Windows support
+    | Platform.is_macos |
+      // MacOS gives us a count of total uptime "ticks" since the OS booted.
+      // We don't know how long a "tick" is without asking the operating system,
+      // so we ask it for the timebase and multiple/divide to get milliseconds.
+      timebase = Pair(U32, U32).new(0, 0)
+      timebase_res = _FFI.mach_timebase_info(stack_address_of_variable timebase)
+      return 0 if (timebase_res != 0)
+      _FFI.mach_absolute_time
+      * timebase.first.u64
+      / (timebase.last.u64 * 1000000)
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair, which we combine. We choose the monotonic clock.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.monotonic
+        stack_address_of_variable pair
+      )
+      pair.first.u64 * 1000 + pair.last.u64 / 1000000
+    )

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
@@ -1,0 +1,414 @@
+:: Represents the amount of time elapsed since the beginning of the Common Era
+:: (`0001-01-01 00:00:00.0`), using the proleptic Gregorian calendar.
+:: Times prior to the beginning of the Common Era are not representable.
+::
+:: The number of seconds is represented with 64-bit integer precision,
+:: with an additional 32-bit integer to specify nanoseconds within the second.
+
+:enum Time.DayOfWeek
+  :member NoDay: 0
+  :member Monday: 1
+  :member Tuesday: 2
+  :member Wednesday: 3
+  :member Thursday: 4
+  :member Friday: 5
+  :member Saturday: 6
+  :member Sunday: 7
+
+  :fun non from_value(value U8)
+    case value == (
+    | 1 | Time.DayOfWeek.Monday
+    | 2 | Time.DayOfWeek.Tuesday
+    | 3 | Time.DayOfWeek.Wednesday
+    | 4 | Time.DayOfWeek.Thursday
+    | 5 | Time.DayOfWeek.Friday
+    | 6 | Time.DayOfWeek.Saturday
+    | 7 | Time.DayOfWeek.Sunday
+    | Time.DayOfWeek.NoDay
+    )
+
+:struct val Time
+  :is Comparable(Time)
+
+  :const _seconds_per_day U64: 86400
+  :const _seconds_per_hour U64: 3600
+  :const _seconds_per_minute U64: 60
+  :const _nanoseconds_per_second U32: 1000000000
+  :const _days_per_400_years U64: 146097
+  :const _days_per_100_years U64: 36524
+  :const _days_per_4_years U64: 1461
+
+  :const _unix_epoch U64: 62135596800
+  :fun non unix_epoch
+    @seconds(@_unix_epoch)
+
+  :: The total number of seconds since `0001-01-01 00:00:00.0` UTC
+  :let total_seconds U64
+  :: The number of nanoseconds of the second
+  :let nanosecond U32
+
+  :: An internal-only direct constructor.
+  :new val _new(@total_seconds, @nanosecond)
+
+  :: The maximum duration representable by this data type.
+  :fun non max_value: @_new(U64.max_value, Time._nanoseconds_per_second - 1)
+
+  :: The minimum duration representable by this data type (a.k.a `zero`).
+  :fun non min_value: @_new(0, 0)
+
+  :: A duration of zero length.
+  :fun non zero: @_new(0, 0)
+
+  :: Represent the moment in time indicated by the given year, month, day,
+  :: and optional hour, minute, second, and nanosecond (in the UTC time zone).
+  :new val utc(
+    year   U32
+    month  U8
+    day    U8
+    hour   U8 = 0
+    minute U8 = 0
+    second U8 = 0
+    @nanosecond = 0
+  )
+    @total_seconds =
+      @_seconds_per_day * @_absolute_days(year, month, day)
+      + @_seconds_per_hour * hour.u64
+      + @_seconds_per_minute * minute.u64
+      + second.u64
+
+  :: Represent a duration of the given number of nanoseconds.
+  :: DEPRECATED: Use `Time.Duration.nanoseconds` instead.
+  :new nanoseconds(n U32):
+    @total_seconds = 0
+    while (@_nanoseconds_per_second < n) (
+      n -= @_nanoseconds_per_second
+      @total_seconds += 1
+    )
+    @nanosecond = n
+
+  :: Represent a duration of the given number of seconds.
+  :: DEPRECATED: Use `Time.Duration.seconds` instead.
+  :new seconds(n): @nanosecond = 0, @total_seconds = n
+
+  :: Represent a duration of the given number of minutes.
+  :: DEPRECATED: Use `Time.Duration.minutes` instead.
+  :new minutes(n): @nanosecond = 0, @total_seconds = @_seconds_per_minute * n
+
+  :: Represent a duration of the given number of hours.
+  :: DEPRECATED: Use `Time.Duration.hours` instead.
+  :new hours(n): @nanosecond = 0, @total_seconds = @_seconds_per_hour * n
+
+  :: Represent a duration of the given number of days.
+  :: DEPRECATED: Use `Time.Duration.days` instead.
+  :new days(n): @nanosecond = 0, @total_seconds = @_seconds_per_day * n
+
+  :: Return True if the given time is exactly equivalent to this one.
+  :fun "=="(other Time'box)
+    @total_seconds == other.total_seconds
+    && @nanosecond == other.nanosecond
+
+  :: Return True if the given time is less than (earlier than) this one.
+  :fun "<"(other Time'box)
+    @total_seconds < other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond < other.nanosecond)
+
+  :: Return True if the given time is greater than (later than) this one.
+  :fun ">"(other Time'box)
+    @total_seconds > other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond > other.nanosecond)
+
+  :: Add the given duration to this time and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use the `+!` method instead.
+  :fun "+"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) + other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Add the given duration to this time and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow semantics are desired, use the `+` method instead.
+  :fun "+!"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) +! other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Subtract the given duration from this time and return the result.
+  ::
+  :: Uses wrap-around underflow semantics if the result is less than `zero`.
+  :: If an error on underflow is desired, use the `-!` method instead.
+  :fun "-"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) - other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Subtract the given duration from this time and return the result.
+  ::
+  :: Raises an error if the result would be less than `zero`.
+  :: If wrap-around underflow semantics is desired, use the `-` method instead.
+  :fun "-!"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) -! other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Returns the year (a number greater than or equal to 1).
+  :fun year U32
+    @_year_month_day.bit_and(0xFFFF_FFFF).u32
+
+  :: Returns the month of the year (a number between 1 and 12).
+  :fun month U8
+    (@_year_month_day.bit_shr(32)).bit_and(0xFF).u8
+
+  :: Returns the day of the month (a number between 1 and 31).
+  :fun day U8
+    (@_year_month_day.bit_shr(40)).bit_and(0xFF).u8
+
+  :: Returns the hour of the day (a number between 0 and 23).
+  :fun hour U8
+    ((@total_seconds % @_seconds_per_day) / @_seconds_per_hour).u8
+
+  :: Returns the minute of the hour (a number between 0 and 59).
+  :fun minute U8
+    ((@total_seconds % @_seconds_per_hour) / @_seconds_per_minute).u8
+
+  :: Returns the second of the minute (a number between 0 and 59).
+  :fun second U8
+    (@total_seconds % @_seconds_per_minute).u8
+
+  :: Print the time data for human inspection (the format is subject to change).
+  :fun inspect_into(output String'iso)
+    // TODO: Properly pad numbers with zeros for a constant string width.
+    output = Inspect.into(--output, @year),       output.push_byte('-')
+    output = Inspect.into(--output, @month),      output.push_byte('-')
+    output = Inspect.into(--output, @day),        output.push_byte(' ')
+    output = Inspect.into(--output, @hour),       output.push_byte(':')
+    output = Inspect.into(--output, @minute),     output.push_byte(':')
+    output = Inspect.into(--output, @second),     output.push_byte('\'')
+    output = Inspect.into(--output, @nanosecond)
+    --output
+
+  :: Returns a bit-packed representation of the year, month, and day,
+  :: for internal reuse by other functions that need this information.
+  :fun _year_month_day U64 // TODO: Return tuple instead of packed U64 hack
+    total_days = (@total_seconds / @_seconds_per_day)
+
+    num400 = total_days / @_days_per_400_years
+    total_days -= num400 * @_days_per_400_years
+
+    num100 U64 = total_days / @_days_per_100_years // TODO: shouldn't need an explicit U64 here
+    if (num100 == 4) (num100 = 3) // account for leap years
+    total_days -= num100 * @_days_per_100_years
+
+    num4 = total_days / @_days_per_4_years
+    total_days -= num4 * @_days_per_4_years
+
+    numyears U64 = total_days / 365 // TODO: shouldn't need an explicit U64 here
+    if (numyears == 4) (numyears = 3) // account for leap years
+    total_days -= numyears * 365
+
+    year = (num400 * 400 + num100 * 100 + num4 * 4 + numyears + 1).u32
+
+    month U8 = 0
+    days_in_month U64 = 0
+    while (total_days >= days_in_month) (
+      total_days -= days_in_month
+      month += 1
+      days_in_month = @_days_in_month(month, year).u64
+    )
+
+    day = total_days.u8 + 1
+
+    year.u64
+      .bit_or(month.u64.bit_shl(32))
+      .bit_or(day.u64.bit_shl(40))
+
+  :: Returns True if the given year is a leap year.
+  :fun non _is_leap_year(year U32)
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+
+  :: Returns the number of days in the given month of the given year.
+  :fun non _days_in_month(month U8, year) U8
+    case month == (
+    |  1 | 31 // January
+    |  2 | if @_is_leap_year(year) (29 | 28) // Feb.
+    |  3 | 31 // March
+    |  4 | 30 // April
+    |  5 | 31 // May
+    |  6 | 30 // June
+    |  7 | 31 // July
+    |  8 | 31 // August
+    |  9 | 30 // September
+    | 10 | 31 // October
+    | 11 | 30 // November
+    | 12 | 31 // December
+    | 0 // months that don't exist have zero days
+    )
+
+  :: Returns the number of days from `0001-01-01` to the date indicated
+  :: by the given year, month, and day in the proleptic Gregorian calendar.
+  :fun non _absolute_days(year U32, month U8, day U8) U64
+    // Normalize the month index, treating months beyond 12 as additional years.
+    while (month > 12) (year += 1, month -= 12)
+
+    // Calculate the number of days since day 1 of the given year.
+    days_since_jan_1 = day.u64 - 1
+    scan_month U8 = 1
+    while (scan_month < month) (
+      days_since_jan_1 += @_days_in_month(scan_month, year).u64
+      scan_month += 1
+    )
+
+    // Finally, add in the number of days elapsed in the years already passed.
+    year -= 1
+    year.u64 * 365
+    + year.u64 / 4
+    - year.u64 / 100
+    + year.u64 / 400
+    + days_since_jan_1
+
+  :fun year_month_day_day_year Array(U64)
+    total_days U64 = (@total_seconds / @_seconds_per_day)
+
+    num400 U64 = (total_days / @_days_per_400_years)
+    total_days -= num400 * @_days_per_400_years
+
+    num100 U64 = (total_days / @_days_per_100_years)
+    if (num100 == 4) (// leap
+      num100 = 3
+    )
+    total_days -= num100 * @_days_per_100_years
+
+    num4 U64 = (total_days / @_days_per_4_years)
+    total_days -= num4 * @_days_per_4_years
+
+    numyears = (total_days / 365)
+    if (numyears == 4) (// leap
+      numyears = 3
+    )
+    total_days -= numyears * 365
+
+    year = num400 * 400 + num100 * 100 + num4 * 4 + numyears + 1
+
+    ordinal_day_in_year U64 = total_days + 1
+
+    month U64 = 1
+
+    try (
+      while True (
+        days_in_month = @_days_in_month(month.u8, year.u32).u64
+        if (total_days < days_in_month) (
+          error! // TODO use break
+        )
+
+        total_days -= days_in_month
+        month += 1
+      )
+    )
+
+    day U64 = total_days + 1
+
+    [year, month, day, ordinal_day_in_year]
+
+  :fun calendar_week Array(U64) // TODO USE TUPPLE INSTEAD
+    try (
+      tmp = @year_month_day_day_year
+
+      year = tmp[0]!
+
+      month = tmp[1]!
+      day = tmp[2]!
+      day_year = tmp[3]!
+
+      day_of_week = @day_of_week
+
+      // The week number can be calculated as number of Mondays in the year up to
+      // the ordinal date.
+      // The addition by +10 consists of +7 to start the week numbering with 1
+      // instead of 0 and +3 because the first week has already started in the
+      // previous year and the first Monday is actually in week 2.
+      week_number = ((day_year - day_of_week.u64 + 10) / 7).u64
+
+      if (week_number == 0) (
+        // Week number 0 means the date belongs to the last week of the previous year.
+        year -= 1
+
+        // The week number depends on whether the previous year has 52 or 53 weeks
+        // which can be determined by the day of week of January 1.
+        // The year has 53 weeks if Januar 1 is on a Friday or the year was a leap
+        // year and January 1 is on a Saturday.
+        jan1_day_of_week = Time.DayOfWeek.from_value(((day_of_week.u64 - day_year + 1) % 7).u8)
+
+        if ((jan1_day_of_week == Time.DayOfWeek.Friday) || (jan1_day_of_week == Time.DayOfWeek.Saturday && @_is_leap_year(year.u32))) (
+          week_number = 53
+        |
+          week_number = 52
+        )
+      |
+        if (week_number == 53) (
+          // Week number 53 is actually week number 1 of the following year, if
+          // December 31 is on a Monday, Tuesday or Wednesday.
+          dec31_day_of_week = (day_of_week.u64 + 31 - day) % 7
+
+          if (dec31_day_of_week <= Time.DayOfWeek.Wednesday.u64) (
+            year += 1
+            week_number = 1
+          )
+        )
+      )
+
+      [year, week_number]
+    |
+      // THIS SHOULD BE UNREACHABLE
+      []
+    )
+
+  :fun to_unix I64
+    (@total_seconds - @_unix_epoch).i64
+
+  :fun day_of_year U64
+    try (
+      @year_month_day_day_year[3]!
+    |
+      0
+    )
+
+  :fun day_of_week
+    days U64 = (@total_seconds / @_seconds_per_day)
+    Time.DayOfWeek.from_value((days % 7 + 1).u8)
+
+  :fun to_s
+    @format("%m/%d/%y")
+
+  :fun format(pattern String'box) String'val
+    Time.Formatter.new(pattern).format(@)
+
+  :: Get the current wall-clock adjusted system time (in UTC).
+  ::
+  :: Because this time is not monotonic and gets adjusted to match wall clocks,
+  :: it is not suitable for measuring intervals of time during the program.
+  :: To measure time intervals, use functions of `Time.Measure` instead.
+  :new now
+    case (
+    | Platform.is_windows |
+      // TODO: Windows support
+      @total_seconds = 0
+      @nanosecond = 0
+    | Platform.is_macos |
+      // MacOS gives us the seconds since unix epoch and microseconds as a pair.
+      // We could also get the time zone here, but we don't; we pass null there.
+      macos_pair = Pair(U64, U64).new(0, 0)
+      _FFI.gettimeofday(
+        stack_address_of_variable macos_pair
+        CPointer(Pair(I32, I32)).null
+      )
+      @total_seconds = macos_pair.first + @_unix_epoch
+      @nanosecond = macos_pair.last.u32 * 1000
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair. We choose the "real time" clock type.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.real_time
+        stack_address_of_variable pair
+      )
+      @total_seconds = pair.first.u64 + @_unix_epoch
+      @nanosecond = pair.last.u32
+    )

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/_FFI.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/_FFI.savi
@@ -1,0 +1,23 @@
+:ffimodule _FFI
+  :: C function used to get the current time on MacOS.
+  :fun gettimeofday(
+    time_pair_out CPointer(Pair(U64, U64))
+    time_zone_out CPointer(Pair(I32, I32))
+  ) I32
+
+  :: C function used to get the current time on non-MacOS POSIX platforms.
+  :fun clock_gettime(
+    clock_id U32
+    time_pair_out CPointer(Pair(USize, USize))
+  ) I32
+
+  :: C function used to get the system uptime ticks on MacOS.
+  :fun mach_absolute_time U64
+
+  :: C function used to get the numerator and denominator for ticks on MacOS.
+  :fun mach_timebase_info(info CPointer(Pair(U32, U32))) I32
+
+:: Clock IDs to use when calling `_FFI.clock_gettime`.
+:module _FFI.ClockType
+  :fun real_time U32: 0
+  :fun monotonic U32: if Platform.is_linux (1 | 4)

--- a/examples/adventofcode/2018/src/day_4.savi
+++ b/examples/adventofcode/2018/src/day_4.savi
@@ -1,8 +1,8 @@
 :enum Day4Event
   :const bit_width U8: 8 // TODO infer this from the number of members instead
-  :member Day4EventBegin: 0
-  :member Day4EventSleep: 1
-  :member Day4EventAwake: 2
+  :member Begin: 0
+  :member Sleep: 1
+  :member Awake: 2
 
 :class Day4Entry
   :var guard String
@@ -21,15 +21,15 @@
     // Parse the event type from the message.
     message = halves[1]!.trim(1)
     event = case (
-    | message.includes("begins shift") | Day4EventBegin
-    | message.includes("falls asleep") | Day4EventSleep
-    | message.includes("wakes up")     | Day4EventAwake
+    | message.includes("begins shift") | Day4Event.Begin
+    | message.includes("falls asleep") | Day4Event.Sleep
+    | message.includes("wakes up")     | Day4Event.Awake
     | error!
     )
 
     // Parse the guard id from the message (on "begin" events).
     guard = ""
-    if (event == Day4EventBegin) (
+    if (event == Day4Event.Begin) (
       guard = message.split('#')[1]!.split(' ')[0]!
     )
 
@@ -76,8 +76,8 @@
     sleeps = Map(String, Map(I32, Array(U32))).new
     last_entry = try (entries[0]! | Day4Entry.empty)
     entries.each -> (entry |
-      if (entry.event == Day4EventAwake) (
-        if (last_entry.event != Day4EventSleep) (
+      if (entry.event == Day4Event.Awake) (
+        if (last_entry.event != Day4Event.Sleep) (
           env.err.print("warning: awoke without first sleeping!")
         )
 
@@ -179,7 +179,7 @@
     assert no_error: (
       entry = Day4Entry.parse!("[1518-11-01 23:58] Guard #99 begins shift")
       assert: entry.guard       == "99"
-      assert: entry.event       == Day4EventBegin
+      assert: entry.event       == Day4Event.Begin
       assert: entry.time.year   == 1518
       assert: entry.time.month  == 11
       assert: entry.time.day    == 1
@@ -191,7 +191,7 @@
     assert no_error: (
       entry = Day4Entry.parse!("[1518-11-02 00:40] falls asleep")
       assert: entry.guard       == ""
-      assert: entry.event       == Day4EventSleep
+      assert: entry.event       == Day4Event.Sleep
       assert: entry.time.year   == 1518
       assert: entry.time.month  == 11
       assert: entry.time.day    == 2
@@ -203,7 +203,7 @@
     assert no_error: (
       entry = Day4Entry.parse!("[1518-11-02 00:50] wakes up")
       assert: entry.guard       == ""
-      assert: entry.event       == Day4EventAwake
+      assert: entry.event       == Day4Event.Awake
       assert: entry.time.year   == 1518
       assert: entry.time.month  == 11
       assert: entry.time.day    == 2

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE-crystal
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE-crystal
@@ -1,0 +1,15 @@
+Parts of this source code are based on code from `crystal`, whose license is:
+
+Copyright 2012-2019 Manas Technology Solutions.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE.md
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/LICENSE.md
@@ -1,0 +1,11 @@
+Copyright 2019 Joe Eli McIlvain
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/manifest.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/manifest.savi
@@ -1,0 +1,3 @@
+:manifest lib Time
+  :sources "src/*.savi"
+

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Duration.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Duration.savi
@@ -1,0 +1,520 @@
+:struct val Time.Duration
+  :is Comparable(Time.Duration)
+
+  :: The total number of seconds in the duration.
+  :let total_seconds U64
+  :: The number of nanoseconds past the second.
+  :let nanosecond U32
+
+  :: An internal-only direct constructor.
+  :new val _new(@total_seconds, @nanosecond)
+
+  :: The maximum duration representable by this data type.
+  :fun non max_value: @_new(U64.max_value, Time._nanoseconds_per_second - 1)
+
+  :: The minimum duration representable by this data type (a.k.a `zero`).
+  :fun non min_value: @_new(0, 0)
+
+  :: A duration of zero length.
+  :fun non zero: @_new(0, 0)
+
+  :: Represent a duration of the given number of nanoseconds.
+  :new nanoseconds(n U64):
+    if (n < 1000000000) (
+      @total_seconds = 0
+      @nanosecond = n.u32
+    |
+      @total_seconds = n / 1000000000
+      @nanosecond = (n % 1000000000).u32
+    )
+
+  :: Represent a duration of the given number of microseconds.
+  :new microseconds(n U64)
+    if (n < 1000000) (
+      @total_seconds = 0
+      @nanosecond = n.u32 * 1000
+    |
+      @total_seconds = n / 1000000
+      @nanosecond = (n % 1000000).u32 * 1000
+    )
+
+  :: Represent a duration of the given number of milliseconds.
+  :new milliseconds(n U64)
+    if (n < 1000) (
+      @total_seconds = 0
+      @nanosecond = n.u32 * 1000000
+    |
+      @total_seconds = n / 1000
+      @nanosecond = (n % 1000).u32 * 1000000
+    )
+
+  :: Represent a duration of the given number of seconds.
+  :new seconds(n)
+    @total_seconds = n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of minutes.
+  :new minutes(n)
+    @total_seconds = Time._seconds_per_minute * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of hours.
+  :new hours(n)
+    @total_seconds = Time._seconds_per_hour * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of days.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :new days(n)
+    @total_seconds = Time._seconds_per_day * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of 7-day weeks.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :new weeks(n)
+    @total_seconds = Time._seconds_per_day * 7 * n
+    @nanosecond = 0
+
+  :: Return the total number of complete weeks in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_weeks: @total_seconds / (Time._seconds_per_day * 7)
+
+  :: Return the total number of complete days in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_days: @total_seconds / Time._seconds_per_day
+
+  :: Return the total number of complete hours in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  :fun total_hours: @total_seconds / Time._seconds_per_hour
+
+  :: Return the total number of complete minutes in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  :fun total_minutes: @total_seconds / Time._seconds_per_minute
+
+  :: Return the total number of complete milliseconds in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_milliseconds!
+    (@total_seconds *! 1000) +! (@nanosecond / 1000000).u64
+
+  :: Return the total number of complete microseconds in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_microseconds!
+    (@total_seconds *! 1000000) +! (@nanosecond / 1000).u64
+
+  :: Return the total number of nanoseconds in the duration.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_nanoseconds!
+    (@total_seconds *! 1000000000) +! @nanosecond.u64
+
+  :: Return the total number of complete weeks in the duration.
+  :: The remainder of the duration (beyond those weeks) is also returned.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_weeks_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / (Time._seconds_per_day * 7)
+      @_new(
+        @total_seconds % (Time._seconds_per_day * 7)
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete days in the duration.
+  :: The remainder of the duration (beyond those days) is also returned.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_days_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_day
+      @_new(
+        @total_seconds % Time._seconds_per_day
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete hours in the duration.
+  :: The remainder of the duration (beyond those hours) is also returned.
+  :fun total_hours_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_hour
+      @_new(
+        @total_seconds % Time._seconds_per_hour
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete minutes in the duration.
+  :: The remainder of the duration (beyond those minutes) is also returned.
+  :fun total_minutes_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_minute
+      @_new(
+        @total_seconds % Time._seconds_per_minute
+        @nanosecond
+      )
+    )
+
+  :: Print the duration for human inspection (the format is subject to change).
+  :fun inspect_into(output String'iso)
+    weeks_result = @total_weeks_with_remainder
+    days_result = weeks_result.tail.total_days_with_remainder
+    hours_result = days_result.tail.total_hours_with_remainder
+    minutes_result = hours_result.tail.total_minutes_with_remainder
+
+    weeks = weeks_result.head
+    days = days_result.head
+    hours = hours_result.head
+    minutes = minutes_result.head
+    seconds = minutes_result.tail.total_seconds
+    nanoseconds = minutes_result.tail.nanosecond
+
+    printed_anything = False
+    output << "Time.Duration("
+
+    if (weeks > 0) (
+      output = Inspect.into(--output, weeks), output << " weeks"
+      printed_anything = True
+    )
+
+    if (days > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, days), output << " days"
+      printed_anything = True
+    )
+
+    if (hours > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, hours), output << " hours"
+      printed_anything = True
+    )
+
+    if (minutes > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, minutes), output << " minutes"
+      printed_anything = True
+    )
+
+    if (seconds > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, seconds), output << " seconds"
+      printed_anything = True
+    )
+
+    if (nanoseconds > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, nanoseconds), output << " nanoseconds"
+      printed_anything = True
+    )
+
+    output << ")"
+    --output
+
+  :: Return True if the given duration is exactly equivalent to this one.
+  :fun "=="(other Time.Duration'box)
+    @total_seconds == other.total_seconds
+    && @nanosecond == other.nanosecond
+
+  :: Return True if the given duration is less than (earlier than) this one.
+  :fun "<"(other Time.Duration'box)
+    @total_seconds < other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond < other.nanosecond)
+
+  :: Return True if the given duration is greater than (later than) this one.
+  :fun ">"(other Time.Duration'box)
+    @total_seconds > other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond > other.nanosecond)
+
+  :: Add the given duration to this one and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use the `+!` method instead.
+  :fun "+"(other Time.Duration'box)
+    total = @total_seconds + other.total_seconds
+    nanos = @nanosecond + other.nanosecond
+    while (nanos >= Time._nanoseconds_per_second) (
+      nanos -= Time._nanoseconds_per_second
+      total += 1
+    )
+    @_new(total, nanos)
+
+  :: Add the given duration to this one and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow semantics are desired, use the `+` method instead.
+  :fun "+!"(other Time.Duration'box)
+    total = @total_seconds +! other.total_seconds
+    nanos = @nanosecond + other.nanosecond
+    while (nanos >= Time._nanoseconds_per_second) (
+      nanos -= Time._nanoseconds_per_second
+      total = total +! 1
+    )
+    @_new(total, nanos)
+
+  :: Subtract the given duration from this one and return the result.
+  ::
+  :: Uses wrap-around underflow semantics if the result is less than `zero`.
+  :: If an error on underflow is desired, use the `-!` method instead.
+  :fun "-"(other Time.Duration'box)
+    total = @total_seconds, other_total = other.total_seconds
+    nanos = @nanosecond,    other_nanos = other.nanosecond
+    while (nanos < other_nanos) (
+      nanos += Time._nanoseconds_per_second
+      total -= 1
+    )
+    @_new(total - other_total, nanos - other_nanos)
+
+  :: Subtract the given duration from this one and return the result.
+  ::
+  :: Raises an error if the result would be less than `zero`.
+  :: If wrap-around underflow semantics is desired, use the `-` method instead.
+  :fun "-!"(other Time.Duration'box)
+    total = @total_seconds, other_total = other.total_seconds
+    nanos = @nanosecond,    other_nanos = other.nanosecond
+    while (nanos < other_nanos) (
+      nanos += Time._nanoseconds_per_second
+      total = total -! 1
+    )
+    @_new(total -! other_total, nanos - other_nanos)
+
+  :: Add the given number of weeks to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_weeks!` instead.
+  :fun plus_weeks(n)
+    @_new(
+      @total_seconds + Time._seconds_per_day * 7 * n
+      @nanosecond
+    )
+
+  :: Add the given number of weeks to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_weeks` instead.
+  :fun plus_weeks!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_day * 7 *! n
+      @nanosecond
+    )
+
+  :: Add the given number of days to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_days!` instead.
+  :fun plus_days(n)
+    @_new(
+      @total_seconds + Time._seconds_per_day * n
+      @nanosecond
+    )
+
+  :: Add the given number of days to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_days` instead.
+  :fun plus_days!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_day *! n
+      @nanosecond
+    )
+
+  :: Add the given number of hours to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_hours!` instead.
+  :fun plus_hours(n)
+    @_new(
+      @total_seconds + Time._seconds_per_hour * n
+      @nanosecond
+    )
+
+  :: Add the given number of hours to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_hours` instead.
+  :fun plus_hours!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_hour *! n
+      @nanosecond
+    )
+
+  :: Add the given number of minutes to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_minutes!` instead.
+  :fun plus_minutes(n)
+    @_new(
+      @total_seconds + Time._seconds_per_minute * n
+      @nanosecond
+    )
+
+  :: Add the given number of minutes to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_minutes` instead.
+  :fun plus_minutes!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_minute *! n
+      @nanosecond
+    )
+
+  :: Add the given number of seconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_seconds!` instead.
+  :fun plus_seconds(n)
+    @_new(
+      @total_seconds + n
+      @nanosecond
+    )
+
+  :: Add the given number of seconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_seconds` instead.
+  :fun plus_seconds!(n)
+    @_new(
+      @total_seconds +! n
+      @nanosecond
+    )
+
+  :: Add the given milliseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_milliseconds!` instead.
+  :fun plus_milliseconds(n): @ + @milliseconds(n)
+
+  :: Add the given milliseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_milliseconds` instead.
+  :fun plus_milliseconds!(n): @ +! @milliseconds(n)
+
+  :: Add the given microseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_microseconds!` instead.
+  :fun plus_microseconds(n): @ + @microseconds(n)
+
+  :: Add the given microseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_microseconds` instead.
+  :fun plus_microseconds!(n): @ +! @microseconds(n)
+
+  :: Add the given nanoseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_nanoseconds!` instead.
+  :fun plus_nanoseconds(n): @ + @nanoseconds(n)
+
+  :: Add the given nanoseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_nanoseconds` instead.
+  :fun plus_nanoseconds!(n): @ +! @nanoseconds(n)
+
+  :: Subtract the given weeks from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_weeks!` instead.
+  :fun minus_weeks(n): @ - @weeks(n)
+
+  :: Subtract the given weeks from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_weeks` instead.
+  :fun minus_weeks!(n): @ -! @weeks(n)
+
+  :: Subtract the given days from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_days!` instead.
+  :fun minus_days(n): @ - @days(n)
+
+  :: Subtract the given days from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_days` instead.
+  :fun minus_days!(n): @ -! @days(n)
+
+  :: Subtract the given hours from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_hours!` instead.
+  :fun minus_hours(n): @ - @hours(n)
+
+  :: Subtract the given hours from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_hours` instead.
+  :fun minus_hours!(n): @ -! @hours(n)
+
+  :: Subtract the given minutes from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_minutes!` instead.
+  :fun minus_minutes(n): @ - @minutes(n)
+
+  :: Subtract the given minutes from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_minutes` instead.
+  :fun minus_minutes!(n): @ -! @minutes(n)
+
+  :: Subtract the given seconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_seconds!` instead.
+  :fun minus_seconds(n): @ - @seconds(n)
+
+  :: Subtract the given seconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_seconds` instead.
+  :fun minus_seconds!(n): @ -! @seconds(n)
+
+  :: Subtract the given milliseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_milliseconds!` instead.
+  :fun minus_milliseconds(n): @ - @milliseconds(n)
+
+  :: Subtract the given milliseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_milliseconds` instead.
+  :fun minus_milliseconds!(n): @ -! @milliseconds(n)
+
+  :: Subtract the given microseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_microseconds!` instead.
+  :fun minus_microseconds(n): @ - @microseconds(n)
+
+  :: Subtract the given microseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_microseconds` instead.
+  :fun minus_microseconds!(n): @ -! @microseconds(n)
+
+  :: Subtract the given nanoseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_nanoseconds!` instead.
+  :fun minus_nanoseconds(n): @ - @nanoseconds(n)
+
+  :: Subtract the given nanoseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_nanoseconds` instead.
+  :fun minus_nanoseconds!(n): @ -! @nanoseconds(n)

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Formatter.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Formatter.savi
@@ -1,0 +1,463 @@
+:struct Time.Formatter
+  :const month_names Array(String)'val: [
+    "January"
+    "February"
+    "March"
+    "April"
+    "May"
+    "June"
+    "July"
+    "August"
+    "September"
+    "October"
+    "November"
+    "December"
+  ]
+
+  :const day_names Array(String)'val: [
+    "Sunday"
+    "Monday"
+    "Tuesday"
+    "Wednesday"
+    "Thursday"
+    "Friday"
+    "Saturday"
+  ]
+
+  :let pattern String'box
+  :new (@pattern)
+
+  :fun format(time Time'box, out String'iso = String.new_iso)
+    i USize = 0
+    original_out_size = out.size
+    is_bad_format = False
+
+    while (i < @pattern.size()) (
+      try (
+        char U8 = @pattern.byte_at!(i)
+
+        ok = True
+
+        if (char == '%') (
+          char = @pattern.byte_at!(i + 1)
+          case (
+          | char == 'a' | out = @short_day_name(time, --out)
+          | char == 'A' | out = @day_name(time, --out)
+          | (char == 'b') || (char == 'h') | out = @short_month_name(time, --out)
+          | char == 'c' | out = @date_and_time(time, --out)
+          | char == 'B' | out = @month_name(time, --out)
+          | char == 'C' | out = @year_divided_by_100(time, --out)
+          | char == 'd' | out = @day_of_month_zero_padded(time, --out)
+          | (char == 'D') || (char == 'x') | out = @date(time, --out)
+          | char == 'e' | out = @day_of_month_blank_padded(time, --out)
+          | char == 'F' | out = @year_month_day(time, --out)
+          | char == 'g' | out = @calendar_week_year_modulo100(time, --out)
+          | char == 'G' | out = @calendar_week_year(time, --out)
+          | char == 'H' | out = @hour_24_zero_padded(time, --out)
+          | char == 'I' | out = @hour_12_zero_padded(time, --out)
+          | char == 'j' | out = @day_of_year_zero_padded(time, --out)
+          | char == 'k' | out = @hour_24_blank_padded(time, --out)
+          | char == 'l' | out = @hour_12_blank_padded(time, --out)
+          | char == 'L' | out = @milliseconds(time, --out)
+          | char == 'm' | out = @month_zero_padded(time, --out)
+          | char == 'M' | out = @minute(time, --out)
+          | char == 'N' | out = @second_fraction(time, --out)
+          | char == 'p' | out << @am_pm(time)
+          | char == 'P' | out << @am_pm_upcase(time)
+          | char == 'r' | out = @twelve_hour_time(time, --out)
+          | char == 'R' | out = @twenty_four_hour_time(time, --out)
+          | char == 's' | out = @unix_seconds(time, --out)
+          | char == 'S' | out = @second(time, --out)
+          | (char == 'T') || (char == 'X') | out = @twenty_four_hour_time_with_seconds(time, --out)
+          | char == 'u' | out = @day_of_week_monday_1_7(time, --out)
+          | char == 'V' | out = @calendar_week_week(time, --out)
+          | char == 'w' | out = @day_of_week_sunday_0_6(time, --out)
+          | char == 'y' | out = @year_modulo_100(time, --out)
+          | char == 'Y' | out = @year(time, --out)
+          | char == 'z' | out = @time_zone(time, False, --out)
+          | char == '_' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'm' | out << @month_blank_padded(time)
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte('_')
+            )
+            if ok (i += 1)
+          | char == '-' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'd' | out << @day_of_month(time)
+            | char == 'm' | out << @month(time)
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte('-')
+            )
+            if ok (i += 1)
+          | char == '^' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'a' | out << @short_day_name_upcase(time)
+            | char == 'A' | out << @day_name_upcase(time)
+            | (char == 'b') || (char == 'h') | out << @short_month_name_upcase(time)
+            | char == 'B' | out << @month_name_upcase(time)
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte('^')
+            )
+            if ok (i += 1)
+          | char == ':' |
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'z' | out << @time_zone_colon(time)
+            | char == ':' |
+              char = @pattern.byte_at!(i + 3)
+              case (
+              | char == 'z' | out << @time_zone_colon_with_seconds(time)
+              |
+                ok = False
+                out.push_byte('%')
+                out.push_byte(':')
+                out.push_byte(':')
+              )
+              if ok (i += 1)
+            |
+              out.push_byte('%')
+              out.push_byte(':')
+            )
+            if ok (i += 1)
+          | (char == '3') || (char == '6') || (char == '9') |
+            digit_char = char
+            char = @pattern.byte_at!(i + 2)
+            case (
+            | char == 'N' |
+              case (
+              | digit_char == '3' | out << @milliseconds(time)
+              | digit_char == '6' | out << @microseconds(time)
+              | digit_char == '9' | out << @nanoseconds(time)
+              )
+            |
+              ok = False
+              out.push_byte('%')
+              out.push_byte(digit_char)
+            )
+            if ok (i += 1)
+          | char == '%' |
+            out.push_byte('%')
+          |
+            out.push_byte('%')
+            out.push_byte(char)
+          )
+          i += 1
+        |
+          out.push_byte(char)
+        )
+        i += 1
+      |
+        is_bad_format = True
+      )
+    )
+
+    // If the format was bad, we undo all of the stuff we may have written
+    // by trimming the output string to its original size before we started.
+    if is_bad_format (
+      out.trim_in_place(0, original_out_size.isize)
+    )
+
+    --out
+
+  :fun date_and_time(time Time'box, out String'iso = String.new_iso)
+    out << @short_day_name(time)
+    out.push_byte(' ')
+    out << @short_month_name(time)
+    out.push_byte(' ')
+    out << @day_of_month_blank_padded(time)
+    out.push_byte(' ')
+    out << @twenty_four_hour_time_with_seconds(time)
+    out.push_byte(' ')
+    out << @year(time)
+    --out
+
+  :fun date(time Time'box, out String'iso = String.new_iso)
+    out << @month_zero_padded(time)
+    out.push_byte('/')
+    out << @day_of_month_zero_padded(time)
+    out.push_byte('/')
+    out << @year_modulo_100(time)
+    --out
+
+  :fun year_month_day(time Time'box, out String'iso = String.new_iso)
+    out << @year(time)
+    out.push_byte('-')
+    out << @month_zero_padded(time)
+    out.push_byte('-')
+    out << @day_of_month_zero_padded(time)
+    --out
+
+  :fun twelve_hour_time(time Time'box, out String'iso = String.new_iso)
+    out << @hour_12_zero_padded(time)
+    out.push_byte(':')
+    out << @minute(time)
+    out.push_byte(':')
+    out << @second(time)
+    out.push_byte(' ')
+    out << @am_pm_upcase(time)
+    --out
+
+  :fun twenty_four_hour_time(time Time'box, out String'iso = String.new_iso)
+    out << @hour_24_zero_padded(time)
+    out.push_byte(':')
+    out << @minute(time)
+    --out
+
+  :fun twenty_four_hour_time_with_seconds(time Time'box, out String'iso = String.new_iso)
+    out << @hour_24_zero_padded(time)
+    out.push_byte(':')
+    out << @minute(time)
+    out.push_byte(':')
+    out << @second(time)
+    --out
+
+  :fun year(time Time'box, out String'iso = String.new_iso)
+    @pad4(time.year.u64, '0', --out)
+
+  :fun year_modulo_100(time Time'box, out String'iso = String.new_iso)
+    @pad2((time.year % 100).u64, '0', --out)
+
+  :fun year_divided_by_100(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, (time.year / 100).u32)
+
+  :fun full_or_short_year(time Time'box, out String'iso = String.new_iso)
+    @year(time, --out)
+
+  :fun calendar_week_year(time Time'box, out String'iso = String.new_iso)
+    try (
+      calendar_week_0 = time.calendar_week()[0]!
+      out = @pad4(calendar_week_0, '0', --out)
+    )
+    --out
+
+  :fun calendar_week_year_modulo100(time Time'box, out String'iso = String.new_iso)
+    try (
+      calendar_week_0 = time.calendar_week()[0]!
+      out = @pad2(calendar_week_0 % 100, '0', --out)
+    )
+    --out
+
+  :fun month(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.month)
+
+  :fun month_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.month.u64, '0', --out)
+
+  :fun month_blank_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.month.u64, ' ', --out)
+
+  :fun month_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_month_name(time)
+    --out
+
+  :fun month_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // get_month_name.upcase
+    --out
+
+  :fun short_month_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_short_month_name(time)
+    --out
+
+  :fun short_month_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // get_short_month_name.upcase
+    --out
+
+  :fun calendar_week_week(time Time'box, out String'iso = String.new_iso)
+    try (
+      calendar_week_1 = time.calendar_week()[1]!
+      out = @pad2(calendar_week_1, '0', --out)
+    )
+    --out
+
+  :fun day_of_month(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.day)
+
+  :fun day_of_month_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.day.u64, '0', --out)
+
+  :fun day_of_month_blank_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.day.u64, ' ', --out)
+
+  :fun day_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_day_name(time)
+    --out
+
+  :fun day_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // @get_day_name(time).upcase
+    ""
+
+  :fun short_day_name(time Time'box, out String'iso = String.new_iso)
+    out << @get_short_day_name(time)
+    --out
+
+  :fun short_day_name_upcase(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // get_short_day_name.upcase
+    ""
+
+  :fun short_day_name_with_comma(time Time'box, out String'iso = String.new_iso)
+    out << @short_day_name(time)
+    out.push_byte(',')
+    out.push_byte(' ')
+    --out
+
+  :fun day_of_year_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad3(time.day_of_year, '0', --out)
+
+  :fun hour_24_zero_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.hour.u64, '0', --out)
+
+  :fun hour_24_blank_padded(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.hour.u64, ' ', --out)
+
+  :fun hour_12_zero_padded(time Time'box, out String'iso = String.new_iso)
+    h = (time.hour % 12).u64
+    @pad2(if (h == 0) (12 | h), '0', --out)
+
+  :fun hour_12_blank_padded(time Time'box, out String'iso = String.new_iso)
+    h = (time.hour % 12).u64
+    @pad2(if (h == 0) (12 | h), ' ', --out)
+
+  :fun minute(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.minute.u64, '0', --out)
+
+  :fun second(time Time'box, out String'iso = String.new_iso)
+    @pad2(time.second.u64, '0', --out)
+
+  :fun milliseconds(time Time'box, out String'iso = String.new_iso)
+    @pad3((time.nanosecond / 1000000).u64, '0', --out)
+
+  :fun microseconds(time Time'box, out String'iso = String.new_iso)
+    @pad6((time.nanosecond / 1000).u64, '0', --out)
+
+  :fun nanoseconds(time Time'box, out String'iso = String.new_iso)
+    @pad9(time.nanosecond.u64, '0', --out)
+
+  :fun second_fraction(time Time'box, out String'iso = String.new_iso)
+    @nanoseconds(time, --out)
+
+  :fun second_fraction!(
+    time Time'box
+    fraction_digits I32 = 9
+    out String'iso = String.new_iso
+  )
+    case (
+    | fraction_digits == 0 |
+    | fraction_digits == 3 |
+      out.push_byte('.')
+      out = @milliseconds(time, --out)
+    | fraction_digits == 6 |
+      out.push_byte('.')
+      out = @microseconds(time, --out)
+    | fraction_digits == 9 |
+      out.push_byte('.')
+      out = @nanoseconds(time, --out)
+    |
+      error!
+    )
+    --out
+
+  :fun am_pm(time Time'box) String
+    if (time.hour < 12) ("am" | "pm")
+
+  :fun am_pm_upcase(time Time'box) String
+    if (time.hour < 12) ("AM" | "PM")
+
+  :fun day_of_week_monday_1_7(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.day_of_week.u64)
+
+  :fun day_of_week_sunday_0_6(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.day_of_week.u64 % 7)
+
+  :fun unix_seconds(time Time'box, out String'iso = String.new_iso)
+    Inspect.into(--out, time.to_unix)
+
+  :fun time_zone(time Time'box, with_seconds = False, out String'iso = String.new_iso)
+    // TODO
+    // time_zone_offset(format_seconds: with_seconds)
+    --out
+
+  // def time_zone_z_or_offset(**options)
+  //   if time.utc?
+  //     io << 'Z'
+  //   else
+  //     time_zone_offset(**options)
+  //   end
+  // end
+
+  // def time_zone_offset(force_colon = false, allow_colon = true, format_seconds = false, parse_seconds = true)
+  //   time.zone.format(io, with_colon: force_colon, with_seconds: format_seconds)
+  // end
+
+  :fun time_zone_colon(time Time'box, with_seconds = False, out String'iso = String.new_iso)
+    // TODO
+    // time_zone_offset(force_colon: true, format_seconds: with_seconds)
+    --out
+
+  :fun time_zone_colon_with_seconds(time Time'box, out String'iso = String.new_iso)
+    @time_zone_colon(time, True, --out)
+
+  :fun time_zone_gmt(time Time'box, out String'iso = String.new_iso)
+    out << "GMT"
+    --out
+
+  :fun time_zone_rfc2822(time Time'box, out String'iso = String.new_iso)
+    // TODO
+    // time_zone_offset(allow_colon: false)
+    --out
+
+  // def time_zone_gmt_or_rfc2822(**options)
+  //   if time.utc? || time.location.name == "UT" || time.location.name == "GMT"
+  //     time_zone_gmt
+  //   else
+  //     time_zone_rfc2822
+  //   end
+  // end
+
+  :fun get_month_name(time Time'box) String
+    try (@month_names[time.month.usize - 1]! | "")
+
+  :fun get_short_month_name(time Time'box) String
+    @get_month_name(time).substring(0, 3)
+
+  :fun get_day_name(time Time'box) String
+    try (@day_names[time.day_of_week.usize % 7]! | "")
+
+  :fun get_short_day_name(time Time'box) String
+    @get_day_name(time).substring(0, 3)
+
+  :fun pad2(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 10) out.push_byte(padding)
+    Inspect.into(--out, value)
+
+  :fun pad3(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 100) out.push_byte(padding)
+    @pad2(value, padding, --out)
+
+  :fun pad4(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 1000) out.push_byte(padding)
+    @pad3(value, padding, --out)
+
+  :fun pad6(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 100000) out.push_byte(padding)
+    if (value < 10000) out.push_byte(padding)
+    @pad4(value, padding, --out)
+
+  :fun pad9(value U64, padding U8, out String'iso = String.new_iso)
+    if (value < 100000000) out.push_byte(padding)
+    if (value < 10000000) out.push_byte(padding)
+    if (value < 1000000) out.push_byte(padding)
+    @pad6(value, padding, --out)

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Measure.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.Measure.savi
@@ -1,0 +1,149 @@
+:: A collection of functions relating to measuring intervals of time elapsed
+:: during some portion of the program's execution.
+:module Time.Measure
+  :: Measure the interval in nanoseconds that elapse in the given yield block.
+  :fun nanoseconds
+    :yields None for None
+    prior = @current_nanoseconds
+    yield None
+    @current_nanoseconds - prior
+
+  :: Measure the interval in microseconds that elapse in the given yield block.
+  :fun microseconds
+    :yields None for None
+    prior = @current_microseconds
+    yield None
+    @current_microseconds - prior
+
+  :: Measure the interval in milliseconds that elapse in the given yield block.
+  :fun milliseconds
+    :yields None for None
+    prior = @current_milliseconds
+    yield None
+    @current_milliseconds - prior
+
+  :: Get the current monotonic non-adjusted nanosecond count.
+  ::
+  :: This number is not guaranteed to have any particular relationship to the
+  :: current wall clock time - it is more likely to be related to system uptime,
+  :: although there is no particular guarantee of that relationship either.
+  :: For wall clock time, call `Time.now` instead.
+  ::
+  :: Being monotonic and non-adjusted, this is suitable for calculating
+  :: time intervals using subtraction with wrap-around underflow semantics.
+  :: That is, because the underlying count will wrap around on overflow,
+  :: subtraction of two values across time should wrap around on underflow
+  :: to properly account for the case of two values that straddle an overflow.
+  :: See `nanoseconds` function for an example of how to measure time.
+  ::
+  :: This function is intended to be used for asynchronous timing measurements.
+  :: For synchronous timing measurements, use the `nanoseconds` function,
+  :: which handles the timing measurement for you around the given yield block.
+  :fun current_nanoseconds U64
+    case (
+    | Platform.is_windows |
+      0 // TODO: Windows support
+    | Platform.is_macos |
+      // MacOS gives us a count of total uptime "ticks" since the OS booted.
+      // We don't know how long a "tick" is without asking the operating system,
+      // so we ask it for the timebase and multiple/divide to get nanoseconds.
+      timebase = Pair(U32, U32).new(0, 0)
+      timebase_res = _FFI.mach_timebase_info(stack_address_of_variable timebase)
+      return 0 if (timebase_res != 0)
+      _FFI.mach_absolute_time
+      * timebase.first.u64
+      / timebase.last.u64
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair, which we combine. We choose the monotonic clock.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.monotonic
+        stack_address_of_variable pair
+      )
+      pair.first.u64 * 1000000000 + pair.last.u64
+    )
+
+  :: Get the current monotonic non-adjusted microsecond count.
+  ::
+  :: This number is not guaranteed to have any particular relationship to the
+  :: current wall clock time - it is more likely to be related to system uptime,
+  :: although there is no particular guarantee of that relationship either.
+  :: For wall clock time, call `Time.now` instead.
+  ::
+  :: Being monotonic and non-adjusted, this is suitable for calculating
+  :: time intervals using subtraction with wrap-around underflow semantics.
+  :: That is, because the underlying count will wrap around on overflow,
+  :: subtraction of two values across time should wrap around on underflow
+  :: to properly account for the case of two values that straddle an overflow.
+  :: See `microseconds` function for an example of how to measure time.
+  ::
+  :: This function is intended to be used for asynchronous timing measurements.
+  :: For synchronous timing measurements, use the `microseconds` function,
+  :: which handles the timing measurement for you around the given yield block.
+  :fun current_microseconds U64
+    case (
+    | Platform.is_windows |
+      0 // TODO: Windows support
+    | Platform.is_macos |
+      // MacOS gives us a count of total uptime "ticks" since the OS booted.
+      // We don't know how long a "tick" is without asking the operating system,
+      // so we ask it for the timebase and multiple/divide to get microseconds.
+      timebase = Pair(U32, U32).new(0, 0)
+      timebase_res = _FFI.mach_timebase_info(stack_address_of_variable timebase)
+      return 0 if (timebase_res != 0)
+      _FFI.mach_absolute_time
+      * timebase.first.u64
+      / (timebase.last.u64 * 1000)
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair, which we combine. We choose the monotonic clock.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.monotonic
+        stack_address_of_variable pair
+      )
+      pair.first.u64 * 1000000 + pair.last.u64 / 1000
+    )
+
+  :: Get the current monotonic non-adjusted millisecond count.
+  ::
+  :: This number is not guaranteed to have any particular relationship to the
+  :: current wall clock time - it is more likely to be related to system uptime,
+  :: although there is no particular guarantee of that relationship either.
+  :: For wall clock time, call `Time.now` instead.
+  ::
+  :: Being monotonic and non-adjusted, this is suitable for calculating
+  :: time intervals using subtraction with wrap-around underflow semantics.
+  :: That is, because the underlying count will wrap around on overflow,
+  :: subtraction of two values across time should wrap around on underflow
+  :: to properly account for the case of two values that straddle an overflow.
+  :: See `milliseconds` function for an example of how to measure time.
+  ::
+  :: This function is intended to be used for asynchronous timing measurements.
+  :: For synchronous timing measurements, use the `milliseconds` function,
+  :: which handles the timing measurement for you around the given yield block.
+  :fun current_milliseconds U64
+    case (
+    | Platform.is_windows |
+      0 // TODO: Windows support
+    | Platform.is_macos |
+      // MacOS gives us a count of total uptime "ticks" since the OS booted.
+      // We don't know how long a "tick" is without asking the operating system,
+      // so we ask it for the timebase and multiple/divide to get milliseconds.
+      timebase = Pair(U32, U32).new(0, 0)
+      timebase_res = _FFI.mach_timebase_info(stack_address_of_variable timebase)
+      return 0 if (timebase_res != 0)
+      _FFI.mach_absolute_time
+      * timebase.first.u64
+      / (timebase.last.u64 * 1000000)
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair, which we combine. We choose the monotonic clock.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.monotonic
+        stack_address_of_variable pair
+      )
+      pair.first.u64 * 1000 + pair.last.u64 / 1000000
+    )

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
@@ -1,0 +1,414 @@
+:: Represents the amount of time elapsed since the beginning of the Common Era
+:: (`0001-01-01 00:00:00.0`), using the proleptic Gregorian calendar.
+:: Times prior to the beginning of the Common Era are not representable.
+::
+:: The number of seconds is represented with 64-bit integer precision,
+:: with an additional 32-bit integer to specify nanoseconds within the second.
+
+:enum Time.DayOfWeek
+  :member NoDay: 0
+  :member Monday: 1
+  :member Tuesday: 2
+  :member Wednesday: 3
+  :member Thursday: 4
+  :member Friday: 5
+  :member Saturday: 6
+  :member Sunday: 7
+
+  :fun non from_value(value U8)
+    case value == (
+    | 1 | Time.DayOfWeek.Monday
+    | 2 | Time.DayOfWeek.Tuesday
+    | 3 | Time.DayOfWeek.Wednesday
+    | 4 | Time.DayOfWeek.Thursday
+    | 5 | Time.DayOfWeek.Friday
+    | 6 | Time.DayOfWeek.Saturday
+    | 7 | Time.DayOfWeek.Sunday
+    | Time.DayOfWeek.NoDay
+    )
+
+:struct val Time
+  :is Comparable(Time)
+
+  :const _seconds_per_day U64: 86400
+  :const _seconds_per_hour U64: 3600
+  :const _seconds_per_minute U64: 60
+  :const _nanoseconds_per_second U32: 1000000000
+  :const _days_per_400_years U64: 146097
+  :const _days_per_100_years U64: 36524
+  :const _days_per_4_years U64: 1461
+
+  :const _unix_epoch U64: 62135596800
+  :fun non unix_epoch
+    @seconds(@_unix_epoch)
+
+  :: The total number of seconds since `0001-01-01 00:00:00.0` UTC
+  :let total_seconds U64
+  :: The number of nanoseconds of the second
+  :let nanosecond U32
+
+  :: An internal-only direct constructor.
+  :new val _new(@total_seconds, @nanosecond)
+
+  :: The maximum duration representable by this data type.
+  :fun non max_value: @_new(U64.max_value, Time._nanoseconds_per_second - 1)
+
+  :: The minimum duration representable by this data type (a.k.a `zero`).
+  :fun non min_value: @_new(0, 0)
+
+  :: A duration of zero length.
+  :fun non zero: @_new(0, 0)
+
+  :: Represent the moment in time indicated by the given year, month, day,
+  :: and optional hour, minute, second, and nanosecond (in the UTC time zone).
+  :new val utc(
+    year   U32
+    month  U8
+    day    U8
+    hour   U8 = 0
+    minute U8 = 0
+    second U8 = 0
+    @nanosecond = 0
+  )
+    @total_seconds =
+      @_seconds_per_day * @_absolute_days(year, month, day)
+      + @_seconds_per_hour * hour.u64
+      + @_seconds_per_minute * minute.u64
+      + second.u64
+
+  :: Represent a duration of the given number of nanoseconds.
+  :: DEPRECATED: Use `Time.Duration.nanoseconds` instead.
+  :new nanoseconds(n U32):
+    @total_seconds = 0
+    while (@_nanoseconds_per_second < n) (
+      n -= @_nanoseconds_per_second
+      @total_seconds += 1
+    )
+    @nanosecond = n
+
+  :: Represent a duration of the given number of seconds.
+  :: DEPRECATED: Use `Time.Duration.seconds` instead.
+  :new seconds(n): @nanosecond = 0, @total_seconds = n
+
+  :: Represent a duration of the given number of minutes.
+  :: DEPRECATED: Use `Time.Duration.minutes` instead.
+  :new minutes(n): @nanosecond = 0, @total_seconds = @_seconds_per_minute * n
+
+  :: Represent a duration of the given number of hours.
+  :: DEPRECATED: Use `Time.Duration.hours` instead.
+  :new hours(n): @nanosecond = 0, @total_seconds = @_seconds_per_hour * n
+
+  :: Represent a duration of the given number of days.
+  :: DEPRECATED: Use `Time.Duration.days` instead.
+  :new days(n): @nanosecond = 0, @total_seconds = @_seconds_per_day * n
+
+  :: Return True if the given time is exactly equivalent to this one.
+  :fun "=="(other Time'box)
+    @total_seconds == other.total_seconds
+    && @nanosecond == other.nanosecond
+
+  :: Return True if the given time is less than (earlier than) this one.
+  :fun "<"(other Time'box)
+    @total_seconds < other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond < other.nanosecond)
+
+  :: Return True if the given time is greater than (later than) this one.
+  :fun ">"(other Time'box)
+    @total_seconds > other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond > other.nanosecond)
+
+  :: Add the given duration to this time and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use the `+!` method instead.
+  :fun "+"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) + other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Add the given duration to this time and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow semantics are desired, use the `+` method instead.
+  :fun "+!"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) +! other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Subtract the given duration from this time and return the result.
+  ::
+  :: Uses wrap-around underflow semantics if the result is less than `zero`.
+  :: If an error on underflow is desired, use the `-!` method instead.
+  :fun "-"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) - other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Subtract the given duration from this time and return the result.
+  ::
+  :: Raises an error if the result would be less than `zero`.
+  :: If wrap-around underflow semantics is desired, use the `-` method instead.
+  :fun "-!"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) -! other
+    @_new(result.total_seconds, result.nanosecond)
+
+  :: Returns the year (a number greater than or equal to 1).
+  :fun year U32
+    @_year_month_day.bit_and(0xFFFF_FFFF).u32
+
+  :: Returns the month of the year (a number between 1 and 12).
+  :fun month U8
+    (@_year_month_day.bit_shr(32)).bit_and(0xFF).u8
+
+  :: Returns the day of the month (a number between 1 and 31).
+  :fun day U8
+    (@_year_month_day.bit_shr(40)).bit_and(0xFF).u8
+
+  :: Returns the hour of the day (a number between 0 and 23).
+  :fun hour U8
+    ((@total_seconds % @_seconds_per_day) / @_seconds_per_hour).u8
+
+  :: Returns the minute of the hour (a number between 0 and 59).
+  :fun minute U8
+    ((@total_seconds % @_seconds_per_hour) / @_seconds_per_minute).u8
+
+  :: Returns the second of the minute (a number between 0 and 59).
+  :fun second U8
+    (@total_seconds % @_seconds_per_minute).u8
+
+  :: Print the time data for human inspection (the format is subject to change).
+  :fun inspect_into(output String'iso)
+    // TODO: Properly pad numbers with zeros for a constant string width.
+    output = Inspect.into(--output, @year),       output.push_byte('-')
+    output = Inspect.into(--output, @month),      output.push_byte('-')
+    output = Inspect.into(--output, @day),        output.push_byte(' ')
+    output = Inspect.into(--output, @hour),       output.push_byte(':')
+    output = Inspect.into(--output, @minute),     output.push_byte(':')
+    output = Inspect.into(--output, @second),     output.push_byte('\'')
+    output = Inspect.into(--output, @nanosecond)
+    --output
+
+  :: Returns a bit-packed representation of the year, month, and day,
+  :: for internal reuse by other functions that need this information.
+  :fun _year_month_day U64 // TODO: Return tuple instead of packed U64 hack
+    total_days = (@total_seconds / @_seconds_per_day)
+
+    num400 = total_days / @_days_per_400_years
+    total_days -= num400 * @_days_per_400_years
+
+    num100 U64 = total_days / @_days_per_100_years // TODO: shouldn't need an explicit U64 here
+    if (num100 == 4) (num100 = 3) // account for leap years
+    total_days -= num100 * @_days_per_100_years
+
+    num4 = total_days / @_days_per_4_years
+    total_days -= num4 * @_days_per_4_years
+
+    numyears U64 = total_days / 365 // TODO: shouldn't need an explicit U64 here
+    if (numyears == 4) (numyears = 3) // account for leap years
+    total_days -= numyears * 365
+
+    year = (num400 * 400 + num100 * 100 + num4 * 4 + numyears + 1).u32
+
+    month U8 = 0
+    days_in_month U64 = 0
+    while (total_days >= days_in_month) (
+      total_days -= days_in_month
+      month += 1
+      days_in_month = @_days_in_month(month, year).u64
+    )
+
+    day = total_days.u8 + 1
+
+    year.u64
+      .bit_or(month.u64.bit_shl(32))
+      .bit_or(day.u64.bit_shl(40))
+
+  :: Returns True if the given year is a leap year.
+  :fun non _is_leap_year(year U32)
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+
+  :: Returns the number of days in the given month of the given year.
+  :fun non _days_in_month(month U8, year) U8
+    case month == (
+    |  1 | 31 // January
+    |  2 | if @_is_leap_year(year) (29 | 28) // Feb.
+    |  3 | 31 // March
+    |  4 | 30 // April
+    |  5 | 31 // May
+    |  6 | 30 // June
+    |  7 | 31 // July
+    |  8 | 31 // August
+    |  9 | 30 // September
+    | 10 | 31 // October
+    | 11 | 30 // November
+    | 12 | 31 // December
+    | 0 // months that don't exist have zero days
+    )
+
+  :: Returns the number of days from `0001-01-01` to the date indicated
+  :: by the given year, month, and day in the proleptic Gregorian calendar.
+  :fun non _absolute_days(year U32, month U8, day U8) U64
+    // Normalize the month index, treating months beyond 12 as additional years.
+    while (month > 12) (year += 1, month -= 12)
+
+    // Calculate the number of days since day 1 of the given year.
+    days_since_jan_1 = day.u64 - 1
+    scan_month U8 = 1
+    while (scan_month < month) (
+      days_since_jan_1 += @_days_in_month(scan_month, year).u64
+      scan_month += 1
+    )
+
+    // Finally, add in the number of days elapsed in the years already passed.
+    year -= 1
+    year.u64 * 365
+    + year.u64 / 4
+    - year.u64 / 100
+    + year.u64 / 400
+    + days_since_jan_1
+
+  :fun year_month_day_day_year Array(U64)
+    total_days U64 = (@total_seconds / @_seconds_per_day)
+
+    num400 U64 = (total_days / @_days_per_400_years)
+    total_days -= num400 * @_days_per_400_years
+
+    num100 U64 = (total_days / @_days_per_100_years)
+    if (num100 == 4) (// leap
+      num100 = 3
+    )
+    total_days -= num100 * @_days_per_100_years
+
+    num4 U64 = (total_days / @_days_per_4_years)
+    total_days -= num4 * @_days_per_4_years
+
+    numyears = (total_days / 365)
+    if (numyears == 4) (// leap
+      numyears = 3
+    )
+    total_days -= numyears * 365
+
+    year = num400 * 400 + num100 * 100 + num4 * 4 + numyears + 1
+
+    ordinal_day_in_year U64 = total_days + 1
+
+    month U64 = 1
+
+    try (
+      while True (
+        days_in_month = @_days_in_month(month.u8, year.u32).u64
+        if (total_days < days_in_month) (
+          error! // TODO use break
+        )
+
+        total_days -= days_in_month
+        month += 1
+      )
+    )
+
+    day U64 = total_days + 1
+
+    [year, month, day, ordinal_day_in_year]
+
+  :fun calendar_week Array(U64) // TODO USE TUPPLE INSTEAD
+    try (
+      tmp = @year_month_day_day_year
+
+      year = tmp[0]!
+
+      month = tmp[1]!
+      day = tmp[2]!
+      day_year = tmp[3]!
+
+      day_of_week = @day_of_week
+
+      // The week number can be calculated as number of Mondays in the year up to
+      // the ordinal date.
+      // The addition by +10 consists of +7 to start the week numbering with 1
+      // instead of 0 and +3 because the first week has already started in the
+      // previous year and the first Monday is actually in week 2.
+      week_number = ((day_year - day_of_week.u64 + 10) / 7).u64
+
+      if (week_number == 0) (
+        // Week number 0 means the date belongs to the last week of the previous year.
+        year -= 1
+
+        // The week number depends on whether the previous year has 52 or 53 weeks
+        // which can be determined by the day of week of January 1.
+        // The year has 53 weeks if Januar 1 is on a Friday or the year was a leap
+        // year and January 1 is on a Saturday.
+        jan1_day_of_week = Time.DayOfWeek.from_value(((day_of_week.u64 - day_year + 1) % 7).u8)
+
+        if ((jan1_day_of_week == Time.DayOfWeek.Friday) || (jan1_day_of_week == Time.DayOfWeek.Saturday && @_is_leap_year(year.u32))) (
+          week_number = 53
+        |
+          week_number = 52
+        )
+      |
+        if (week_number == 53) (
+          // Week number 53 is actually week number 1 of the following year, if
+          // December 31 is on a Monday, Tuesday or Wednesday.
+          dec31_day_of_week = (day_of_week.u64 + 31 - day) % 7
+
+          if (dec31_day_of_week <= Time.DayOfWeek.Wednesday.u64) (
+            year += 1
+            week_number = 1
+          )
+        )
+      )
+
+      [year, week_number]
+    |
+      // THIS SHOULD BE UNREACHABLE
+      []
+    )
+
+  :fun to_unix I64
+    (@total_seconds - @_unix_epoch).i64
+
+  :fun day_of_year U64
+    try (
+      @year_month_day_day_year[3]!
+    |
+      0
+    )
+
+  :fun day_of_week
+    days U64 = (@total_seconds / @_seconds_per_day)
+    Time.DayOfWeek.from_value((days % 7 + 1).u8)
+
+  :fun to_s
+    @format("%m/%d/%y")
+
+  :fun format(pattern String'box) String'val
+    Time.Formatter.new(pattern).format(@)
+
+  :: Get the current wall-clock adjusted system time (in UTC).
+  ::
+  :: Because this time is not monotonic and gets adjusted to match wall clocks,
+  :: it is not suitable for measuring intervals of time during the program.
+  :: To measure time intervals, use functions of `Time.Measure` instead.
+  :new now
+    case (
+    | Platform.is_windows |
+      // TODO: Windows support
+      @total_seconds = 0
+      @nanosecond = 0
+    | Platform.is_macos |
+      // MacOS gives us the seconds since unix epoch and microseconds as a pair.
+      // We could also get the time zone here, but we don't; we pass null there.
+      macos_pair = Pair(U64, U64).new(0, 0)
+      _FFI.gettimeofday(
+        stack_address_of_variable macos_pair
+        CPointer(Pair(I32, I32)).null
+      )
+      @total_seconds = macos_pair.first + @_unix_epoch
+      @nanosecond = macos_pair.last.u32 * 1000
+    |
+      // Other POSIX platforms give us the seconds since unix epoch and
+      // nanoseconds as a pair. We choose the "real time" clock type.
+      pair = Pair(USize, USize).new(0, 0)
+      _FFI.clock_gettime(
+        _FFI.ClockType.real_time
+        stack_address_of_variable pair
+      )
+      @total_seconds = pair.first.u64 + @_unix_epoch
+      @nanosecond = pair.last.u32
+    )

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/_FFI.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/_FFI.savi
@@ -1,0 +1,23 @@
+:ffimodule _FFI
+  :: C function used to get the current time on MacOS.
+  :fun gettimeofday(
+    time_pair_out CPointer(Pair(U64, U64))
+    time_zone_out CPointer(Pair(I32, I32))
+  ) I32
+
+  :: C function used to get the current time on non-MacOS POSIX platforms.
+  :fun clock_gettime(
+    clock_id U32
+    time_pair_out CPointer(Pair(USize, USize))
+  ) I32
+
+  :: C function used to get the system uptime ticks on MacOS.
+  :fun mach_absolute_time U64
+
+  :: C function used to get the numerator and denominator for ticks on MacOS.
+  :fun mach_timebase_info(info CPointer(Pair(U32, U32))) I32
+
+:: Clock IDs to use when calling `_FFI.clock_gettime`.
+:module _FFI.ClockType
+  :fun real_time U32: 0
+  :fun monotonic U32: if Platform.is_linux (1 | 4)

--- a/spec/language/semantics/enum_spec.savi
+++ b/spec/language/semantics/enum_spec.savi
@@ -10,10 +10,10 @@
     total U64 = 0
 
     test["can declare a member value as an integer"].pass =
-      Integer48.u8 == 48
+      EnumExample.Integer48.u8 == 48
 
     test["can declare a member value as a hexadecimal integer"].pass =
-      Hexadecimal49.u8 == 49
+      EnumExample.Hexadecimal49.u8 == 49
 
     test["can declare a member value as a char literal"].pass =
-      Char50.u8 == 50
+      EnumExample.Char50.u8 == 50

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -428,8 +428,12 @@ module Savi::Program::Intrinsic
     when "type_enum"
       case declarator.name.value
       when "member"
+        name = terms["name"].as(AST::Identifier)
+        name.value = "#{scope.current_type.ident.value}.#{name.value}" \
+          unless terms["noprefix"]?
+
         type_with_value = Program::TypeWithValue.new(
-          terms["name"].as(AST::Identifier),
+          name,
           scope.current_type.make_link(scope.current_package),
         )
 


### PR DESCRIPTION
Now an `:enum My.Example` with `:member Foo` will allow access to that
member via the name `My.Example.Foo` instead of just `Foo`.

That is, the name of the `:enum` type will be automatically used as
a prefix for the name of each `:member`.

---

Note that this change necessitates introducing a patched version
of the `Time` library into our codebase to allow our tests to pass,
because the real `Time` library has not yet been updated to match
these breaking changes.