### PR TITLE
Fix syntax highlighting (pygments and rouge) for nested type names.

### DIFF
--- a/tooling/pygments/lexers/savi.py
+++ b/tooling/pygments/lexers/savi.py
@@ -58,8 +58,11 @@ class SaviLexer(RegexLexer):
       # Single-Char String
       (r"'", String.Char, "string.char"),
 
-      # Class (or other type)
+      # Type Name
       (r'(_?[A-Z]\w*)', Name.Class),
+
+      # Nested Type Name
+      (r'(\.)(\s*)(_?[A-Z]\w*)', bygroups(Punctuation, Whitespace, Name.Class)),
 
       # Declare
       (r'^([ \t]*)(:\w+)',

--- a/tooling/rouge/lexers/savi.rb
+++ b/tooling/rouge/lexers/savi.rb
@@ -41,8 +41,13 @@ module Rouge
         # Single-Char String
         rule %r{'}, Str::Char, :string_char
 
-        # Class (or other type)
+        # Type Name
         rule %r{(_?[A-Z]\w*)}, Name::Class
+
+        # Nested Type Name
+        rule %r{(\.)(\s*)(_?[A-Z]\w*)} do
+          groups Punctuation, Text::Whitespace, Name::Class
+        end
 
         # Declare
         rule %r{^([ \t]*)(:\w+)} do


### PR DESCRIPTION
Nested type names were being highlighted as if they were method calls.

Now we use the uppercase letter to distinguish them visually.

---

A corresponding pygments PR has been opened: https://github.com/pygments/pygments/pull/2110
The still-open rouge PR has been updated: https://github.com/rouge-ruby/rouge/pull/1724