### PR TITLE
Add `None.into_string`, which emits nothing (i.e. an empty string).

### DIFF
--- a/core/None.savi
+++ b/core/None.savi
@@ -1,1 +1,9 @@
 :module None
+  :is IntoString
+  // TODO: These shouldn't need to be `:fun box` - `:fun non` should be okay.
+  :: When emitting into a string, emit nothing (i.e. an empty string).
+  :fun box into_string(out String'iso): --out
+  :fun box into_string_space USize: 0
+
+  :: When inspecting, print explicitly using the name `None`.
+  :fun box inspect_into(out String'iso): out << "None", --out

--- a/spec/core/Inspect.Spec.savi
+++ b/spec/core/Inspect.Spec.savi
@@ -46,7 +46,6 @@
     assert: Inspect[U8[0]] == "0"
 
   :it "inspects a module with its type name"
-    assert: Inspect[None] == "None"
     assert: Inspect[_InspectableTestModule] == "_InspectableTestModule"
 
   :it "inspects strings"

--- a/spec/core/Main.savi
+++ b/spec/core/Main.savi
@@ -8,6 +8,7 @@
       Spec.Run(Savi.CPointer.Spec).new(env)
       Spec.Run(Savi.Indexable.Spec).new(env)
       Spec.Run(Savi.Inspect.Spec).new(env)
+      Spec.Run(Savi.None.Spec).new(env)
       Spec.Run(Savi.Numeric.Spec).new(env)
       Spec.Run(Savi.Platform.Spec).new(env)
       Spec.Run(Savi.String.Spec).new(env)

--- a/spec/core/None.Spec.savi
+++ b/spec/core/None.Spec.savi
@@ -1,0 +1,9 @@
+:class Savi.None.Spec
+  :is Spec
+  :const describes: "None"
+
+  :it "emits nothing into a string"
+    assert: "\(None)" == ""
+
+  :it "inspects as its explicit name"
+    assert: Inspect[None] == "None"

--- a/src/savi/compiler/infer/reified.cr
+++ b/src/savi/compiler/infer/reified.cr
@@ -203,9 +203,9 @@ module Savi::Compiler::Infer
   struct ReifiedFunction
     getter type : ReifiedType
     getter link : Program::Function::Link
-    getter receiver : MetaType
+    getter receiver_cap : MetaType
 
-    def initialize(@type, @link, @receiver)
+    def initialize(@type, @link, @receiver_cap)
     end
 
     def func(ctx)
@@ -226,8 +226,8 @@ module Savi::Compiler::Infer
       @type.show_type + name
     end
 
-    def receiver_cap
-      receiver.cap_only
+    def receiver_mt
+      MetaType.new_nominal(@type).intersect(@receiver_cap)
     end
 
     def meta_type_of(

--- a/src/savi/compiler/subtyping_cache.cr
+++ b/src/savi/compiler/subtyping_cache.cr
@@ -108,7 +108,7 @@ class Savi::Compiler::SubtypingCache
         # Get the MetaType of the asserted supertype trait
         f_link = f.make_link(@this.link)
         pre_infer = ctx.pre_infer[f_link]
-        rf = ReifiedFunction.new(@this, f_link, MetaType.new(@this, Infer::Cap::NON))
+        rf = ReifiedFunction.new(@this, f_link, MetaType.cap(Infer::Cap::NON))
         trait_mt = rf.meta_type_of(ctx, pre_infer[f.ret.not_nil!])
         next unless trait_mt
 
@@ -254,8 +254,8 @@ class Savi::Compiler::SubtypingCache
       raise "found hygienic function" if this_func.has_tag?(:hygienic)
 
       # Get the Infer instance for both this and that function, to compare them.
-      this_rf = ReifiedFunction.new(this, this_func.make_link(this.link), MetaType.new(this, this_cap.value.as(Infer::Cap)))
-      that_rf = ReifiedFunction.new(that, that_func.make_link(that.link), MetaType.new(that, that_cap.value.as(Infer::Cap)))
+      this_rf = ReifiedFunction.new(this, this_func.make_link(this.link), MetaType.cap(this_cap.value.as(Infer::Cap)))
+      that_rf = ReifiedFunction.new(that, that_func.make_link(that.link), MetaType.cap(that_cap.value.as(Infer::Cap)))
       this_infer = ctx.infer[this_func.make_link(this.link)]
       that_infer = ctx.infer[that_func.make_link(that.link)]
 

--- a/src/savi/compiler/type_check.cr
+++ b/src/savi/compiler/type_check.cr
@@ -89,8 +89,7 @@ class Savi::Compiler::TypeCheck
     f : Program::Function::Link,
     cap : MetaType,
   ) : ForReifiedFunc
-    mt = MetaType.new(rt).override_cap(cap)
-    rf = ReifiedFunction.new(rt, f, mt)
+    rf = ReifiedFunction.new(rt, f, cap)
     @map[rf] ||= (
       refer_type = ctx.refer_type[f]
       classify = ctx.classify[f]
@@ -615,8 +614,7 @@ class Savi::Compiler::TypeCheck
 
         # Check if auto-recovery of the receiver is possible.
         if autorecover_needed
-          receiver = MetaType.new(call_defn, reify_cap.cap_only_inner.value.as(Cap))
-          other_rf = ReifiedFunction.new(call_defn, call_func_link, receiver)
+          other_rf = ReifiedFunction.new(call_defn, call_func_link, reify_cap)
           TypeCheck.verify_call_autorecover(ctx, self, info, call_mt)
         end
       end

--- a/src/savi/compiler/type_check.cr
+++ b/src/savi/compiler/type_check.cr
@@ -240,7 +240,7 @@ class Savi::Compiler::TypeCheck
 
     receiver_okay =
       if required_cap.value.is_a?(Cap)
-        call_cap_mt.subtype_of?(ctx, MetaType.new(required_cap))
+        call_mt.subtype_of?(ctx, MetaType.new(required_cap))
       else
         call_cap_mt.satisfies_bound?(ctx, MetaType.new(required_cap))
       end


### PR DESCRIPTION
This will be used in string interpolation for cases where the interpolated expression has a type of `(SomeType | None)` - the interpolation will either be the representation of `SomeType` or it will come out empty, indicating `None`.