### PR TITLE
Fix type check for parameters of elevated-cap constructor.

### DIFF
--- a/spec/compiler/type_check.validation.savi.spec.md
+++ b/spec/compiler/type_check.validation.savi.spec.md
@@ -5,19 +5,34 @@ pass: type_check
 It complains if some params of an elevated constructor are not sendable:
 
 ```savi
-  :new val bad_constructor(a String'ref, b String'val, c String'box)
+  :new iso iso_constructor(a String'ref, b String'val, c String'box)
+  :new val val_constructor(a String'ref, b String'val, c String'box)
+  :new box box_constructor(a String'ref, b String'val, c String'box)
 ```
 ```error
 A constructor with elevated capability must only have sendable parameters:
-  :new val bad_constructor(a String'ref, b String'val, c String'box)
+  :new iso iso_constructor(a String'ref, b String'val, c String'box)
        ^~~
 
 - this parameter type (String'ref) is not sendable:
-  :new val bad_constructor(a String'ref, b String'val, c String'box)
+  :new iso iso_constructor(a String'ref, b String'val, c String'box)
                            ^~~~~~~~~~~~
 
 - this parameter type (String'box) is not sendable:
-  :new val bad_constructor(a String'ref, b String'val, c String'box)
+  :new iso iso_constructor(a String'ref, b String'val, c String'box)
+                                                       ^~~~~~~~~~~~
+```
+```error
+A constructor with elevated capability must only have sendable parameters:
+  :new val val_constructor(a String'ref, b String'val, c String'box)
+       ^~~
+
+- this parameter type (String'ref) is not sendable:
+  :new val val_constructor(a String'ref, b String'val, c String'box)
+                           ^~~~~~~~~~~~
+
+- this parameter type (String'box) is not sendable:
+  :new val val_constructor(a String'ref, b String'val, c String'box)
                                                        ^~~~~~~~~~~~
 ```
 

--- a/src/savi/compiler/type_check.cr
+++ b/src/savi/compiler/type_check.cr
@@ -770,7 +770,9 @@ class Savi::Compiler::TypeCheck
         if @func.has_tag?(:async)
           "An asynchronous function"
         elsif @func.has_tag?(:constructor) \
-        && !resolve(ctx, @pre_infer[ret]).not_nil!.subtype_of?(ctx, MetaType.cap(Cap::REF))
+        && !MetaType.cap(Cap::REF).subtype_of?(ctx,
+          resolve(ctx, @pre_infer[ret]).not_nil!.cap_only
+        )
           "A constructor with elevated capability"
         end
       if require_sendable


### PR DESCRIPTION
Prior to this change, the compiler was wrongly allowing
`iso` constructors to take non-sendable arguments, and
preventing `box` constructors from taking them.

To fix this issue, the direction of subtype checking was reversed
in this particular check in the `TypeCheck` pass of the compiler.