### PR TITLE
Deprecate `CPointer.usize` in favor of `CPointer.address`.

### DIFF
--- a/core/BitArray.savi
+++ b/core/BitArray.savi
@@ -85,7 +85,7 @@
     other_ptr._unsafe._copy_to(@_ptr, size)
 
   :fun val as_bytes
-    ptr = CPointer(U8).from_usize(@_ptr.usize)
+    ptr = CPointer(U8).from_address(@_ptr.address)
     Bytes.val_from_cpointer(ptr._unsafe, @_u8_space, @_u8_space)
 
   :fun val as_native_u64_array

--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -457,7 +457,7 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U16.
   :fun read_native_u16!(offset USize) U16
     if ((offset + U16.byte_width.usize) > @_size) error!
-    CPointer(U16).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
+    CPointer(U16).from_address(@_ptr._offset(offset).address)._unsafe._get_at(0)
 
   :: Write a U16 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -465,7 +465,7 @@
   :: Use push_native_u16 instead if writing past the end is needed.
   :fun ref write_native_u16!(offset USize, number U16)
     if ((offset + U16.byte_width.usize) > @_size) error!
-    CPointer(U16).from_usize(@_ptr._offset(offset).usize)._unsafe
+    CPointer(U16).from_address(@_ptr._offset(offset).address)._unsafe
       ._assign_at(0, number)
     @
 
@@ -473,7 +473,7 @@
   :: This is not suitable for protocols using a platform-independent byte order.
   :fun ref push_native_u16(number U16)
     @reserve(@_size + U16.byte_width.usize)
-    CPointer(U16).from_usize(@_ptr._offset(@_size).usize)._unsafe
+    CPointer(U16).from_address(@_ptr._offset(@_size).address)._unsafe
       ._assign_at(0, number)
     @_size += U16.byte_width.usize
     @
@@ -483,7 +483,7 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U32.
   :fun read_native_u32!(offset USize) U32
     if ((offset + U32.byte_width.usize) > @_size) error!
-    CPointer(U32).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
+    CPointer(U32).from_address(@_ptr._offset(offset).address)._unsafe._get_at(0)
 
   :: Write a U32 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -491,7 +491,7 @@
   :: Use push_native_u32 instead if writing past the end is needed.
   :fun ref write_native_u32!(offset USize, number U32)
     if ((offset + U32.byte_width.usize) > @_size) error!
-    CPointer(U32).from_usize(@_ptr._offset(offset).usize)._unsafe
+    CPointer(U32).from_address(@_ptr._offset(offset).address)._unsafe
       ._assign_at(0, number)
     @
 
@@ -499,7 +499,7 @@
   :: This is not suitable for protocols using a platform-independent byte order.
   :fun ref push_native_u32(number U32)
     @reserve(@_size + U32.byte_width.usize)
-    CPointer(U32).from_usize(@_ptr._offset(@_size).usize)._unsafe
+    CPointer(U32).from_address(@_ptr._offset(@_size).address)._unsafe
       ._assign_at(0, number)
     @_size += U32.byte_width.usize
     @
@@ -509,7 +509,7 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U64.
   :fun read_native_u64!(offset USize) U64
     if ((offset + U64.byte_width.usize) > @_size) error!
-    CPointer(U64).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
+    CPointer(U64).from_address(@_ptr._offset(offset).address)._unsafe._get_at(0)
 
   :: Write a U64 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -517,7 +517,7 @@
   :: Use push_native_u64 instead if writing past the end is needed.
   :fun ref write_native_u64!(offset USize, number U64)
     if ((offset + U64.byte_width.usize) > @_size) error!
-    CPointer(U64).from_usize(@_ptr._offset(offset).usize)._unsafe
+    CPointer(U64).from_address(@_ptr._offset(offset).address)._unsafe
       ._assign_at(0, number)
     @
 
@@ -525,7 +525,7 @@
   :: This is not suitable for protocols using a platform-independent byte order.
   :fun ref push_native_u64(number U64)
     @reserve(@_size + U64.byte_width.usize)
-    CPointer(U64).from_usize(@_ptr._offset(@_size).usize)._unsafe
+    CPointer(U64).from_address(@_ptr._offset(@_size).address)._unsafe
       ._assign_at(0, number)
     @_size += U64.byte_width.usize
     @

--- a/core/CPointer.savi
+++ b/core/CPointer.savi
@@ -140,8 +140,18 @@
   :: Return True unless this is a null pointer (i.e. a zero address).
   :fun tag is_not_null Bool: compiler intrinsic
 
-  :: Return the address of this pointer as an integer.
-  :fun tag usize USize: compiler intrinsic
+  :: Return the address of this pointer as an unsigned integer.
+  :fun tag address USize: compiler intrinsic
+
+  :: DEPRECATED: Use `address` instead.
+  :fun tag usize: @address
 
   // TODO: Remove this method. It's not compatible with CHERI hardware.
-  :fun non from_usize(number USize) @'tag: compiler intrinsic
+  // To replace it, we need a method to convert a pointer of one type
+  // into a (`tag`) pointer of another type, so we can replace the places
+  // where `address` and `from_address` are being used together for conversion.
+  // To do that, we need to have generic functions, which we don't have yet.
+  :fun non from_address(number USize) @'tag: compiler intrinsic
+
+  :: DEPRECATED: Use `from_address` instead.
+  :fun tag from_usize(number): @from_address(number)

--- a/spec/core/CPointer.Spec.savi
+++ b/spec/core/CPointer.Spec.savi
@@ -3,8 +3,8 @@
   :const describes: "CPointer"
 
   :it "converts to and from USize"
-    assert: CPointer(U8).null.usize == 0
-    assert: CPointer(U8).from_usize(0xdeadbeef).usize == 0xdeadbeef
+    assert: CPointer(U8).null.address == 0
+    assert: CPointer(U8).from_address(0xdeadbeef).address == 0xdeadbeef
 
   :it "tests if it is a null pointer or not"
     assert: CPointer(U8).null.is_null

--- a/spec/language/semantics/stack_address_of_variable_spec.savi
+++ b/spec/language/semantics/stack_address_of_variable_spec.savi
@@ -9,7 +9,7 @@
     test["stack_address_of_variable foo not null"].pass = foo_addr.is_not_null
 
     test["stack_address_of_variable foo != bar"].pass =
-      foo_addr.usize != bar_addr.usize
+      foo_addr.address != bar_addr.address
 
     test["stack_address_of_variable foo == foo"].pass =
-      foo_addr.usize == foo_addr_2.usize
+      foo_addr.address == foo_addr_2.address

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -969,9 +969,9 @@ class Savi::Compiler::CodeGen
         @builder.is_null(params[0])
       when "is_not_null"
         @builder.is_not_null(params[0])
-      when "usize"
+      when "address"
         @builder.ptr_to_int(params[0], @isize)
-      when "from_usize"
+      when "from_address"
         @builder.int_to_ptr(params[0], llvm_type)
       else
         raise NotImplementedError.new(gfunc.func.ident.value)


### PR DESCRIPTION
We'll also deprecate `from_usize` in favor of `from_address`,
but `from_address` itself is also in need of deprecation because
it makes the faulty assumption that a pointer's value can come
from its address alone. On CHERI hardware this is not true,
because the pointer value contains both an address and
extra information.