### PR TITLE
Implement `IntoString` for all `:numeric` types.

### DIFF
--- a/core/FloatingPoint.savi
+++ b/core/FloatingPoint.savi
@@ -87,8 +87,18 @@
 :: This trait isn't meant to be used externally. It's just a base implementation
 :: of methods to be copied into every new floating-point 32-bit `:numeric` type.
 :trait val FloatingPoint.BaseImplementation32 // TODO: don't use :trait for this... `common`?
+  :: An internal method for converting a `box` number value to a `val` one.
+  :: This is sometimes needed for `:fun box` uses of `val` methods.
+  :: It is safe because no builtin numeric type can have interior mutability.
+  :: TODO: Remove this hack in favor of a more generalized mechanism
+  :: for marking types which have no possibility of interior mutability,
+  :: allowing them to treat any `box` reference as a `val` reference.
+  :fun as_val @'val: compiler intrinsic
+
   :fun non from_bits(bits U32) @'val: compiler intrinsic
   :fun val bits U32: compiler intrinsic
+
+  :is Numeric.Convertible
 
   :is FloatingPoint.Representable
   :fun non exp_bit_width U8: 8
@@ -121,11 +131,25 @@
   :fun val is_finite
     @bits.bit_and(0x7F80_0000) != 0x7F80_0000 // exponent
 
+  :is IntoString
+  :fun into_string_space: @f64.into_string_space
+  :fun into_string(out String'iso): @f64.into_string(--out) // TODO: 32-bit impl
+
 :: This trait isn't meant to be used externally. It's just a base implementation
 :: of methods to be copied into every new floating-point 64-bit `:numeric` type.
 :trait val FloatingPoint.BaseImplementation64 // TODO: don't use :trait for this... `common`?
+  :: An internal method for converting a `box` number value to a `val` one.
+  :: This is sometimes needed for `:fun box` uses of `val` methods.
+  :: It is safe because no builtin numeric type can have interior mutability.
+  :: TODO: Remove this hack in favor of a more generalized mechanism
+  :: for marking types which have no possibility of interior mutability,
+  :: allowing them to treat any `box` reference as a `val` reference.
+  :fun as_val @'val: compiler intrinsic
+
   :fun non from_bits(bits U64) @'val: compiler intrinsic
   :fun val bits U64: compiler intrinsic
+
+  :is Numeric.Convertible
 
   :is FloatingPoint.Representable
   :fun non exp_bit_width U8: 11
@@ -157,3 +181,46 @@
     @bits.bit_and(0x000F_FFFF_FFFF_FFFF) == 0                        // mantissa
   :fun val is_finite
     @bits.bit_and(0x7FF0_0000_0000_0000) != 0x7FF0_0000_0000_0000 // exponent
+
+  :is IntoString
+  :fun into_string_space USize: 14 // (max size of the below logic)
+  :fun into_string(out String'iso) String'iso
+    value = @as_val
+    case (
+    | value == @zero |
+      out << "0.0"
+    | value.is_finite |
+      // If the value is negative, begin with a negative symbol character.
+      // Then from here on we will work only with the absolute value.
+      if (value < @zero) out.push_byte('-')
+      value = value.abs
+
+      // TODO: Avoid this hacky workaround for lack of numeric literals here.
+      ten = @one + @one + @one + @one + @one + @one + @one + @one + @one + @one
+      million = ten * ten * ten * ten * ten * ten
+      hundredth = @one / ten / ten
+
+      // Decide which representation to use based on the magnitude of the
+      // value, limiting the left side of the decimal point so that it will
+      // have no more than 6 digits, and keeping the right side of the decimal
+      // (which is limited to 6 digits) having at least 5 significant digits.
+      use_scientific = value >= million || value < hundredth
+
+      // Cheat and use `snprintf` to print the value into the output string.
+      // TODO: use grisu3 algorithm like Crystal does, for better performance
+      // for those numbers that the algorithm handles, using this as a fallback:
+      out.reserve(out.size + @into_string_space)
+      out_offset_cpointer = out.cpointer._unsafe._offset(out.size)
+      buffer = _FFI.snprintf(
+        out_offset_cpointer
+        @into_string_space.i32
+        if use_scientific ("%.6e".cstring | "%.12g".cstring)
+        value
+      )
+      out._size += _FFI.strlen(out_offset_cpointer).usize
+    | value.is_infinite |
+      out << if (value > @zero) ("Infinity" | "-Infinity")
+    |
+      out << "NaN"
+    )
+    --out

--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -3,9 +3,6 @@
   :fun size USize
   :fun "[]!"(index USize) Any'box // TODO: use `box` instead of `Any'box`
 
-:trait box _InspectEnum
-  :fun member_name String
-
 :trait box _InspectCustom
   :fun inspect_into(output String'iso) String'iso
 
@@ -21,31 +18,6 @@
   :fun into(output String'iso, input Any'box) String'iso // TODO: use `box` instead of `Any'box` // TODO: use something like Crystal IO instead of String?
     case input <: (
     | _InspectCustom | input.inspect_into(--output)
-    | _InspectEnum | output << input.member_name, --output
-    | U8'box    | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | U16'box   | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | U32'box   | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | USize'box | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | U64'box   |                            // TODO: unify into one integer clause?
-      u64 = input.u64
-      digits Array(U8) = []
-      while (u64 > 0) (
-        digits << (u64 % 10).u8 + '0'
-        u64 = u64 / 10
-      )
-      digits.reverse_each -> (digit | output.push_byte(digit), None) // TODO: None should not be needed here
-      if (digits.size == 0) output.push_byte('0')
-      --output
-    | I8'box    | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | I16'box   | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | I32'box   | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | ISize'box | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | I64'box   |                            // TODO: unify into one integer clause?
-      i64 = input.i64
-      positive = if (i64 >= 0) (i64 | output.push_byte('-'), i64.abs)
-      @into(--output, positive.u64)
-    | F32'box | @_inspect_float_into(--output, input.f64) // TODO: unify into one float clause?
-    | F64'box | @_inspect_float_into(--output, input.f64) // TODO: unify into one float clause?
     | String'box |
       output.push_byte('"')
       output << input.clone // TODO: show some characters as escaped.
@@ -80,7 +52,10 @@
       )
       output.push_byte(']')
       --output
-    // TODO: support inspection of more types
+    | IntoString |
+      // If there's nothing more specific, then our last option is to print
+      // the same representation that `into_string` gives for that value.
+      input.into_string(--output)
     |
       // Otherwise, fall back to just printing the name of the type.
       output << reflection_of_runtime_type_name input
@@ -101,33 +76,3 @@
       out.push_byte(digit + 'A' - 0xA)
     )
     --out
-
-  :fun non _inspect_float_into(out String'iso, value F64) String'iso
-    if (value < 0) (
-      out.push_byte('-')
-      value = value.negate
-    )
-    case (
-    | value == 0 | out << "0.0"
-    | value.is_finite | out = @_inspect_finite_positive_float_into(--out, value)
-    | value.is_infinite | out << "Infinity"
-    | out << "NaN"
-    )
-    --out
-
-  :const _inspect_float_buffer_size USize: 128
-
-  :fun non _inspect_finite_positive_float_into(out String'iso, value F64) String'iso
-    // TODO: use grisu3 algorithm like Crystal does, for better performance
-    // for those numbers that the algorithm handles, using this as a fallback:
-    out.reserve(out.size + @_inspect_float_buffer_size)
-    out_offset_cpointer = out.cpointer._unsafe._offset(out.size)
-    buffer = _FFI.snprintf(
-      out_offset_cpointer
-      @_inspect_float_buffer_size.i32
-      "%.17g".cstring
-      value
-    )
-    out._size += _FFI.strlen(out_offset_cpointer).usize
-    --out
-

--- a/core/Integer.savi
+++ b/core/Integer.savi
@@ -225,6 +225,14 @@
 :: This trait isn't meant to be used externally. It's just a base implementation
 :: of methods to be copied into every new integer `:numeric` type.
 :trait val Integer.BaseImplementation // TODO: don't use :trait for this... `common`?
+  :: An internal method for converting a `box` number value to a `val` one.
+  :: This is sometimes needed for `:fun box` uses of `val` methods.
+  :: It is safe because no builtin numeric type can have interior mutability.
+  :: TODO: Remove this hack in favor of a more generalized mechanism
+  :: for marking types which have no possibility of interior mutability,
+  :: allowing them to treat any `box` reference as a `val` reference.
+  :fun as_val @'val: compiler intrinsic
+
   :is Integer.Representable
   :fun non mag_bit_width U8
     if @is_signed (@bit_width - 1 | @bit_width)
@@ -286,6 +294,62 @@
     )
     @
 
+  :is IntoString
+
+  :fun into_string(out String'iso) String'iso
+    // Fast path for zero - it always has exactly one digit.
+    if (@ == @zero) (
+      out.push_byte('0')
+      return --out
+    )
+
+    // If the value is less than zero, we need to negate it to make it positive
+    // before we try to append its representation into the given string,
+    // and we'll append a negative sign byte first.
+    value = @as_val
+    if (@ < @zero) (
+      value = @zero - value
+      out.push_byte('-')
+    )
+
+    // TODO: Avoid this hacky workaround for lack of numeric literals here.
+    ten = @one + @one + @one + @one + @one + @one + @one + @one + @one + @one
+
+    // Collect the digits we need to print, from least to most significant.
+    // TODO: Avoid this temporary array allocation here.
+    digits Array(U8) = []
+    while (value > @zero) (
+      digits << (value % ten).u8 + '0'
+      value = value / ten
+    )
+
+    // Print each digit in the expected order (from most to least significant).
+    // Then return the output string now that we are done.
+    digits.reverse_each -> (digit | out.push_byte(digit))
+    --out
+
+  :fun into_string_space USize
+    // Fast path for zero - it always has exactly one digit.
+    return 1 if (@ == @zero)
+
+    // If the value is less than zero, we need to negate it to make it positive
+    // before we try to count the number of its significant bits.
+    value = @as_val
+    if (@ < @zero) (value = @zero - value)
+
+    // Count the number of significant bits, add 3, and multiply by (5 / 16),
+    // which is a rough heuristic arithmetic expression that conservatively
+    // estimates the number of decimal digits needed to print the number,
+    // while avoiding an actual division operation by using a bit shift
+    // (which is possible because the denominator is a power of 2).
+    bits = @bit_width - value.leading_zero_bits
+    digits = ((bits + 3).usize * 5).bit_shr(4) + 1
+
+    // The number of bytes we need available to print the number is the
+    // same as the number of digits, with an added byte for the negative sign
+    // in the case that the number is a negative one.
+    if (@ < @zero) (digits + 1 | digits)
+
   // TODO: explicit conformance to a particular trait for `hash`
   :fun hash USize
     if (USize.bit_width == 32) (
@@ -312,3 +376,14 @@
     x = x.bit_xor(x.bit_shr(28))
     x = x + x.bit_shl(31)
     x
+
+:: This trait isn't meant to be used externally. It's just a base implementation
+:: of methods to be copied into every new integer `:enum` type.
+:trait val Integer.BaseImplementation.Enum // TODO: don't use :trait for this... `common`?
+  :copies Integer.BaseImplementation
+
+  :fun member_name String
+
+  :is IntoString
+  :fun into_string(out String'iso): @member_name.into_string(--out)
+  :fun into_string_space: @member_name.into_string_space

--- a/spec/core/Inspect.Spec.savi
+++ b/spec/core/Inspect.Spec.savi
@@ -33,6 +33,8 @@
     assert: Inspect[F32[-0.0625]]     == "-0.0625"
     assert: Inspect[F64[0]]           == "0.0"
     assert: Inspect[F32[0]]           == "0.0"
+    assert: Inspect[F64[36.5]]        == "36.5"
+    assert: Inspect[F32[36.5]]        == "36.5"
     assert: Inspect[F64.infinity]     == "Infinity"
     assert: Inspect[F32.infinity]     == "Infinity"
     assert: Inspect[F64.neg_infinity] == "-Infinity"

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -558,3 +558,21 @@
       assert: u64.be_to_native == u64
       assert: u64.le_to_native == u64_swapped
     )
+
+  :it "prints the decimal digits of the number value into a string"
+    assert: "\(0)" == "0"
+    assert: "\(36)" == "36"
+    assert: "\(-36)" == "-36"
+    assert: "\(9999)" == "9999"
+    assert: "\(-9999)" == "-9999"
+    assert: "\(0.0)" == "0.0"
+    assert: "\(333333.33333333)" == "333333.333333"
+    assert: "\(-5.5555546e-123)" == "-5.555555e-123"
+
+  :it "never under-estimates the amount of space to emit a U64 into a string"
+    value = U64.max_value
+    while (value > 0) (
+      value = value.bit_shr(1)
+      assert: value.into_string_space >= "\(value)".size
+    )
+    assert: U64[0].into_string_space == 1

--- a/spec/language/semantics/enum_spec.savi
+++ b/spec/language/semantics/enum_spec.savi
@@ -16,3 +16,7 @@
 
     test["can declare a member value as a char literal"].pass =
       EnumExample.Char50.u8 == 50
+
+    test.env.out.print("EnumExample.Integer48: \(EnumExample.Integer48)")
+    test["can interpolate into a string with the member name"].pass =
+      "\(EnumExample.Integer48)" == "EnumExample.Integer48"

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1029,6 +1029,8 @@ class Savi::Compiler::CodeGen
     already_returned = false # set to true if the intrinsic does a return in it
     return_value =
       case gfunc.func.ident.value
+      when "as_val"
+        params[0]
       when "bit_width"
         @i8.const_int(
           abi_size_of(llvm_type_of(gtype)) * 8
@@ -2624,6 +2626,7 @@ class Savi::Compiler::CodeGen
   end
 
   def bit_width_of(llvm_type : LLVM::Type)
+    return 1 if llvm_type == @i1
     abi_size_of(llvm_type) * 8
   end
 

--- a/src/savi/compiler/populate.cr
+++ b/src/savi/compiler/populate.cr
@@ -29,7 +29,7 @@ class Savi::Compiler::Populate
       dest = t
       dest_link = dest.make_link(package)
       orig_functions = dest.functions
-      copy_sources.each do |source_defn, visitor|
+      copy_sources.reverse_each do |source_defn, visitor|
         new_functions = copy_from(ctx, source_defn, dest)
         if new_functions.any?
           if dest.functions.same?(orig_functions)

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -666,12 +666,16 @@ module Savi::Program::Intrinsic
 
     # Also copy the base implementation for this specific flavor of numeric.
     copy2_name =
-      if !type.has_tag?(:numeric_floating_point)
-        "Integer.BaseImplementation"
-      elsif scope.current_type.metadata[:numeric_bit_width]? == 32
-        "FloatingPoint.BaseImplementation32"
+      if type.has_tag?(:numeric_floating_point)
+        if scope.current_type.metadata[:numeric_bit_width]? == 32
+          "FloatingPoint.BaseImplementation32"
+        else
+          "FloatingPoint.BaseImplementation64"
+        end
+      elsif type.has_tag?(:enum)
+        "Integer.BaseImplementation.Enum"
       else
-        "FloatingPoint.BaseImplementation64"
+        "Integer.BaseImplementation"
       end
     copy2_cap = AST::Identifier.new("non").from(type.ident)
     copy2_is = AST::Identifier.new("copies").from(type.ident)


### PR DESCRIPTION
This allows numeric types to be used in string interpolations.