### PR TITLE
Fix linker path detection for 64bit Arch Linux.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -213,6 +213,7 @@ class Savi::Compiler::Binary
           yield "/lib/gcc/x86_64-linux-gnu/*"
           yield "/lib/x86_64-linux-gnu"
           yield "/usr/lib/gcc/x86_64-linux-gnu/*"
+          yield "/usr/lib/gcc/x86_64-pc-linux-gnu/*"
           yield "/usr/lib/x86_64-linux-gnu"
           yield "/usr/lib/gcc/x86_64-redhat-linux/*"
         else


### PR DESCRIPTION
The path used on Arch Linux is apparently
`/usr/lib/gcc/x86_64-pc-linux-gnu/*`.