### PR TITLE
Add `saturating_` methods to the `Integer.SafeArithmetic` trait.

### DIFF
--- a/core/Integer.savi
+++ b/core/Integer.savi
@@ -52,22 +52,62 @@
 :: where handling the error case is important, rather than checking
 :: for safety pre-conditions using other means at the call site.
 :trait val Integer.SafeArithmetic(T Integer(T)'val)
-  // TODO: :fun val "/!"(other T) T
-
   :: Add this value to another value, resulting in a sum value.
-  :: Raises an error if the proper result would overflow the `max_value`.
+  :: Raises an error if the proper result would overflow the `max_value`
+  :: (or in a signed integer type, when adding a negative number,
+  :: if the proper result would underflow the `min_value`).
+  ::
   :: Use the `+` method instead if wrap-around overflow semantics are desired.
+  :: Use the `saturating_add` method instead if returning the `max_value`
+  :: on overflow or the `min_value` on underflow is the desired behavior.
   :fun val "+!"(other T) T
 
   :: Subtract another value from this value, resulting in a difference value.
-  :: Raises an error if the proper result would underflow the `max_value`.
-  :: Use the `-` method instead if wrap-around underflow semantics are desired.
+  :: Raises an error if the proper result would underflow the `min_value`
+  :: (or in a signed integer type, when subtracting a negative number,
+  :: if the proper result would overflow the `max_value`).
+  ::
+  :: Use the `-` method instead if wrap-around overflow semantics are desired.
+  :: Use the `saturating_subtract` method instead if returning the `max_value`
+  :: on overflow or the `min_value` on underflow is the desired behavior.
   :fun val "-!"(other T) T
 
   :: Multiply this value with another value, resulting in a product value.
-  :: Raises an error if the proper result would overflow or underflow.
+  :: Raises an error if the proper result would overflow the `max_value`
+  :: (or in a signed integer type, when one of the factors is a negative number,
+  :: if the proper result would underflow the `min_value`).
+  ::
   :: Use the `*` method instead if wrap-around overflow semantics are desired.
+  :: Use the `saturating_multiply` method instead if returning the `max_value`
+  :: on overflow or the `min_value` on underflow is the desired behavior.
   :fun val "*!"(other T) T
+
+  :: Add this value to another value, resulting in a sum value.
+  :: Returns `max_value` if the proper result would be greater than `max_value`.
+  :: Returns `min_value` if the proper result would be less than `min_value`,
+  :: which is possible for signed integer types when adding a negative.
+  ::
+  :: Use the `+!` method instead if raising an error on these cases is desired.
+  :: Use the `+` method instead if wrap-around overflow semantics are desired.
+  :fun val "saturating_add"(other T) T
+
+  :: Subtract another value from this value, resulting in a difference value.
+  :: Returns `min_value` if the proper result would be less than `min_value`.
+  :: Returns `max_value` if the proper result would be greater than `max_value`,
+  :: which is possible for signed integer types when subtracting a negative.
+  ::
+  :: Use the `-!` method instead if raising an error on these cases is desired.
+  :: Use the `-` method instead if wrap-around overflow semantics are desired.
+  :fun val "saturating_subtract"(other T) T
+
+  :: Multiply this value with another value, resulting in a product value.
+  :: Returns `max_value` if the proper result would be greater than `max_value`.
+  :: Returns `min_value` if the proper result would be less than `min_value`,
+  :: which is possible for signed integer types when one factor is negative.
+  ::
+  :: Use the `*!` method instead if raising an error on these cases is desired.
+  :: Use the `*` method instead if wrap-around overflow semantics are desired.
+  :fun val "saturating_multiply"(other T) T
 
 :: A type which can do "wide" arithmetic operations of the given integer type T,
 :: allowing integer arithmetic that is guaranteed to neither lose information
@@ -272,6 +312,19 @@
   :fun val "+!"(other @) @: compiler intrinsic
   :fun val "-!"(other @) @: compiler intrinsic
   :fun val "*!"(other @) @: compiler intrinsic
+  :fun val saturating_add(other @) @: compiler intrinsic
+  :fun val saturating_subtract(other @) @: compiler intrinsic
+  :fun val saturating_multiply(other @) @
+    // There is no LLVM intrinsic for saturating multiplication of integers,
+    // so we implement it using partial multiplication here below.
+    try (
+      @ *! other
+    |
+      left_is_negative = @ < @zero
+      right_is_negative = other < @zero
+      one_is_negative = left_is_negative != right_is_negative
+      if one_is_negative (@min_value | @max_value)
+    )
 
   :is Integer.WideArithmetic(@)
   :fun val wide_multiply(other @) Pair(@, @): compiler intrinsic

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -334,16 +334,48 @@
     assert: U32.max_value - 1 +! 1 == U32.max_value
     assert error: I32.max_value - 1 +! 2
     assert: I32.max_value - 1 +! 1 == I32.max_value
+    assert error: I32.min_value + 1 +! -2
+    assert: I32.min_value + 1 +! -1 == I32.min_value
 
     assert error: U32.min_value + 1 -! 2
     assert: U32.min_value + 1 -! 1 == U32.min_value
     assert error: I32.min_value + 1 -! 2
     assert: I32.min_value + 1 -! 1 == I32.min_value
+    assert error: I32.max_value - 1 -! -2
+    assert: I32.max_value - 1 -! -1 == I32.max_value
 
     assert error: U32[0x4000_0000] *! 4
-    assert: U32[0x4000_0000] *! 3 == U32[0x4000_0000] * 3
+    assert: U32[0x4000_0000] *! 3 == U32[0xc000_0000]
     assert error: I32[0x2000_0000] *! 4
-    assert: I32[0x2000_0000] *! 3 == I32[0x2000_0000] * 3
+    assert: I32[0x2000_0000] *! 3 == I32[0x6000_0000]
+    assert error: I32[0x2000_0000] *! -5
+    assert: I32[0x2000_0000] *! -3 == I32[0x6000_0000 * -1]
+
+  :it "implements saturating arithmetic for integers"
+    assert: (U32.max_value - 2).saturating_add(3) == U32.max_value
+    assert: (U32.max_value - 2).saturating_add(1) == U32.max_value - 1
+    assert: (I32.max_value - 2).saturating_add(3) == I32.max_value
+    assert: (I32.max_value - 2).saturating_add(1) == I32.max_value - 1
+    assert: (I32.min_value + 2).saturating_add(-3) == I32.min_value
+    assert: (I32.min_value + 2).saturating_add(-1) == I32.min_value + 1
+
+    assert: (U32.min_value + 2).saturating_subtract(3) == U32.min_value
+    assert: (U32.min_value + 2).saturating_subtract(1) == U32.min_value + 1
+    assert: (I32.min_value + 2).saturating_subtract(3) == I32.min_value
+    assert: (I32.min_value + 2).saturating_subtract(1) == I32.min_value + 1
+    assert: (I32.max_value - 2).saturating_subtract(-3) == I32.max_value
+    assert: (I32.max_value - 2).saturating_subtract(-1) == I32.max_value - 1
+
+    assert: U32[0x4000_0000].saturating_multiply(5) == U32.max_value
+    assert: U32[0x4000_0000].saturating_multiply(3) == U32[0xc000_0000]
+    assert: I32[0x2000_0000].saturating_multiply(5) == I32.max_value
+    assert: I32[0x2000_0000].saturating_multiply(3) == I32[0x6000_0000]
+    assert: I32[0x2000_0000].saturating_multiply(-5) == I32.min_value
+    assert: I32[0x2000_0000].saturating_multiply(-3) == I32[0x6000_0000 * -1]
+    assert: I32[0x2000_0000 * -1].saturating_multiply(5) == I32.min_value
+    assert: I32[0x2000_0000 * -1].saturating_multiply(3) == I32[0x6000_0000 * -1]
+    assert: I32[0x2000_0000 * -1].saturating_multiply(-5) == I32.max_value
+    assert: I32[0x2000_0000 * -1].saturating_multiply(-3) == I32[0x6000_0000]
 
   :it "implements bitwise analysis and manipulation for integers"
     assert: U8[18]                    == 0b00010010


### PR DESCRIPTION
These new methods return `max_value` on overflow or `min_value` on underflow.
- `saturating_add`
- `saturating_subtract`
- `saturating_multiply`

These new methods should be preferred over using `+!`, `-!`, and `*!`
in a `try` block with `max_value` and/or `min_value` in the else block,
which was otherwise the established pattern for acheiving this.

The `_add` and `_subtract` methods use efficient LLVM intrinsics
dedicated to this purpose, while the `_multiply` method has no
associated LLVM intrinsic, and thus is implemented using
the `*!` method as a basis for detecting overflow/underflow efficiently.

In working on this, it was noticed that a few test cases were missing
for `+!`, `-!`, and `*!`, so those tests were added here as well.
Also the doc comments for those methods were fixed up/improved
to better cover how negative numbers behave in signed integers,
and to mention the saturating variants and when to use those instead.