### PR TITLE
Add `static_address_of_function` macro.

### DIFF
--- a/docs/intro-vs-pony.md
+++ b/docs/intro-vs-pony.md
@@ -543,7 +543,7 @@ Generic functions are not yet in Savi. See [this ticket](https://github.com/savi
 
 ### C-FFI
 
-#### FFI Block
+#### FFI Functions
 
 While in Pony we use `@` to mark that we are calling a C function, in Savi we declare an `:ffi` function instead of a normal `:fun` function:
 
@@ -572,6 +572,25 @@ In Savi, all FFI functions are namespaced by the type name you declared, so you 
   :new iso (@message)
   :fun say
     _FFI.printf("%s\n".cstring, @message.cstring)
+```
+
+#### FFI Callbacks
+
+If an FFI function needs to accept a function pointer as a callback back into Savi code, you can define a `:fun non` and use the `static_address_of_function` macro to get the address of the function.
+
+The C code will be able to call it without a receiver, since a `:fun non` does not require the type instance to be passed as an implicit receiver argument. However, for many use cases you'll need to take a Savi object in some form as an explicit argument to the function (most C APIs with a callback take an extra void pointer for this purpose).
+
+```savi
+:class val MyObject
+  :let name String
+  :new val (@name)
+  :fun val pass_to_c
+    callback = static_address_of_function MyCallback.callback
+    _FFI.call_me_back_with(@, callback)
+
+:module MyCallback
+  :fun callback(object MyObject)
+    _FFI.puts("got called back from C with object: \(object.name)")
 ```
 
 ### [TODO: More Syntax Info...]

--- a/spec/compiler/macros/static_address_of_function_spec.cr
+++ b/spec/compiler/macros/static_address_of_function_spec.cr
@@ -1,0 +1,94 @@
+describe Savi::Compiler::Macros do
+  describe "static_address_of_function" do
+    it "is transformed into a relation" do
+      source = Savi::Source.new_example <<-SOURCE
+      :module _Math
+        :fun non add(a U8, b U8): a + b
+
+      :actor Main
+        :new (env Env)
+          static_address_of_function _Math.add
+      SOURCE
+
+      ctx = Savi.compiler.test_compile([source], :macros)
+      ctx.errors.should be_empty
+
+      func = ctx.namespace.find_func!(ctx, source, "Main", "new")
+      func.body.not_nil!.to_a.should eq [:group, ":", [:group, "(", [:relate,
+        [:ident, "_Math"],
+        [:op, "static_address_of_function"],
+        [:ident, "add"],
+      ]]]
+    end
+
+    it "complains if there are too many terms" do
+      source = Savi::Source.new_example <<-SOURCE
+      :module _Math
+        :fun non add(a U8, b U8): a + b
+
+      :actor Main
+        :new (env Env)
+          static_address_of_function _Math.add _Math.add
+      SOURCE
+
+      expected = <<-MSG
+      This macro has too many terms:
+      from (example):6:
+          static_address_of_function _Math.add _Math.add
+          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      - this term is the function whose static address should be captured:
+        from (example):6:
+          static_address_of_function _Math.add _Math.add
+                                     ^~~~~~~~~
+
+      - this is an excessive term:
+        from (example):6:
+          static_address_of_function _Math.add _Math.add
+                                               ^~~~~~~~~
+      MSG
+
+      Savi.compiler.test_compile([source], :macros)
+        .errors.map(&.message).join("\n").should eq expected
+    end
+
+    it "complains if the term isn't a call" do
+      source = Savi::Source.new_example <<-SOURCE
+      :actor Main
+        :new (env Env)
+          static_address_of_function 99
+      SOURCE
+
+      expected = <<-MSG
+      Expected this term to be a type name and function name with a dot in between:
+      from (example):3:
+          static_address_of_function 99
+                                     ^~
+      MSG
+
+      Savi.compiler.test_compile([source], :macros)
+        .errors.map(&.message).join("\n").should eq expected
+    end
+
+    it "complains if the term has arguments" do
+      source = Savi::Source.new_example <<-SOURCE
+      :module _Math
+        :fun non add(a U8, b U8): a + b
+
+      :actor Main
+        :new (env Env)
+          static_address_of_function _Math.add(2, 2)
+      SOURCE
+
+      expected = <<-MSG
+      Expected this function to have no arguments:
+      from (example):6:
+          static_address_of_function _Math.add(2, 2)
+                                              ^~~~~~
+      MSG
+
+      Savi.compiler.test_compile([source], :macros)
+        .errors.map(&.message).join("\n").should eq expected
+    end
+  end
+end

--- a/spec/compiler/t_type_check.address.savi.spec.md
+++ b/spec/compiler/t_type_check.address.savi.spec.md
@@ -1,0 +1,83 @@
+---
+pass: t_type_check
+---
+
+It complains when getting a function address from a non-single type:
+
+```savi
+:module Foo1
+  :fun foo: "foo"
+
+:module Foo2
+  :fun bar: "bar"
+```
+```savi
+    object (Foo1 | Foo2) = Foo1
+    static_address_of_function object.foo
+```
+```error
+A function address can only be taken from a single explicit type:
+    static_address_of_function object.foo
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- (Foo1 | Foo2) is not a single type:
+    object (Foo1 | Foo2) = Foo1
+           ^~~~~~~~~~~~~
+```
+
+---
+
+It complains when getting a function address from a non-existent function:
+
+```savi
+    static_address_of_function None.bogus
+```
+```error
+The function trying to be addressed here does not exist:
+    static_address_of_function None.bogus
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- None has no function named "bogus":
+:module None
+        ^~~~
+```
+
+---
+
+It complains when getting a function address from a non-`non` function:
+
+```savi
+    static_address_of_function @foo
+
+  :fun tag foo: "Foo"
+```
+```error
+A function address can only be taken when the cap is "non":
+    static_address_of_function @foo
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- this function has a cap of "tag":
+  :fun tag foo: "Foo"
+       ^~~
+```
+
+---
+
+It complains when getting a function address from a function with no body:
+
+```savi
+:trait Fooable
+  :fun non foo String
+```
+```savi
+    static_address_of_function Fooable.foo
+```
+```error
+A function address can only be taken from a function with a body:
+    static_address_of_function Fooable.foo
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- this function has no body:
+  :fun non foo String
+           ^~~
+```

--- a/spec/compiler/type_check.address.savi.spec.md
+++ b/spec/compiler/type_check.address.savi.spec.md
@@ -1,0 +1,83 @@
+---
+pass: type_check
+---
+
+It complains when getting a function address from a non-single type:
+
+```savi
+:module Foo1
+  :fun foo: "foo"
+
+:module Foo2
+  :fun bar: "bar"
+```
+```savi
+    object (Foo1 | Foo2) = Foo1
+    static_address_of_function object.foo
+```
+```error
+A function address can only be taken from a single explicit type:
+    static_address_of_function object.foo
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- (Foo1 | Foo2) is not a single type:
+    object (Foo1 | Foo2) = Foo1
+           ^~~~~~~~~~~~~
+```
+
+---
+
+It complains when getting a function address from a non-existent function:
+
+```savi
+    static_address_of_function None.bogus
+```
+```error
+The function trying to be addressed here does not exist:
+    static_address_of_function None.bogus
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- None has no function named "bogus":
+:module None
+        ^~~~
+```
+
+---
+
+It complains when getting a function address from a non-`non` function:
+
+```savi
+    static_address_of_function @foo
+
+  :fun tag foo: "Foo"
+```
+```error
+A function address can only be taken when the cap is "non":
+    static_address_of_function @foo
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- this function has a cap of "tag":
+  :fun tag foo: "Foo"
+       ^~~
+```
+
+---
+
+It complains when getting a function address from a function with no body:
+
+```savi
+:trait Fooable
+  :fun non foo String
+```
+```savi
+    static_address_of_function Fooable.foo
+```
+```error
+A function address can only be taken from a function with a body:
+    static_address_of_function Fooable.foo
+    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- this function has no body:
+  :fun non foo String
+           ^~~
+```

--- a/spec/language/semantics/static_address_of_function_spec.savi
+++ b/spec/language/semantics/static_address_of_function_spec.savi
@@ -1,0 +1,16 @@
+:module StaticAddressOfFunctionSpec
+  :fun foo: "Foo"
+  :fun bar: "Bar"
+
+  :fun run(test MicroTest)
+    foo_addr = static_address_of_function @foo
+    bar_addr = static_address_of_function @bar
+    foo_addr_2 = static_address_of_function StaticAddressOfFunctionSpec.foo
+
+    test["static_address_of_function foo not null"].pass = foo_addr.is_not_null
+
+    test["static_address_of_function foo != bar"].pass =
+      foo_addr.address != bar_addr.address
+
+    test["static_address_of_function foo == foo"].pass =
+      foo_addr.address == foo_addr_2.address

--- a/spec/language/semantics/test.savi
+++ b/spec/language/semantics/test.savi
@@ -16,6 +16,7 @@
     ReturnSpec.run(test)
     YieldingCallSpec.run(test)
     StackAddressOfVariableSpec.run(test)
+    StaticAddressOfFunctionSpec.run(test)
     ReflectionSpec.run(test)
     SourceCodeSpec.run(test)
     DisplacingAssignmentSpec.run(test)

--- a/src/savi/compiler/classify.cr
+++ b/src/savi/compiler/classify.cr
@@ -167,6 +167,8 @@ module Savi::Compiler::Classify
       case relate.op.value
       when "<:", "!<:", "EXPLICITTYPE"
         type_expr_visit(ctx, relate.rhs)
+      when "static_address_of_function"
+        @analysis.no_value!(relate.rhs)
       else
       end
     end

--- a/src/savi/compiler/infer.cr
+++ b/src/savi/compiler/infer.cr
@@ -31,6 +31,7 @@ module Savi::Compiler::Infer
     def initialize
       @spans = {} of Info => Span
       @reflections = Set(ReflectionOfType).new
+      @captured_function_pointers = Set(StaticAddressOfFunction).new
       @called_func_spans = {} of Info => {Span, String | Array(String)}
     end
 
@@ -158,6 +159,9 @@ module Savi::Compiler::Infer
 
     getter! yield_out_spans : Array(Span)
     protected setter yield_out_spans
+
+    protected getter captured_function_pointers
+    def each_captured_function_pointer; @captured_function_pointers.each; end
 
     protected getter reflections
     def each_reflection; @reflections.each; end
@@ -963,8 +967,11 @@ module Savi::Compiler::Infer
       ReifiedType.new(ctx.namespace.core_savi_type(ctx, name), args)
     end
 
-    def core_savi_type_span(ctx : Context, name : String)
-      Span.simple(MetaType.new(core_savi_reified_type(ctx, name)))
+    def core_savi_type_span(ctx : Context, name : String, type_arg_name : String? = nil)
+      args = type_arg_name.try { |t|
+        [MetaType.new(core_savi_reified_type(ctx, t))]
+      } || [] of MetaType
+      Span.simple(MetaType.new(core_savi_reified_type(ctx, name, args)))
     end
   end
 

--- a/src/savi/compiler/infer/info.cr
+++ b/src/savi/compiler/infer/info.cr
@@ -490,6 +490,23 @@ module Savi::Compiler::Infer
     end
   end
 
+  class StaticAddressOfFunction < DynamicInfo
+    getter receiver_type : Info
+    getter function_name : String
+
+    def describe_kind : String; "function address" end
+
+    def initialize(@pos, @layer_index, @receiver_type, @function_name)
+    end
+
+    def resolve_span!(ctx : Context, infer : Visitor) : Span
+      # Take note of this captured function pointer.
+      infer.analysis.captured_function_pointers.add(self)
+
+      infer.core_savi_type_span(ctx, "CPointer", "None")
+    end
+  end
+
   class ReflectionOfType < DynamicInfo
     getter reflect_type : Info
 

--- a/src/savi/compiler/pre_infer.cr
+++ b/src/savi/compiler/pre_infer.cr
@@ -483,6 +483,14 @@ module Savi::Compiler::PreInfer
           @analysis[node] = Infer::TypeCondition.new(node.pos, layer(node), lhs_info, rhs_info, positive_check)
         end
 
+      when "static_address_of_function"
+        @analysis[node] = Infer::StaticAddressOfFunction.new(
+          node.pos,
+          layer(node),
+          self[node.lhs],
+          node.rhs.as(AST::Identifier).value
+        )
+
       else raise NotImplementedError.new(node.op.value)
       end
     end

--- a/src/savi/compiler/pre_t_infer.cr
+++ b/src/savi/compiler/pre_t_infer.cr
@@ -484,6 +484,14 @@ module Savi::Compiler::PreTInfer
           @analysis[node] = TInfer::TypeCondition.new(node.pos, layer(node), lhs_info, rhs_info, positive_check)
         end
 
+      when "static_address_of_function"
+        @analysis[node] = TInfer::StaticAddressOfFunction.new(
+          node.pos,
+          layer(node),
+          self[node.lhs],
+          node.rhs.as(AST::Identifier).value
+        )
+
       else raise NotImplementedError.new(node.op.value)
       end
     end

--- a/src/savi/compiler/sugar.cr
+++ b/src/savi/compiler/sugar.cr
@@ -185,7 +185,8 @@ class Savi::Compiler::Sugar < Savi::AST::CopyOnMutateVisitor
 
   def visit(ctx, node : AST::Relate)
     case node.op.value
-    when "->", "'", " ", ":", "<:", "!<:", "===", "!==", "DEFAULTPARAM", "EXPLICITTYPE"
+    when "->", "'", " ", ":", "<:", "!<:", "===", "!==",
+         "DEFAULTPARAM", "EXPLICITTYPE", "static_address_of_function"
       node # skip these special-case operators
     when "+=", "-="
       op =

--- a/src/savi/compiler/t_infer.cr
+++ b/src/savi/compiler/t_infer.cr
@@ -31,6 +31,7 @@ module Savi::Compiler::TInfer
     def initialize
       @spans = {} of Info => Span
       @reflections = Set(ReflectionOfType).new
+      @captured_function_pointers = Set(StaticAddressOfFunction).new
       @called_func_spans = {} of Info => {Span, String | Array(String)}
     end
 
@@ -97,6 +98,9 @@ module Savi::Compiler::TInfer
 
     getter! yield_out_spans : Array(Span)
     protected setter yield_out_spans
+
+    protected getter captured_function_pointers
+    def each_captured_function_pointer; @captured_function_pointers.each; end
 
     protected getter reflections
     def each_reflection; @reflections.each; end
@@ -721,8 +725,11 @@ module Savi::Compiler::TInfer
       ReifiedType.new(ctx.namespace.core_savi_type(ctx, name), args)
     end
 
-    def core_savi_type_span(ctx : Context, name : String)
-      Span.simple(MetaType.new(core_savi_reified_type(ctx, name)))
+    def core_savi_type_span(ctx : Context, name : String, type_arg_name : String? = nil)
+      args = type_arg_name.try { |t|
+        [MetaType.new(core_savi_reified_type(ctx, t))]
+      } || [] of MetaType
+      Span.simple(MetaType.new(core_savi_reified_type(ctx, name, args)))
     end
   end
 

--- a/src/savi/compiler/t_infer/info.cr
+++ b/src/savi/compiler/t_infer/info.cr
@@ -459,6 +459,23 @@ module Savi::Compiler::TInfer
     end
   end
 
+  class StaticAddressOfFunction < DynamicInfo
+    getter receiver_type : Info
+    getter function_name : String
+
+    def describe_kind : String; "function address" end
+
+    def initialize(@pos, @layer_index, @receiver_type, @function_name)
+    end
+
+    def resolve_span!(ctx : Context, infer : Visitor) : Span
+      # Take note of this captured function pointer.
+      infer.analysis.captured_function_pointers.add(self)
+
+      infer.core_savi_type_span(ctx, "CPointer", "None")
+    end
+  end
+
   class ReflectionOfType < DynamicInfo
     getter reflect_type : Info
 

--- a/src/savi/compiler/t_type_check.cr
+++ b/src/savi/compiler/t_type_check.cr
@@ -397,6 +397,57 @@ class Savi::Compiler::TTypeCheck
       true
     end
 
+    def type_check_pre(ctx : Context, info : TInfer::StaticAddressOfFunction, mt : MetaType) : Bool
+      receiver_mt = resolve(ctx, info.receiver_type)
+      return false if !receiver_mt
+
+      receiver_rt = receiver_mt.single?.try(&.defn)
+      if !receiver_rt
+        ctx.error_at info,
+          "A function address can only be taken from a single explicit type", [
+            {info.receiver_type.pos,
+              "#{receiver_mt.show_type} is not a single type"},
+          ]
+        return false
+      end
+
+      type =
+        case receiver_rt
+        when TInfer::ReifiedType then receiver_rt.defn(ctx)
+        else
+          raise NotImplementedError.new(receiver_rt.inspect)
+        end
+      func = type.find_func?(info.function_name)
+      if !func
+        ctx.error_at info,
+          "The function trying to be addressed here does not exist", [
+            {type.ident.pos,
+              "#{type.ident.value} has no function named #{
+                info.function_name.inspect}"},
+          ]
+        return false
+      end
+
+      if func.cap.value != "non"
+        ctx.error_at info,
+          "A function address can only be taken when the cap is \"non\"", [
+            {func.cap.pos,
+              "this function has a cap of #{func.cap.value.inspect}"},
+          ]
+        return false
+      end
+
+      if !func.body
+        ctx.error_at info,
+          "A function address can only be taken from a function with a body", [
+            {func.ident.pos, "this function has no body"},
+          ]
+        return false
+      end
+
+      true
+    end
+
     # Other types of Info nodes do not have extra type checks.
     def type_check_pre(ctx : Context, info : TInfer::Info, mt : MetaType) : Bool
       true # There is nothing extra here.


### PR DESCRIPTION
This macro takes a call type and function name and returns
the pointer to that function as a `Pointer(None)`.

It must be a `:fun non`, and it must have a body defined.

The function pointer is suitable for use with FFI functions
that take a callback function pointer. That is, you can define
a `:fun non` function and pass it into a C function that will
call it later.