### PR TITLE
Add String interpolation syntax.

### DIFF
--- a/core/String.savi
+++ b/core/String.savi
@@ -45,6 +45,17 @@
   :fun val as_array: Array(U8).val_from_cpointer(@_ptr._unsafe, @_size, @_space)
   :fun val as_bytes: Bytes.from_string(@)
 
+  :fun into_string_space: @space
+
+  :fun into_string(out String'iso) String'iso
+    if (@_size > 0) (
+      new_size = out._size + @_size
+      out.reserve(new_size)
+      out._clone_from(@_ptr._unsafe_val, @_size, out._size)
+      out._size = new_size
+    )
+    --out
+
   :fun "=="(other String'box)
     (@_size == other._size) && (@_ptr._compare(other._ptr, @_size) == 0)
 
@@ -87,8 +98,8 @@
     copy._size = @size
     --copy // TODO: auto-consume at end of the function?
 
-  :fun ref _clone_from(other_ptr CPointer(U8), size USize)
-    other_ptr._unsafe._copy_to(@_ptr, size)
+  :fun ref _clone_from(other_ptr CPointer(U8), size USize, to_offset = 0)
+    other_ptr._unsafe._copy_to(@_ptr._offset(to_offset), size)
 
   :fun includes(other): try (@offset_of!(other), True | False)
 

--- a/spec/language/semantics/string_spec.savi
+++ b/spec/language/semantics/string_spec.savi
@@ -1,0 +1,6 @@
+:module StringSpec
+  :fun run(test MicroTest)
+    bar = "bar"
+
+    test["compose string 1"].pass = "foo \(bar) baz" == "foo bar baz"
+    test["compose string 2"].pass = "\(bar)\(bar)\(bar)" == "barbarbar"

--- a/spec/language/semantics/test.savi
+++ b/spec/language/semantics/test.savi
@@ -22,5 +22,6 @@
     IdentitySpec.run(test)
     TraitNonSpec.run(test)
     EnumSpec.run(test)
+    StringSpec.run(test)
 
     test.print_line_break // TODO: move to MicroTest constructor and finalizer


### PR DESCRIPTION
This commit adds `\(` as a special escape sequence in double-quoted
strings, which begins the interpolation of an arbitrary expression.
The `)` character marks the end of an open interpolation expression.

The final value inside the expression will be copied into the
built string using the `into_string` method, after first calculating
how much space to reserve using the `into_string_space` method.
Both of these methods must be implemented on the type for that value,
or else type-checking will fail.

Resolves #84.