### PR TITLE
Add line break escape pattern for string literals.

### DIFF
--- a/spec/language/semantics/string_spec.savi
+++ b/spec/language/semantics/string_spec.savi
@@ -4,3 +4,14 @@
 
     test["compose string 1"].pass = "foo \(bar) baz" == "foo bar baz"
     test["compose string 2"].pass = "\(bar)\(bar)\(bar)" == "barbarbar"
+
+    test["line break escape 1"].pass = "\
+      Hello, \
+      World\
+      !\
+    " == "Hello, World!"
+
+    test["line break escape 2"].pass = b"\
+      \x00\x11\x22\x33\x44\x55\x66\x77\
+      \x88\x99\xaa\xbb\xcc\xdd\xee\xff\
+    ".size == 16

--- a/src/savi/parser/builder/state.cr
+++ b/src/savi/parser/builder/state.cr
@@ -113,6 +113,18 @@ module Savi::Parser::Builder
                 codepoint = 16 * codepoint + hex_value
               end
               result << codepoint
+            when '\r', '\n' then
+              while (
+                case reader.peek_next_char
+                when '\n' then true
+                when '\r' then true
+                when '\t' then true
+                when ' ' then true
+                else false
+                end
+              )
+                reader.next_char
+              end
             else
               # Not a valid escape character - pass it on as a literal slash
               # followed by that literal character, as if not an escape.
@@ -122,7 +134,10 @@ module Savi::Parser::Builder
           else
             result << reader.current_char
           end
-          reader.next_char
+          begin
+            reader.next_char
+          rescue
+          end
         end
       end
     end

--- a/src/savi/parser/grammar.cr
+++ b/src/savi/parser/grammar.cr
@@ -54,6 +54,7 @@ module Savi::Parser
       str("\b")  | str("\f")  | str("\n")  | str("\r")  | str("\t") |
       (str("\\u") >> digithex >> digithex >> digithex >> digithex) |
       (str("\\x") >> digithex >> digithex) |
+      (char('\\') >> char('\r').maybe >> char('\n') >> s) |
       str("\\") >> ~(~char('(')) >> parens |
       str("\\").maybe >> (~char('"') >> ~char('\\') >> range(' ', 0x10FFFF_u32))
     string = (


### PR DESCRIPTION
Now a string can be broken onto separate lines without
introducing any extra line breaks or whitespace into the content.

When `\` appears before a line break, the slash, the line break, and
any following indentation will be removed from the string's content.

For example, the following two string literals are equivalent in content:
```savi
    string_1 = "\
      Hello, \
      World\
      !\
    "

    string_2 = "Hello, World!"
```

Resolves #281.