### PR TITLE
Fix sizing of byte string literals in the compiler.

### DIFF
--- a/spec/language/semantics/string_spec.savi
+++ b/spec/language/semantics/string_spec.savi
@@ -5,6 +5,9 @@
     test["compose string 1"].pass = "foo \(bar) baz" == "foo bar baz"
     test["compose string 2"].pass = "\(bar)\(bar)\(bar)" == "barbarbar"
 
+    test["byte string literal size"].pass =
+      b"\xde\xad\xbe\xef\xde\xad\xbe\xef".size == 8
+
     test["line break escape 1"].pass = "\
       Hello, \
       World\

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -3074,8 +3074,8 @@ class Savi::Compiler::CodeGen
   def gen_bstring(value : String)
     @bstring_globals.fetch value do
       global = gen_global_const(@gtypes["Bytes"], {
-        "_size"  => @isize.const_int(value.size),
-        "_space" => @isize.const_int(value.size + 1),
+        "_size"  => @isize.const_int(value.bytesize),
+        "_space" => @isize.const_int(value.bytesize + 1),
         "_ptr"   => gen_cstring(value),
       })
 


### PR DESCRIPTION
Prior to this fix, if a byte string literal happened to contain
a sequence of bytes that could be interpreted as a UTF-8 codepoint,
then the `size` of the `String` in Crystal would be less than
expected (because there are fewer codepoints than bytes),
which was resulting in the byte literal being generated in LLVM IR
as having its last few bytes trimmed off the end.

Using `bytesize` instead of `size` in Crystal fixes this issue.