### PR TITLE
Add the `IntoString` trait, for use with string interpolation.

### DIFF
--- a/core/IntoString.savi
+++ b/core/IntoString.savi
@@ -1,0 +1,17 @@
+:: A trait for emitting a representation of the value into a given `String`.
+::
+:: These methods are used by string interpolation syntax, so ensuring that
+:: a type implements this trait will make it directly usable in interpolation.
+:trait box IntoString
+  :: Emit a representation of this value into the given String, preserving
+  :: its isolation and returning the String with the new content appended.
+  :fun box into_string(out String'iso) String'iso
+
+  :: Return a conservative estimate for how much many bytes are required to hold
+  :: the string representation of this value when emitted with `into_string`.
+  ::
+  :: Here, "conservative estimate" means that if a perfectly accurate estimate
+  :: is not possible, the function should prefer to over-estimate the amount
+  :: of space needed, because an under-estimation would result in a potentially
+  :: costly re-allocation and copy of data in the underlying string buffer.
+  :fun box into_string_space USize

--- a/core/String.savi
+++ b/core/String.savi
@@ -1,5 +1,6 @@
 :class val String
   :is Comparable(String'box)
+  :is IntoString
 
   :var _size USize
   :var _space USize


### PR DESCRIPTION
`IntoString` is a new trait in the core Savi library,
for emitting a representation of the value into a given `String`.

These methods are used by string interpolation syntax, so ensuring that
a type implements this trait will make it directly usable in interpolation.