### PR TITLE
Fix compiler crash related to reachability of `<:` type expressions.

### DIFF
--- a/spec/core/Array.Spec.savi
+++ b/spec/core/Array.Spec.savi
@@ -134,6 +134,13 @@
     assert: ["foo", "bar", "baz"].includes("foo")
     assert: ["foo", "bar", "baz"].includes("f").is_false
 
+  :it "can check for inclusion even of `non` modules by type id"
+    array Array(Any'non) = []
+    assert: array.includes(None).is_false
+
+    array.push(None)
+    assert: array.includes(None)
+
   :it "replaces via a yield block the element at the given index, if it exists"
     array Array(String) = ["foo", "bar", "baz"]
 

--- a/src/savi/compiler/infer.cr
+++ b/src/savi/compiler/infer.cr
@@ -239,6 +239,8 @@ module Savi::Compiler::Infer
       subtyping = ctx.subtyping.for_rf(rf)
 
       @spans.each { |info, span|
+        next if info.is_a?(FixedTypeExpr)
+
         next if subtyping.ignores_layer?(ctx, info.layer_index)
 
         next if seen_spans.includes?(span)


### PR DESCRIPTION
This bug was causing `Equatable(Any'non)` to be considered reachable
when `Array(Any'non).includes` was called, causing a crash due to
`non` not being a valid partial reification of the type param of
`Equatable`.

It was being considered reachable because of the `A <: Equatable(A)'read`
check that happens inside the `includes` method, which was treating
the hypothetical type `Equatable(Any'non)'read` as being reachable
despite not being valid.

The issue was fixed by not treating any pure type expressions as
reachable. Only the types of values are reachable, but not type
expressions.