### PR TITLE
Change `Integer` bit shifting semantics to be more consistent.

### DIFF
--- a/core/Integer.savi
+++ b/core/Integer.savi
@@ -120,6 +120,8 @@
   :: highest bits shifting out of the bounds of the `bit_width` to disappear,
   :: and the lowest bits being filled by zeroes in the empty space left behind.
   ::
+  :: If more than `bit_width` bits are shifted, the result is all zero bits.
+  ::
   :: Because each bit represents a successive power of two, this operation is
   :: equivalent to multiplying the value by 2 the given number of times.
   :fun val bit_shl(bits U8) T
@@ -131,8 +133,12 @@
   :: lowest bits shifting out of the bounds of the `bit_width` to disappear,
   :: and the highest bits being filled by zeroes in the empty space left behind.
   ::
+  :: If more than `bit_width` bits are shifted, the result is all zero bits.
+  ::
   :: Because each bit represents a successive power of two, this operation is
-  :: equivalent to dividing the value by 2 the given number of times.
+  :: equivalent to dividing the value by 2 the given number of times, provided
+  :: that the value is a positive integer rather than a negative integer
+  :: (as a shifted negative integer will have its sign bit filled with a zero).
   :fun val bit_shr(bits U8) T
 
   :: Do a bitwise "rotate left" on this value by the given number of bits.

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -372,6 +372,39 @@
     assert: U16[0b1110010110001010].bit_rotl(5) == 0b1011000101011100
     assert: U16[0b1110010110001010].bit_shr(5)  == 0b0000011100101100
     assert: U16[0b1110010110001010].bit_rotr(5) == 0b0101011100101100
+    assert: True.bit_shl(0) == True
+    assert: True.bit_shl(1) == False
+    assert: True.bit_shr(0) == True
+    assert: True.bit_shr(1) == False
+    assert: False.bit_shl(0) == False
+    assert: False.bit_shl(1) == False
+    assert: False.bit_shr(0) == False
+    assert: False.bit_shr(1) == False
+
+  :it "uses logical bit shift right, even for signed integers"
+    // Some languages/compilers use "arithmetic right shift" for signed integers
+    // in which the sign bit is preserved during shifting, such that shifting
+    // by one can be treated as a proxy for dividing by two, even for
+    // negative numbers (which must keep the sign bit as 1 to remain negative).
+    //
+    // However, in Savi, we use only "logical right shift", wherein for any
+    // non-zero shift amount, the new most significant bits will always be zero.
+    // This makes bit shifting operations work consistently for signed and
+    // unsigned integers, but makes it not a tenable practice to use shifting
+    // as a proxy for dividing by two. Just use division instead, and let LLVM
+    // optimize division by twos into arithmetic bit shifts where appropriate.
+
+    assert: I16[0b1011011100111101].bit_shr(0)  == 0b1011011100111101
+    assert: I16[0b1011011100111101].bit_shr(1)  == 0b0101101110011110
+    assert: I16[0b1011011100111101].bit_shr(5)  == 0b0000010110111001
+    assert: I16[0b1011011100111101].bit_shr(13) == 0b0000000000000101
+    assert: I16[0b1011011100111101].bit_shr(16) == 0b0000000000000000
+
+    assert: U16[0b1011011100111101].bit_shr(0)  == 0b1011011100111101
+    assert: U16[0b1011011100111101].bit_shr(1)  == 0b0101101110011110
+    assert: U16[0b1011011100111101].bit_shr(5)  == 0b0000010110111001
+    assert: U16[0b1011011100111101].bit_shr(13) == 0b0000000000000101
+    assert: U16[0b1011011100111101].bit_shr(16) == 0b0000000000000000
 
   :it "implements special multiplication without overflow by returning a pair"
     product = U8[99].wide_multiply(200)


### PR DESCRIPTION
This commit makes Savi depart from the bit shifting semantics
that were inherited from the Pony language in order to reach
semantics that are (in my opinion) more consistent to reason about.

To a certain extent both of these changes were already implied
by the existing documentation comments in Savi for these operations,
so they were somewhat bugs already in that the documentation didn't
match how it was working under the hood. But in any case, the
documentation comments have been updated to be more clear on these
points, which are also elaborated below:

- Right shifting now uses "logical" shift instead of "arithmetic"
  shift for both signed and unsigned integers.
  - Prior to this, signed integers used "arithmetic" shifting,
    so that the right shifting was always isomorphic with
    the arithmetic operation of dividing by 2.
  - However, that behavior made it hard to write generic code
    that relied on the "logical" semantics of bit shifting,
    as signed integers were a special case to need to deal with.
  - This new change stops the use of arithmetic shifting,
    under the reasoning that if one needs to reliably divide
    negative integers by multiples of 2, then one can explicitly
    use the division operator to do so, and rely on the compiler
    (specifically, LLVM optimizations) to convert division into
    arithmetic bit shifting when/if it is appropriate.

- Bit shifting by more than the `bit_width` of the type now
  always results in all zero bits (zero).
  - Prior to this, the number of bits to be shifted by was
    being clamped to a maximum of one less the `bit_width`,
    meaning that one bit from the original bit set would remain
    in the window of visible bits after the shift operation.
  - This was surprising behavior in several ways, not the least
    of which being that shifting by N bits twice wouldn't
    necessarily give you the same result as shifting by 2N bits once,
    in the case that `2N >= T.bit_width && N < T.bit_width`.
  - This new change fixes that distributive property and ensures
    consistent behavior by making the case behave in such away
    that all of the original bits are shifted away out of sight
    and only zero bits are left in their wake.
  - The reason this needs to be a special case at the LLVM IR
    level is that the LLVM `shl` and `lshr` instructions
    define that shifting by greater than or equal to the `bit_width`
    results in a "poison" value that will break downstream code.
  - Pony (and the Savi semantics inherited from Pony) was treating
    the special case by reducing the bit shift amount but Savi
    instead treats it by just returning zero in that case.