### PR TITLE
Add `Integer.format` method with decimal and hexadecimal options.

### DIFF
--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -28,13 +28,13 @@
       output.push_byte('"')
       input.each -> (byte |
         case (
-        | byte >= 0x7F | output = @_inspect_hex_byte_escape_into(--output, byte)
+        | byte >= 0x7F | output = byte.format.hex.with_prefix("\\x").into_string(--output)
         | byte == '"'  | output.push_byte('\\').push_byte('"')
         | byte >= 0x20 | output.push_byte(byte)
         | byte == '\n' | output.push_byte('\\').push_byte('n')
         | byte == '\r' | output.push_byte('\\').push_byte('r')
         | byte == '\t' | output.push_byte('\\').push_byte('t')
-        |                output = @_inspect_hex_byte_escape_into(--output, byte)
+        |                output = byte.format.hex.with_prefix("\\x").into_string(--output)
         )
       )
       output.push_byte('"')
@@ -61,18 +61,3 @@
       output << reflection_of_runtime_type_name input
       --output
     )
-
-  :fun non _inspect_hex_byte_escape_into(out String'iso, byte U8)
-    out.push_byte('\\')
-    out.push_byte('x')
-    out = @_inspect_hex_digit_into(--out, byte.bit_shr(4))
-    out = @_inspect_hex_digit_into(--out, byte.bit_and(0xF))
-    --out
-
-  :fun non _inspect_hex_digit_into(out String'iso, digit U8)
-    if (digit <= 9) (
-      out.push_byte(digit + '0')
-    |
-      out.push_byte(digit + 'A' - 0xA)
-    )
-    --out

--- a/core/Integer.Format.savi
+++ b/core/Integer.Format.savi
@@ -1,0 +1,142 @@
+:: Format the given integer value using one of the available format types.
+:: Call one of the methods of this struct to choose which format type to use.
+:struct val Integer.Format(T Integer(T)'val)
+  :let _value T
+  :new val _new(@_value)
+
+  :fun decimal: Integer.Format.Decimal(T)._new(@_value)
+  :fun hexadecimal: Integer.Format.Hexadecimal(T)._new(@_value)
+
+  :fun dec: @decimal
+  :fun hex: @hexadecimal
+
+:: Format the given integer into a variable number of decimal digits.
+:struct val Integer.Format.Decimal(T Integer(T)'val)
+  :is IntoString
+
+  :let _value T
+  :new val _new(@_value)
+
+  :fun into_string(out String'iso) String'iso
+    value = @_value
+
+    // TODO: Avoid this hacky workaround for lack of numeric literals here.
+    zero = value.zero
+    one = value.one
+    ten = one + one + one + one + one + one + one + one + one + one
+
+    // Fast path for zero - it always has exactly one digit.
+    if (value == zero) (
+      out.push_byte('0')
+      return --out
+    )
+
+    // If the value is less than zero, we need to negate it to make it positive
+    // before we try to append its representation into the given string,
+    // and we'll append a negative sign byte first.
+    if (value < zero) (
+      value = zero - value
+      out.push_byte('-')
+    )
+
+    // Collect the digits we need to print, from least to most significant.
+    // TODO: Avoid this temporary array allocation here.
+    digits Array(U8) = []
+    while (value > zero) (
+      digits << (value % ten).u8 + '0'
+      value = value / ten
+    )
+
+    // Print each digit in the expected order (from most to least significant).
+    // Then return the output string now that we are done.
+    digits.reverse_each -> (digit | out.push_byte(digit))
+    --out
+
+  :fun into_string_space USize
+    orig_value = value = @_value
+
+    // TODO: Avoid this hacky workaround for lack of numeric literals here.
+    zero = value.zero
+
+    // Fast path for zero - it always has exactly one digit.
+    return 1 if (value == zero)
+
+    // If the value is less than zero, we need to negate it to make it positive
+    // before we try to count the number of its significant bits.
+    if (value < zero) (value = zero - value)
+
+    // Count the number of significant bits, add 3, and multiply by (5 / 16),
+    // which is a rough heuristic arithmetic expression that conservatively
+    // estimates the number of decimal digits needed to print the number,
+    // while avoiding an actual division operation by using a bit shift
+    // (which is possible because the denominator is a power of 2).
+    bits = value.bit_width - value.leading_zero_bits
+    digits = ((bits + 3).usize * 5).bit_shr(4) + 1
+
+    // The number of bytes we need available to print the number is the
+    // same as the number of digits, with an added byte for the negative sign
+    // in the case that the number is a negative one.
+    if (orig_value < zero) (digits + 1 | digits)
+
+:: Format the given integer into a fixed width hexadecimal representation.
+::
+:: By default the digits are shown with a "0x" prefix, but this is adjustable.
+:struct val Integer.Format.Hexadecimal(T Integer(T)'val)
+  :is IntoString
+
+  :let _value T
+  :let _prefix String
+  :new val _new(@_value, @_prefix = "0x")
+
+  :: Format without the standard "0x" hexadecimal prefix.
+  :fun bare: @_new(@_value, "")
+
+  :: Use the given prefix instead of the standard "0x" hexadecimal prefix.
+  :fun with_prefix(prefix): @_new(@_value, prefix)
+
+  :fun into_string_space USize
+    @_prefix.size + if (T.bit_width == 1) (1 | T.bit_width.usize / 4)
+
+  :fun into_string(out String'iso) String'iso
+    out << @_prefix
+    case T.bit_width == (
+    | 1 |
+      out.push_byte(@_digit(@_value.u8))
+    | 8 |
+      out.push_byte(@_digit(@_value.bit_shr(4).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.u8.bit_and(0xF)))
+    | 16 |
+      out.push_byte(@_digit(@_value.bit_shr(12).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(8).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(4).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.u8.bit_and(0xF)))
+    | 32 |
+      out.push_byte(@_digit(@_value.bit_shr(28).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(24).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(20).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(16).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(12).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(8).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(4).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.u8.bit_and(0xF)))
+    | 64 |
+      out.push_byte(@_digit(@_value.bit_shr(60).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(56).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(52).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(48).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(44).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(40).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(36).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(32).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(28).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(24).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(20).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(16).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(12).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(8).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.bit_shr(4).u8.bit_and(0xF)))
+      out.push_byte(@_digit(@_value.u8.bit_and(0xF)))
+    )
+    --out
+
+  :fun non _digit(u4 U8): if (u4 <= 9) (u4 + '0' | u4 + 'A' - 0xA)

--- a/core/Integer.savi
+++ b/core/Integer.savi
@@ -382,6 +382,10 @@
 :trait val Integer.BaseImplementation.Enum // TODO: don't use :trait for this... `common`?
   :copies Integer.BaseImplementation
 
+  :const bit_width U8: 8
+  :const byte_width U8: compiler intrinsic
+
+  :fun non from_u64!(value U64) @'val
   :fun member_name String
 
   :is IntoString

--- a/core/Integer.savi
+++ b/core/Integer.savi
@@ -10,6 +10,7 @@
   :is Integer.WideArithmetic(T)
   :is Integer.BitwiseArithmetic(T)
   :is Integer.Countable(T)
+  :is Integer.Formattable(T)
 
 :: A type which conveys information about the machine-level representation
 :: of an integer numeric type, including the standard information about
@@ -222,6 +223,16 @@
   :fun val times T
     :yields T for None
 
+:: A type which can be formatted as the given integer type T.
+:trait val Integer.Formattable(T Integer(T)'val)
+  :fun as_val T
+
+  :fun format: Integer.Format(T)._new(@as_val)
+
+  :is IntoString
+  :fun into_string(out String'iso): @format.decimal.into_string(--out)
+  :fun into_string_space: @format.decimal.into_string_space
+
 :: This trait isn't meant to be used externally. It's just a base implementation
 :: of methods to be copied into every new integer `:numeric` type.
 :trait val Integer.BaseImplementation // TODO: don't use :trait for this... `common`?
@@ -294,61 +305,7 @@
     )
     @
 
-  :is IntoString
-
-  :fun into_string(out String'iso) String'iso
-    // Fast path for zero - it always has exactly one digit.
-    if (@ == @zero) (
-      out.push_byte('0')
-      return --out
-    )
-
-    // If the value is less than zero, we need to negate it to make it positive
-    // before we try to append its representation into the given string,
-    // and we'll append a negative sign byte first.
-    value = @as_val
-    if (@ < @zero) (
-      value = @zero - value
-      out.push_byte('-')
-    )
-
-    // TODO: Avoid this hacky workaround for lack of numeric literals here.
-    ten = @one + @one + @one + @one + @one + @one + @one + @one + @one + @one
-
-    // Collect the digits we need to print, from least to most significant.
-    // TODO: Avoid this temporary array allocation here.
-    digits Array(U8) = []
-    while (value > @zero) (
-      digits << (value % ten).u8 + '0'
-      value = value / ten
-    )
-
-    // Print each digit in the expected order (from most to least significant).
-    // Then return the output string now that we are done.
-    digits.reverse_each -> (digit | out.push_byte(digit))
-    --out
-
-  :fun into_string_space USize
-    // Fast path for zero - it always has exactly one digit.
-    return 1 if (@ == @zero)
-
-    // If the value is less than zero, we need to negate it to make it positive
-    // before we try to count the number of its significant bits.
-    value = @as_val
-    if (@ < @zero) (value = @zero - value)
-
-    // Count the number of significant bits, add 3, and multiply by (5 / 16),
-    // which is a rough heuristic arithmetic expression that conservatively
-    // estimates the number of decimal digits needed to print the number,
-    // while avoiding an actual division operation by using a bit shift
-    // (which is possible because the denominator is a power of 2).
-    bits = @bit_width - value.leading_zero_bits
-    digits = ((bits + 3).usize * 5).bit_shr(4) + 1
-
-    // The number of bytes we need available to print the number is the
-    // same as the number of digits, with an added byte for the negative sign
-    // in the case that the number is a negative one.
-    if (@ < @zero) (digits + 1 | digits)
+  :is Integer.Formattable(@'val)
 
   // TODO: explicit conformance to a particular trait for `hash`
   :fun hash USize

--- a/core/Numeric.savi
+++ b/core/Numeric.savi
@@ -45,8 +45,8 @@
   :const bit_width U8
 
   :: The number of bytes that are used to represent values of this numeric type.
-  :: This is derived trivially from the `bit_width` constant.
-  :fun non byte_width: @bit_width / 8
+  :: For types smaller than a byte (like `Bool`), a full byte is pretended.
+  :const byte_width U8
 
   :: When true, values are signed, represented using "two's complement",
   ::

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -576,3 +576,12 @@
       assert: value.into_string_space >= "\(value)".size
     )
     assert: U64[0].into_string_space == 1
+
+  :it "can format integers in a standard hexadecimal representation"
+    assert: "\(False.format.hex)" == "0x0"
+    assert: "\(True.format.hex)"  == "0x1"
+    assert: "\(U8[0].format.hex)" == "0x00"
+    assert: "\(0.format.hex)"     == "0x00000000"
+    assert: "\(36.format.hex)"    == "0x00000024"
+    assert: "\((-36).format.hex)" == "0xFFFFFFDC"
+    assert: "\(U64[0x123456789ABCDEF0].format.hex)" == "0x123456789ABCDEF0"

--- a/spec/language/semantics/enum_spec.savi
+++ b/spec/language/semantics/enum_spec.savi
@@ -17,6 +17,5 @@
     test["can declare a member value as a char literal"].pass =
       EnumExample.Char50.u8 == 50
 
-    test.env.out.print("EnumExample.Integer48: \(EnumExample.Integer48)")
     test["can interpolate into a string with the member name"].pass =
       "\(EnumExample.Integer48)" == "EnumExample.Integer48"

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1265,7 +1265,7 @@ class Savi::Compiler::CodeGen
         @builder.xor(params[0], params[1])
       when "bit_shl"
         raise "bit_shl float" if gtype.type_def.is_floating_point_numeric?(ctx)
-        bits = @builder.zext(params[1], llvm_type_of(gtype))
+        bits = gen_numeric_conv(@gtypes["U8"], gtype, params[1])
         clamp = llvm_type_of(gtype).const_int(bit_width_of(gtype) - 1)
         bits = @builder.select(
           @builder.icmp(LLVM::IntPredicate::ULE, bits, clamp),
@@ -1275,7 +1275,7 @@ class Savi::Compiler::CodeGen
         @builder.shl(params[0], bits)
       when "bit_shr"
         raise "bit_shr float" if gtype.type_def.is_floating_point_numeric?(ctx)
-        bits = @builder.zext(params[1], llvm_type_of(gtype))
+        bits = gen_numeric_conv(@gtypes["U8"], gtype, params[1])
         clamp = llvm_type_of(gtype).const_int(bit_width_of(gtype) - 1)
         bits = @builder.select(
           @builder.icmp(LLVM::IntPredicate::ULE, bits, clamp),

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1035,6 +1035,10 @@ class Savi::Compiler::CodeGen
         @i8.const_int(
           abi_size_of(llvm_type_of(gtype)) * 8
         )
+      when "byte_width"
+        @i8.const_int(
+          abi_size_of(llvm_type_of(gtype))
+        )
       when "zero"
         if gtype.type_def.is_floating_point_numeric?(ctx)
           case bit_width_of(gtype)

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -505,6 +505,22 @@ module Savi::Program::Intrinsic
         else
           raise NotImplementedError.new(declarator.pretty_inspect)
         end
+        either_width_ast = (value_ast || c_type_ast).not_nil!
+        scope.current_type.functions << Program::Function.new(
+          AST::Identifier.new("non").from(declare.terms.first),
+          AST::Identifier.new("byte_width").from(declare.terms.first),
+          nil,
+          AST::Identifier.new("U8").from(declare.terms.first),
+          AST::Group.new(":", [
+            AST::Group.new(" ", [
+              AST::Identifier.new("compiler").from(either_width_ast).as(AST::Node),
+              AST::Identifier.new("intrinsic").from(either_width_ast).as(AST::Node),
+            ]).from(either_width_ast).as(AST::Node)
+          ]).from(either_width_ast)
+        ).tap do |f|
+          f.add_tag(:constant)
+          f.add_tag(:inline)
+        end
       else
         raise NotImplementedError.new(declarator.pretty_inspect)
       end


### PR DESCRIPTION
This sets up the new standard convention for formatting values
in variable ways, compatible with string interpolation.

The new convention is to use a "struct DSL" initiated with a `format`
method, with various DSL methods chained onto it which may create
successive structs after that using values from earlier ones in the chain.

For example, `"example: \(99.format.hex.with_prefix("\\x")"` will
render as `"example: \x63"` after interpolation.

Using named methods instead of terse format specifier symbols (a la `printf`)
fits with Savi's goal of being imminently readable.

Using structs (as opposed to classes) for the DSL avoids heap allocation
(as long as the struct doesn't get subsumed into an abstract type),
which fits with Savi's goal of being very performant.

Any user-defined type can make use of this same convention for formatting
(rather than it being restricted to only certain pre-known formattable types)
which fits with Savi's goal of being simultaneously consistent and open-ended.
