### PR TITLE
BREAKING CHANGE: Simpler sub-declarations in `:enum` and `:numeric` types.

### DIFF
--- a/core/Bool.savi
+++ b/core/Bool.savi
@@ -1,7 +1,7 @@
 :enum Bool
-  :const bit_width U8: 1
-  :member noprefix False: 0
-  :member noprefix True: 1
+  :bit_width 1
+  :member noprefix False 0
+  :member noprefix True 1
   :fun val is_true: @
   :fun val is_false: @invert
   :fun val not: @invert

--- a/core/Numeric.savi
+++ b/core/Numeric.savi
@@ -498,7 +498,7 @@
   :fun non "[]"(value @'val) @'val: value
 
   :is Numeric.Representable
-  :const bit_width U8: 64
+  :const bit_width U8: 8
   :const is_signed Bool: False
   :const is_floating_point Bool: False
 
@@ -556,19 +556,19 @@
 :: The standard 8-bit unsigned integer numeric type.
 :: This type is often used to represent a byte.
 :numeric U8
-  :const bit_width U8: 8
+  :bit_width 8
 
 :: The standard 16-bit unsigned integer numeric type.
 :numeric U16
-  :const bit_width U8: 16
+  :bit_width 16
 
 :: The standard 32-bit unsigned integer numeric type.
 :numeric U32
-  :const bit_width U8: 32
+  :bit_width 32
 
 :: The standard 64-bit unsigned integer numeric type.
 :numeric U64
-  :const bit_width U8: 64
+  :bit_width 64
 
 :: The standard platform-specific unsigned "size" numeric type.
 :: This type is often used for counting and indexing collections.
@@ -586,27 +586,27 @@
 :: To put it another way, `USize` is equivalent to the `size_t` type in C,
 :: but it is not guaranteed to be equivalent to the `uintptr_t` type in C.
 :numeric USize
-  :const bit_width U8: compiler intrinsic
+  :bit_width of C size_t
 
 :: The standard 8-bit signed integer numeric type.
 :numeric I8
-  :const bit_width U8: 8
-  :const is_signed: True
+  :signed
+  :bit_width 8
 
 :: The standard 16-bit signed integer numeric type.
 :numeric I16
-  :const bit_width U8: 16
-  :const is_signed: True
+  :signed
+  :bit_width 16
 
 :: The standard 32-bit signed integer numeric type.
 :numeric I32
-  :const bit_width U8: 32
-  :const is_signed: True
+  :signed
+  :bit_width 32
 
 :: The standard 64-bit signed integer numeric type.
 :numeric I64
-  :const bit_width U8: 64
-  :const is_signed: True
+  :signed
+  :bit_width 64
 
 :: The standard platform-specific signed "size" numeric type.
 :: This is the signed type corresponding to the unsigned type `USize`.
@@ -624,17 +624,15 @@
 :: To put it another way, `ISize` is equivalent to the `ssize_t` type in C,
 :: but it is not guaranteed to be equivalent to the `intptr_t` type in C.
 :numeric ISize
-  :const bit_width U8: compiler intrinsic
-  :const is_signed: True
+  :signed
+  :bit_width of C size_t
 
 :: The standard 32-bit floating-point numeric type.
 :numeric F32
-  :const bit_width U8: 32
-  :const is_signed: True
-  :const is_floating_point: True
+  :floating_point
+  :bit_width 32
 
 :: The standard 64-bit floating-point numeric type.
 :numeric F64
-  :const bit_width U8: 64
-  :const is_signed: True
-  :const is_floating_point: True
+  :floating_point
+  :bit_width 64

--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -225,6 +225,7 @@
 :declarator numeric
   :intrinsic
   :begins type
+  :begins type_numeric
 
   :term cap enum (iso, val, ref, box, tag, non)
     :default val
@@ -241,6 +242,7 @@
 :declarator enum
   :intrinsic
   :begins type
+  :begins type_numeric
   :begins type_enum
 
   :term cap enum (iso, val, ref, box, tag, non)
@@ -462,6 +464,32 @@
     :optional
 
 // TODO: Document this.
+:declarator signed
+  :intrinsic
+  :context type_numeric
+
+// TODO: Document this.
+:declarator floating_point
+  :intrinsic
+  :context type_numeric
+
+// TODO: Document this.
+:declarator bit_width
+  :intrinsic
+  :context type_numeric
+
+  :term value Integer
+
+// TODO: Document this.
+:declarator bit_width
+  :intrinsic
+  :context type_numeric
+
+  :keyword of
+  :keyword C
+  :term c_type enum (size_t) // TODO: Add other supported C types
+
+// TODO: Document this.
 :declarator member
   :intrinsic
   :context type_enum
@@ -469,7 +497,7 @@
   :term noprefix enum (noprefix)
     :optional
   :term name Name
-  :body required
+  :term value Integer
 
 // TODO: Document this.
 :declarator manifest

--- a/core/declarators/meta/meta_declarators.savi
+++ b/core/declarators/meta/meta_declarators.savi
@@ -185,6 +185,7 @@
   :term type enum (
     Term     :: any possible declaration term
     String   :: a string literal
+    Integer  :: an integer literal
     Name     :: an identifier or string literal, coerced into an identifier
     Type     :: an algebraic type expression
     NameList :: a parenthesized group of Name terms

--- a/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
+++ b/examples/adventofcode/2018/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
@@ -6,14 +6,14 @@
 :: with an additional 32-bit integer to specify nanoseconds within the second.
 
 :enum Time.DayOfWeek
-  :member NoDay: 0
-  :member Monday: 1
-  :member Tuesday: 2
-  :member Wednesday: 3
-  :member Thursday: 4
-  :member Friday: 5
-  :member Saturday: 6
-  :member Sunday: 7
+  :member NoDay 0
+  :member Monday 1
+  :member Tuesday 2
+  :member Wednesday 3
+  :member Thursday 4
+  :member Friday 5
+  :member Saturday 6
+  :member Sunday 7
 
   :fun non from_value(value U8)
     case value == (

--- a/examples/adventofcode/2018/src/day_4.savi
+++ b/examples/adventofcode/2018/src/day_4.savi
@@ -1,8 +1,7 @@
 :enum Day4Event
-  :const bit_width U8: 8 // TODO infer this from the number of members instead
-  :member Begin: 0
-  :member Sleep: 1
-  :member Awake: 2
+  :member Begin 0
+  :member Sleep 1
+  :member Awake 2
 
 :class Day4Entry
   :var guard String

--- a/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
+++ b/spec/core/deps/github:savi-lang/Time/v0.20220321.0.999/src/Time.savi
@@ -6,14 +6,14 @@
 :: with an additional 32-bit integer to specify nanoseconds within the second.
 
 :enum Time.DayOfWeek
-  :member NoDay: 0
-  :member Monday: 1
-  :member Tuesday: 2
-  :member Wednesday: 3
-  :member Thursday: 4
-  :member Friday: 5
-  :member Saturday: 6
-  :member Sunday: 7
+  :member NoDay 0
+  :member Monday 1
+  :member Tuesday 2
+  :member Wednesday 3
+  :member Thursday 4
+  :member Friday 5
+  :member Saturday 6
+  :member Sunday 7
 
   :fun non from_value(value U8)
     case value == (

--- a/spec/language/semantics/enum_spec.savi
+++ b/spec/language/semantics/enum_spec.savi
@@ -1,8 +1,7 @@
 :enum EnumExample
-  :const bit_width U8: 8
-  :member Integer48: 48
-  :member Hexadecimal49: 0x31
-  :member Char50: '2'
+  :member Integer48 48
+  :member Hexadecimal49 0x31
+  :member Char50 '2'
 
 :module EnumSpec
   :fun run(test MicroTest)

--- a/src/savi/compiler/reach.cr
+++ b/src/savi/compiler/reach.cr
@@ -90,11 +90,11 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
     end
 
     def is_floating_point_numeric?(ctx)
-      is_numeric?(ctx) && single!.defn(ctx).const_bool("is_floating_point")
+      is_numeric?(ctx) && single!.defn(ctx).has_tag?(:numeric_floating_point)
     end
 
     def is_signed_numeric?(ctx)
-      is_numeric?(ctx) && single!.defn(ctx).const_bool("is_signed")
+      is_numeric?(ctx) && single!.defn(ctx).has_tag?(:numeric_signed)
     end
 
     def is_enum?(ctx)
@@ -117,16 +117,16 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
       else
         defn = single!.defn(ctx)
         if defn.has_tag?(:numeric)
-          if defn.ident.value == "USize" || defn.ident.value == "ISize"
-            :isize
-          elsif defn.const_bool("is_floating_point")
-            case defn.const_u64("bit_width")
+          if defn.has_tag?(:numeric_floating_point)
+            case defn.metadata[:numeric_bit_width].as(UInt64)
             when 32 then :f32
             when 64 then :f64
             else raise NotImplementedError.new(defn.inspect)
             end
+          elsif defn.metadata[:numeric_bit_width_of_c_type]?
+            :isize
           else
-            case defn.const_u64("bit_width")
+            case defn.metadata[:numeric_bit_width].as(UInt64)
             when 1 then :i1
             when 8 then :i8
             when 16 then :i16
@@ -507,11 +507,11 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
     end
 
     def is_floating_point_numeric?(ctx)
-      is_numeric?(ctx) && @reified.defn(ctx).const_bool("is_floating_point")
+      is_numeric?(ctx) && @reified.defn(ctx).has_tag?(:numeric_floating_point)
     end
 
     def is_signed_numeric?(ctx)
-      is_numeric?(ctx) && @reified.defn(ctx).const_bool("is_signed")
+      is_numeric?(ctx) && @reified.defn(ctx).has_tag?(:numeric_signed)
     end
 
     def is_enum?(ctx)

--- a/src/savi/compiler/type_check.cr
+++ b/src/savi/compiler/type_check.cr
@@ -735,6 +735,7 @@ class Savi::Compiler::TypeCheck
               # TODO: Remove this hacky special case.
               next if param_mt.show_type.starts_with? "CPointer"
 
+              # TODO: show the cap to let the user know why it's not sendable
               errs << {param.pos,
                 "this parameter type (#{param_mt.show_type}) is not sendable"}
             end

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -209,6 +209,8 @@ class Savi::Program
       :hygienic,
       :ignores_cap,
       :numeric,
+      :numeric_signed,
+      :numeric_floating_point,
       :pass_by_value,
       :no_field_reassign,
       :simple_value,
@@ -317,40 +319,6 @@ class Savi::Program
 
     def is_instantiable?
       has_tag?(:allocated) && is_concrete?
-    end
-
-    def const_u64(name) : UInt64
-      f = find_func!(name)
-      raise "#{ident.value}.#{name} not a constant" unless f.has_tag?(:constant)
-
-      f.body.not_nil!.terms.last.as(AST::LiteralInteger).value.to_u64
-    end
-
-    def const_bool(name) : Bool
-      f = find_func!(name)
-      raise "#{ident.value}.#{name} not a constant" unless f.has_tag?(:constant)
-
-      case f.body.not_nil!.terms.last.as(AST::Identifier).value
-      when "True" then true
-      when "False" then false
-      else raise NotImplementedError.new(f.body.not_nil!.to_a)
-      end
-    end
-
-    def const_u64_eq?(name, value : UInt64) : Bool
-      f = find_func?(name)
-      return false unless f && f.has_tag?(:constant)
-
-      term = f.body.try(&.terms[-1]?)
-      term.is_a?(AST::LiteralInteger) && term.value == value
-    end
-
-    def const_bool_true?(name) : Bool
-      f = find_func?(name)
-      return false unless f && f.has_tag?(:constant)
-
-      term = f.body.try(&.terms[-1]?)
-      term.is_a?(AST::Identifier) && term.value == "True"
     end
 
     def make_link(package : Package)

--- a/src/savi/program/declarator/term_acceptor.cr
+++ b/src/savi/program/declarator/term_acceptor.cr
@@ -67,6 +67,13 @@ abstract class Savi::Program::Declarator::TermAcceptor
         term
       when "String"
         term if term.is_a?(AST::LiteralString)
+      when "Integer"
+        case term
+        when AST::LiteralInteger
+          term
+        when AST::LiteralCharacter
+          AST::LiteralInteger.new(term.value.to_u64).from(term)
+        end
       when "Name"
         case term
         when AST::Identifier
@@ -186,6 +193,8 @@ abstract class Savi::Program::Declarator::TermAcceptor
         "any term"
       when "String"
         "a string literal"
+      when "Integer"
+        "an integer literal"
       when "Name"
         "an identifier or string literal"
       when "Type"


### PR DESCRIPTION
- Use `:bit_width 64` instead of a declaration like `:const bit_width U8: 64`
- Use `:signed` instead of a declaration like `:const is_signed: True`
- Use `:floating_point` instead of a declaration like `:const is_floating_point: True`
- Use `:member Foo 2` in an enum instead of a declaration like `:member Foo: 2`