### PR TITLE
Fix the LSP server to not crash on unknown messages.

### DIFF
--- a/lib/.shards.info
+++ b/lib/.shards.info
@@ -3,10 +3,10 @@ version: 1.0
 shards:
   pegmatite:
     git: https://github.com/jemc/crystal-pegmatite.git
-    version: 0.2.3+git.commit.59b3afb296e79a0eea1a7d35db1d093cfc03f420
+    version: 0.2.3+git.commit.e7470d6eb1135cfd8a5353302edc5cad96f2c562
   lsp:
     git: https://github.com/jemc/crystal-lsp.git
-    version: 0.1.0+git.commit.3dee3e0a8596aa647860c3df191310843520b984
+    version: 0.1.0+git.commit.f7af03eed5b63974c04e92c0854b7c4a5b92c7f9
   clim:
     git: https://github.com/at-grandpa/clim.git
     version: 0.13.0

--- a/lib/lsp/src/lsp/codec.cr
+++ b/lib/lsp/src/lsp/codec.cr
@@ -43,7 +43,11 @@ module LSP::Codec
       if length.is_a? Int32
         body = IO::Sized.new(io, length).gets_to_end
         raise IO::EOFError.new if body.bytesize < length
-        return LSP::Message.from_json(body, outstanding)
+        begin
+          return LSP::Message.from_json(body, outstanding)
+        rescue
+          # keep looping until we get a valid, recognized message
+        end
       end
     end
   end

--- a/lib/pegmatite/spec/pegmatite_spec.cr
+++ b/lib/pegmatite/spec/pegmatite_spec.cr
@@ -69,9 +69,9 @@ describe Pegmatite do
         "overcomplicated" => JSON::Any.new(false),
         "worse-than"      => JSON::Any.new(nil),
         "problems"        => JSON::Any.new([] of JSON::Any),
-        "utf8" => JSON::Any.new(
+        "utf8"            => JSON::Any.new(
           [JSON::Any.new("Д"), JSON::Any.new("Ⴃ"), JSON::Any.new("𐀀")]
-        )
+        ),
       } of String => JSON::Any),
     } of String => JSON::Any)
   end

--- a/shard.lock
+++ b/shard.lock
@@ -10,9 +10,9 @@ shards:
 
   lsp:
     git: https://github.com/jemc/crystal-lsp.git
-    version: 0.1.0+git.commit.3dee3e0a8596aa647860c3df191310843520b984
+    version: 0.1.0+git.commit.f7af03eed5b63974c04e92c0854b7c4a5b92c7f9
 
   pegmatite:
     git: https://github.com/jemc/crystal-pegmatite.git
-    version: 0.2.3+git.commit.59b3afb296e79a0eea1a7d35db1d093cfc03f420
+    version: 0.2.3+git.commit.e7470d6eb1135cfd8a5353302edc5cad96f2c562
 


### PR DESCRIPTION
This commit is the result of `shards update`.

This update includes a workaround in the LSP library to ignore
all unknown/invalid messages instead of raising an error.