### PR TITLE
Add support for `relative:../path/to/dep` dependencies.

### DIFF
--- a/src/savi/compiler/manifests.cr
+++ b/src/savi/compiler/manifests.cr
@@ -121,7 +121,11 @@ class Savi::Compiler::Manifests
     end
 
     # Compile all manifests at the path where the dep is to be found.
-    dep_path = ctx.compiler.source_service.find_latest_in_deps(ctx, dep)
+    dep_path = if dep.is_location_relative_path?
+      ctx.compiler.source_service.find_relative_dep(ctx, dep)
+    else
+      ctx.compiler.source_service.find_latest_in_deps(ctx, dep)
+    end
     return unless dep_path
     ctx.compile_manifests_at_path(dep_path)
 

--- a/src/savi/packaging/dependency.cr
+++ b/src/savi/packaging/dependency.cr
@@ -41,6 +41,10 @@ struct Savi::Packaging::Dependency
     location.split(":", 2).last
   end
 
+  def is_location_relative_path?
+    location_scheme == "relative"
+  end
+
   def append_pos
     ast.span_pos(ast.pos.source).next_line_start_as_pos
   end

--- a/src/savi/packaging/remote_service.cr
+++ b/src/savi/packaging/remote_service.cr
@@ -11,6 +11,8 @@ module Savi::Packaging::RemoteService
   def self.update_all(ctx, deps : Array(Dependency), into_dirname : String)
     deps.group_by(&.location_scheme).each { |scheme, scheme_deps|
       case scheme
+      when "relative"
+        # do nothing - expect the directory to be user-provided
       when "github"
         GitHub.update_all(ctx, scheme_deps, into_dirname)
       else


### PR DESCRIPTION
This is primarily expected to be used for libraries that
have an integration test or example to be used with the
current version of the library in a nearby source directory
of the same project's source tree.

It could also be used in complex applications that are divided
into many in-source-tree libraries.