### PR TITLE
Change `Integer.Format.Hexadecimal` to emit `lowercase` by default.

### DIFF
--- a/core/BitArray.savi
+++ b/core/BitArray.savi
@@ -22,13 +22,13 @@
 
   :fun _ptr_get_at(index USize) Bool
     data_index = index.bit_shr(6)
-    bit_number = index.bit_and(0x3F).u8
+    bit_number = index.bit_and(0x3f).u8
     bit_mask = U64[1].bit_shl(bit_number)
     @_ptr._get_at(data_index).bit_and(bit_mask) != 0
 
   :fun ref _ptr_assign_at(index USize, value Bool)
     data_index = index.bit_shr(6)
-    bit_number = index.bit_and(0x3F).u8
+    bit_number = index.bit_and(0x3f).u8
     bit_mask = U64[1].bit_shl(bit_number)
     bits = @_ptr._get_at(data_index)
     bits = bits
@@ -39,7 +39,7 @@
 
   :fun ref _ptr_displace_at(index USize, value Bool)
     data_index = index.bit_shr(6)
-    bit_number = index.bit_and(0x3F).u8
+    bit_number = index.bit_and(0x3f).u8
     bit_mask = U64[1].bit_shl(bit_number)
     bits = @_ptr._get_at(data_index)
     old_value = bits.bit_and(bit_mask) != 0

--- a/core/FloatingPoint.savi
+++ b/core/FloatingPoint.savi
@@ -107,11 +107,11 @@
   :is FloatingPoint.Bounded(@)
   :fun non zero @'val:   compiler intrinsic
   :fun non one @'val:    compiler intrinsic
-  :fun non max_value:    @from_bits(0x7F7F_FFFF)
-  :fun non min_value:    @from_bits(0xFF7F_FFFF)
-  :fun non infinity:     @from_bits(0x7F80_0000)
-  :fun non neg_infinity: @from_bits(0xFF80_0000)
-  :fun non nan:          @from_bits(0x7FC0_0000)
+  :fun non max_value:    @from_bits(0x7f7f_ffff)
+  :fun non min_value:    @from_bits(0xff7f_ffff)
+  :fun non infinity:     @from_bits(0x7f80_0000)
+  :fun non neg_infinity: @from_bits(0xff80_0000)
+  :fun non nan:          @from_bits(0x7fc0_0000)
   :fun non epsilon:      @from_bits(0x3400_0000) // 2 ** -23
   :fun non half_epsilon: @from_bits(0x3380_0000) // 2 ** -24
 
@@ -123,13 +123,13 @@
 
   :is FloatingPoint.Comparable(@)
   :fun val is_nan
-    @bits.bit_and(0x7F80_0000) == 0x7F80_0000 && // exponent
-    @bits.bit_and(0x007F_FFFF) != 0              // mantissa
+    @bits.bit_and(0x7f80_0000) == 0x7f80_0000 && // exponent
+    @bits.bit_and(0x007f_ffff) != 0              // mantissa
   :fun val is_infinite
-    @bits.bit_and(0x7F80_0000) == 0x7F80_0000 && // exponent
-    @bits.bit_and(0x007F_FFFF) == 0              // mantissa
+    @bits.bit_and(0x7f80_0000) == 0x7f80_0000 && // exponent
+    @bits.bit_and(0x007f_ffff) == 0              // mantissa
   :fun val is_finite
-    @bits.bit_and(0x7F80_0000) != 0x7F80_0000 // exponent
+    @bits.bit_and(0x7f80_0000) != 0x7f80_0000 // exponent
 
   :is IntoString
   :fun into_string_space: @f64.into_string_space
@@ -158,13 +158,13 @@
   :is FloatingPoint.Bounded(@)
   :fun non zero @'val:   compiler intrinsic
   :fun non one @'val:    compiler intrinsic
-  :fun non max_value:    @from_bits(0x7FEF_FFFF_FFFF_FFFF)
-  :fun non min_value:    @from_bits(0xFFEF_FFFF_FFFF_FFFF)
-  :fun non infinity:     @from_bits(0x7FF0_0000_0000_0000)
-  :fun non neg_infinity: @from_bits(0xFFF0_0000_0000_0000)
-  :fun non nan:          @from_bits(0x7FF8_0000_0000_0000)
-  :fun non epsilon:      @from_bits(0x3CB0_0000_0000_0000) // 2 ** -52
-  :fun non half_epsilon: @from_bits(0x3CA0_0000_0000_0000) // 2 ** -53
+  :fun non max_value:    @from_bits(0x7fef_ffff_ffff_ffff)
+  :fun non min_value:    @from_bits(0xffef_ffff_ffff_ffff)
+  :fun non infinity:     @from_bits(0x7ff0_0000_0000_0000)
+  :fun non neg_infinity: @from_bits(0xfff0_0000_0000_0000)
+  :fun non nan:          @from_bits(0x7ff8_0000_0000_0000)
+  :fun non epsilon:      @from_bits(0x3cb0_0000_0000_0000) // 2 ** -52
+  :fun non half_epsilon: @from_bits(0x3ca0_0000_0000_0000) // 2 ** -53
 
   :is FloatingPoint.Arithmetic(@)
   :fun val log @: compiler intrinsic
@@ -174,13 +174,13 @@
 
   :is FloatingPoint.Comparable(@)
   :fun val is_nan
-    @bits.bit_and(0x7FF0_0000_0000_0000) == 0x7FF0_0000_0000_0000 && // exponent
-    @bits.bit_and(0x000F_FFFF_FFFF_FFFF) != 0                        // mantissa
+    @bits.bit_and(0x7ff0_0000_0000_0000) == 0x7ff0_0000_0000_0000 && // exponent
+    @bits.bit_and(0x000f_ffff_ffff_ffff) != 0                        // mantissa
   :fun val is_infinite
-    @bits.bit_and(0x7FF0_0000_0000_0000) == 0x7FF0_0000_0000_0000 && // exponent
-    @bits.bit_and(0x000F_FFFF_FFFF_FFFF) == 0                        // mantissa
+    @bits.bit_and(0x7ff0_0000_0000_0000) == 0x7ff0_0000_0000_0000 && // exponent
+    @bits.bit_and(0x000f_ffff_ffff_ffff) == 0                        // mantissa
   :fun val is_finite
-    @bits.bit_and(0x7FF0_0000_0000_0000) != 0x7FF0_0000_0000_0000 // exponent
+    @bits.bit_and(0x7ff0_0000_0000_0000) != 0x7ff0_0000_0000_0000 // exponent
 
   :is IntoString
   :fun into_string_space USize: 14 // (max size of the below logic)

--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -28,7 +28,7 @@
       output.push_byte('"')
       input.each -> (byte |
         case (
-        | byte >= 0x7F | output = byte.format.hex.with_prefix("\\x").into_string(--output)
+        | byte >= 0x7f | output = byte.format.hex.with_prefix("\\x").into_string(--output)
         | byte == '"'  | output.push_byte('\\').push_byte('"')
         | byte >= 0x20 | output.push_byte(byte)
         | byte == '\n' | output.push_byte('\\').push_byte('n')

--- a/core/Integer.Format.savi
+++ b/core/Integer.Format.savi
@@ -88,12 +88,12 @@
 
   :let _value T
   :let _prefix String
-  :let _is_uppercase Bool
+  :let _is_lowercase Bool
   :let _has_leading_zeros Bool
   :new val _new(
     @_value
     @_prefix = "0x"
-    @_is_uppercase = True
+    @_is_lowercase = True
     @_has_leading_zeros = True
   )
 
@@ -102,15 +102,19 @@
 
   :: Use the given prefix instead of the standard "0x" hexadecimal prefix.
   :fun with_prefix(prefix)
-    @_new(@_value, prefix, @_is_uppercase, @_has_leading_zeros)
+    @_new(@_value, prefix, @_is_lowercase, @_has_leading_zeros)
 
-  :: Use lowercase hexadecimal letters instead of the default uppercase.
+  :: Use lowercase hexadecimal letters (which is the default).
   :fun lowercase
+    @_new(@_value, @_prefix, True, @_has_leading_zeros)
+
+  :: Use uppercase hexadecimal letters instead of the default lowercase.
+  :fun uppercase
     @_new(@_value, @_prefix, False, @_has_leading_zeros)
 
   :: Disable the default behavior of including all leading zeros.
   :fun without_leading_zeros
-    @_new(@_value, @_prefix, @_is_uppercase, False)
+    @_new(@_value, @_prefix, @_is_lowercase, False)
 
   :fun into_string_space USize
     // TODO: different strategy when `_has_leading_zeros` is False.
@@ -160,9 +164,9 @@
     --out
 
   :fun _digit(shr)
-    u4 = @_value.bit_shr(shr).u8.bit_and(0xF)
-    a = if @_is_uppercase ('A' | 'a')
-    if (u4 <= 9) (u4 + '0' | u4 + a - 0xA)
+    u4 = @_value.bit_shr(shr).u8.bit_and(0xf)
+    a = if @_is_lowercase ('a' | 'A')
+    if (u4 <= 9) (u4 + '0' | u4 + a - 0xa)
 
 :: Format the given integer into a fixed width binary representation.
 ::

--- a/core/String.savi
+++ b/core/String.savi
@@ -159,7 +159,7 @@
 
   :: Return the UTF8-encoded Unicode codepoint starting at the given byte index.
   :: Raises an error if the given index is out of bounds.
-  :: Returns 0xFFFD (Unicode "Replacement Character") if the given byte index
+  :: Returns 0xfffd (Unicode "Replacement Character") if the given byte index
   :: is not pointing to the start of a well-formed UTF-8-encoded codepoint.
   :fun char_at!(index USize) U32
     if (@size <= index) error!
@@ -175,7 +175,7 @@
       state == 0
     )
 
-    if early_stop (codepoint | 0xFFFD)
+    if early_stop (codepoint | 0xfffd)
 
   :fun _offset_to_index(offset ISize) USize
     if (offset < 0) (offset.usize + @size | offset.usize)
@@ -253,7 +253,7 @@
   ::
   :: When invalid UTF8 encoded bytes are observed, (whether because the String
   :: is invalid UTF8, or the starting byte index was pointing to the middle
-  :: of a multibyte codepoint rather than its start), the value 0xFFFD,
+  :: of a multibyte codepoint rather than its start), the value 0xfffd,
   :: known as a Unicode "Replacement character" will be yielded for those bytes.
   ::
   :: If the given byte range is outside of the bounds of the actual byte buffer,
@@ -278,7 +278,7 @@
         yield (codepoint, start_index, index - start_index)
         start_index = index
       | UTF8Decoding.is_error_state(state) |
-        yield (U32[0xFFFD], start_index, index - start_index)
+        yield (U32[0xfffd], start_index, index - start_index)
         start_index = index
         state = 0
       )
@@ -464,36 +464,36 @@
       yield (1, value.u8, 0, 0, 0)
     | 0x800 |
       yield (2
-        value.bit_shr(6).bit_or(0xC0).u8
-        value.bit_and(0x3F).bit_or(0x80).u8
+        value.bit_shr(6).bit_or(0xc0).u8
+        value.bit_and(0x3f).bit_or(0x80).u8
         0
         0
       )
-    | 0xD800 |
+    | 0xd800 |
       yield (3
-        value.bit_shr(12).bit_or(0xE0).u8
-        value.bit_shr(6).bit_and(0x3F).bit_or(0x80).u8
-        value.bit_and(0x3F).bit_or(0x80).u8
+        value.bit_shr(12).bit_or(0xe0).u8
+        value.bit_shr(6).bit_and(0x3f).bit_or(0x80).u8
+        value.bit_and(0x3f).bit_or(0x80).u8
         0
       )
-    | 0xE000 |
+    | 0xe000 |
       // UTF-16 surrogate pairs are not allowed.
-      yield (3, 0xEF, 0xBF, 0xBD, 0)
+      yield (3, 0xef, 0xbf, 0xbd, 0)
     | 0x10000 |
       yield (3
-        value.bit_shr(12).bit_or(0xE0).u8
-        value.bit_shr(6).bit_and(0x3F).bit_or(0x80).u8
-        value.bit_and(0x3F).bit_or(0x80).u8
+        value.bit_shr(12).bit_or(0xe0).u8
+        value.bit_shr(6).bit_and(0x3f).bit_or(0x80).u8
+        value.bit_and(0x3f).bit_or(0x80).u8
         0
       )
     | 0x110000 |
       yield (4
-        value.bit_shr(18).bit_or(0xF0).u8
-        value.bit_shr(12).bit_and(0x3F).bit_or(0x80).u8
-        value.bit_shr(6).bit_and(0x3F).bit_or(0x80).u8
-        value.bit_and(0x3F).bit_or(0x80).u8
+        value.bit_shr(18).bit_or(0xf0).u8
+        value.bit_shr(12).bit_and(0x3f).bit_or(0x80).u8
+        value.bit_shr(6).bit_and(0x3f).bit_or(0x80).u8
+        value.bit_and(0x3f).bit_or(0x80).u8
       )
     |
-      // Code points beyond 0x10FFFF are not allowed.
-      yield (3, 0xEF, 0xBF, 0xBD, 0)
+      // Code points beyond 0x10ffff are not allowed.
+      yield (3, 0xef, 0xbf, 0xbd, 0)
     )

--- a/lib/pegmatite/src/pegmatite/pattern/unicode_any.cr
+++ b/lib/pegmatite/src/pegmatite/pattern/unicode_any.cr
@@ -68,13 +68,13 @@ module Pegmatite
         # Make sure the encoding is not overlong.
         return err if (c == 0xF0_u32) && (c2 < 0x90_u32)
 
-        # Make sure the result will be <= 0x10FFFF.
+        # Make sure the result will be <= 0x10ffff.
         return err if (c == 0xF4_u32) && (c2 >= 0x90_u32)
 
         # Return the four-byte character.
         {((c << 18) + (c2 << 12) + (c3 << 6) + c4) - 0x3C82080_u32, 4, true}
       else
-        # The result would not be <= 0x10FFFF.
+        # The result would not be <= 0x10ffff.
         err
       end
     end

--- a/spec/core/BitArray.Spec.savi
+++ b/spec/core/BitArray.Spec.savi
@@ -88,8 +88,8 @@
       << 0 << 1 << 1 << 1 << 1 << 1 << 0 << 1
 
     bytes = bits.as_bytes
-    assert: bytes.read_native_u64!(0) == 0xDEADBEEFBAADF00D
-    assert: bytes.read_native_u64!(8) == 0xBEEF5AFAAAADD00D
+    assert: bytes.read_native_u64!(0) == 0xdeadbeefbaadf00d
+    assert: bytes.read_native_u64!(8) == 0xbeef5afaaaadd00d
 
   :it "allows bit access only within the existing bounds of the array"
     bits = BitArray.new << 0 << 1 << 1

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -162,7 +162,7 @@
     assert: b"bar food foo".includes(b"").is_false
 
   :it "hashes the bytes of the buffer"
-    assert: (b"string".hash == 0x4CF51F4A5B5CF110)
+    assert: (b"string".hash == 0x4cf51f4a5b5cf110)
 
   :it "returns the byte at the given byte offset"
     assert: b"example"[3]! == 'm'
@@ -348,28 +348,28 @@
     assert error: data.write_native_u64!(6, 0xfedcba9876543210)
 
   :it "reads integers in native, big and little endianness at specific offsets"
-    data = Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01])
+    data = Bytes.from_array([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01])
 
     assert: data.read_native_u16!(0) == 0x2301
     assert: data.read_native_u16!(1) == 0x4523
     assert: data.read_native_u32!(0) == 0x67452301
     assert: data.read_native_u32!(1) == 0x89674523
-    assert: data.read_native_u64!(0) == 0xEFCDAB8967452301
-    assert: data.read_native_u64!(1) == 0x01EFCDAB89674523
+    assert: data.read_native_u64!(0) == 0xefcdab8967452301
+    assert: data.read_native_u64!(1) == 0x01efcdab89674523
 
     assert: data.read_le_u16!(0) == 0x2301
     assert: data.read_le_u16!(1) == 0x4523
     assert: data.read_le_u32!(0) == 0x67452301
     assert: data.read_le_u32!(1) == 0x89674523
-    assert: data.read_le_u64!(0) == 0xEFCDAB8967452301
-    assert: data.read_le_u64!(1) == 0x01EFCDAB89674523
+    assert: data.read_le_u64!(0) == 0xefcdab8967452301
+    assert: data.read_le_u64!(1) == 0x01efcdab89674523
 
     assert: data.read_be_u16!(0) == 0x0123
     assert: data.read_be_u16!(1) == 0x2345
     assert: data.read_be_u32!(0) == 0x01234567
     assert: data.read_be_u32!(1) == 0x23456789
-    assert: data.read_be_u64!(0) == 0x0123456789ABCDEF
-    assert: data.read_be_u64!(1) == 0x23456789ABCDEF01
+    assert: data.read_be_u64!(0) == 0x0123456789abcdef
+    assert: data.read_be_u64!(1) == 0x23456789abcdef01
 
   :it "joins an array of bytes"
     assert: Bytes.join([

--- a/spec/core/Inspect.Spec.savi
+++ b/spec/core/Inspect.Spec.savi
@@ -54,8 +54,8 @@
 
   :it "inspects bytes"
     assert: Inspect[b"example"] == "b\"example\""
-    assert: Inspect[b"\x00\x08\x1A ABC123\"\n\r\t\x7F\x80\xFF"] == <<<
-      b"\x00\x08\x1A ABC123\"\n\r\t\x7F\x80\xFF"
+    assert: Inspect[b"\x00\x08\x1a ABC123\"\n\r\t\x7f\x80\xff"] == <<<
+      b"\x00\x08\x1a ABC123\"\n\r\t\x7f\x80\xff"
     >>>
 
   :it "inspects arrays"

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -648,17 +648,17 @@
     assert: "\(U8[0].format.hex)" == "0x00"
     assert: "\(0.format.hex)"     == "0x00000000"
     assert: "\(36.format.hex)"    == "0x00000024"
-    assert: "\((-36).format.hex)" == "0xFFFFFFDC"
-    assert: "\(U64[0x123456789ABCDEF0].format.hex)" == "0x123456789ABCDEF0"
+    assert: "\((-36).format.hex)" == "0xffffffdc"
+    assert: "\(U64[0x123456789abcdef0].format.hex)" == "0x123456789abcdef0"
 
-  :it "can format integers in a lowercase hexadecimal representation"
-    assert: "\(36.format.hex.lowercase)"    == "0x00000024"
-    assert: "\((-36).format.hex.lowercase)" == "0xffffffdc"
+  :it "can format integers in an uppercase hexadecimal representation"
+    assert: "\(36.format.hex.uppercase)"    == "0x00000024"
+    assert: "\((-36).format.hex.uppercase)" == "0xFFFFFFDC"
 
   :it "can format integers in hexadecimal without leading zeros"
     assert: "\(0.format.hex.without_leading_zeros)"     == "0x0"
     assert: "\(36.format.hex.without_leading_zeros)"    == "0x24"
-    assert: "\((-36).format.hex.without_leading_zeros)" == "0xFFFFFFDC"
+    assert: "\((-36).format.hex.without_leading_zeros)" == "0xffffffdc"
     assert: "\(1025.format.hex.without_leading_zeros)"  == "0x401"
 
   :it "can format integers in a standard binary representation"

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -52,20 +52,20 @@
     assert: F64  .is_floating_point
 
   :it "exhibits wraparound behaviour for underflowing numeric literals"
-    assert: U8[-1]                    == 0xFF
-    assert: U16[-1]                   == 0xFFFF
-    assert: U32[-1]                   == 0xFFFF_FFFF
-    assert: U64[-1]                   == 0xFFFF_FFFF_FFFF_FFFF
+    assert: U8[-1]                    == 0xff
+    assert: U16[-1]                   == 0xffff
+    assert: U32[-1]                   == 0xffff_ffff
+    assert: U64[-1]                   == 0xffff_ffff_ffff_ffff
     assert: I8[-128]                  == 128
     assert: I16[-32768]               == 32768
     assert: I32[-2147483648]          == 2147483648
     assert: I64[-9223372036854775808] == 9223372036854775808
 
     if Platform.has_64bit_size (
-      assert: USize[-1]                   == 0xFFFF_FFFF_FFFF_FFFF
+      assert: USize[-1]                   == 0xffff_ffff_ffff_ffff
       assert: ISize[-9223372036854775808] == 9223372036854775808
     |
-      assert: USize[-1]          == 0xFFFF_FFFF
+      assert: USize[-1]          == 0xffff_ffff
       assert: ISize[-2147483648] == 2147483648
     )
 
@@ -99,20 +99,20 @@
 
   :it "can report the max or minimum integer based on bit width and signedness"
     assert: Bool.max_value.is_true
-    assert: U8   .max_value == 0xFF
-    assert: U16  .max_value == 0xFFFF
-    assert: U32  .max_value == 0xFFFF_FFFF
-    assert: U64  .max_value == 0xFFFF_FFFF_FFFF_FFFF
-    assert: I8   .max_value == 0x7F
-    assert: I16  .max_value == 0x7FFF
-    assert: I32  .max_value == 0x7FFF_FFFF
-    assert: I64  .max_value == 0x7FFF_FFFF_FFFF_FFFF
+    assert: U8   .max_value == 0xff
+    assert: U16  .max_value == 0xffff
+    assert: U32  .max_value == 0xffff_ffff
+    assert: U64  .max_value == 0xffff_ffff_ffff_ffff
+    assert: I8   .max_value == 0x7f
+    assert: I16  .max_value == 0x7fff
+    assert: I32  .max_value == 0x7fff_ffff
+    assert: I64  .max_value == 0x7fff_ffff_ffff_ffff
     if Platform.has_64bit_size (
-      assert: USize.max_value == 0xFFFF_FFFF_FFFF_FFFF
-      assert: ISize.max_value == 0x7FFF_FFFF_FFFF_FFFF
+      assert: USize.max_value == 0xffff_ffff_ffff_ffff
+      assert: ISize.max_value == 0x7fff_ffff_ffff_ffff
     |
-      assert: USize.max_value == 0xFFFF_FFFF
-      assert: ISize.max_value == 0x7FFF_FFFF
+      assert: USize.max_value == 0xffff_ffff
+      assert: ISize.max_value == 0x7fff_ffff
     )
 
     assert: Bool.min_value.is_false
@@ -162,30 +162,30 @@
     assert: U64[0x0124].u8                 == 36
     assert: U64[0x0001_0024].u16           == 36
     assert: U64[0x0001_0000_0024].u32      == 36
-    assert: U64[0xFFFF_FFFF_FFFF_FFFF].u64 == 0xFFFF_FFFF_FFFF_FFFF
+    assert: U64[0xffff_ffff_ffff_ffff].u64 == 0xffff_ffff_ffff_ffff
     assert: U64[0x0124].i8                 == 36
     assert: U64[0x0001_0024].i16           == 36
     assert: U64[0x0001_0000_0024].i32      == 36
-    assert: U64[0xFFFF_FFFF_FFFF_FFFF].i64 == 0xFFFF_FFFF_FFFF_FFFF
+    assert: U64[0xffff_ffff_ffff_ffff].i64 == 0xffff_ffff_ffff_ffff
     assert error: U64[0x0124].u8!                 // overflow
     assert error: U64[0x0001_0024].u16!           // overflow
     assert error: U64[0x0001_0000_0024].u32!      // overflow
-    assert: U64[0xFFFF_FFFF_FFFF_FFFF].u64! == 0xFFFF_FFFF_FFFF_FFFF
+    assert: U64[0xffff_ffff_ffff_ffff].u64! == 0xffff_ffff_ffff_ffff
     assert error: U64[0x0124].i8!                 // overflow
     assert error: U64[0x0001_0024].i16!           // overflow
     assert error: U64[0x0001_0000_0024].i32!      // overflow
-    assert error: U64[0xFFFF_FFFF_FFFF_FFFF].i64! // overflow
-    assert: I64[-1].u8  == 0xFF
-    assert: I64[-1].u16 == 0xFFFF
-    assert: I64[-1].u32 == 0xFFFF_FFFF
-    assert: I64[-1].u64 == 0xFFFF_FFFF_FFFF_FFFF
+    assert error: U64[0xffff_ffff_ffff_ffff].i64! // overflow
+    assert: I64[-1].u8  == 0xff
+    assert: I64[-1].u16 == 0xffff
+    assert: I64[-1].u32 == 0xffff_ffff
+    assert: I64[-1].u64 == 0xffff_ffff_ffff_ffff
     assert: I64[-1].i8  == -1
     assert: I64[-1].i16 == -1
     assert: I64[-1].i32 == -1
     assert: I64[-1].i64 == -1
-    assert: I64[0xFF].negate.i8 == 1
-    assert: I64[0xFFFF].negate.i16 == 1
-    assert: I64[0xFFFF_FFFF].negate.i32 == 1
+    assert: I64[0xff].negate.i8 == 1
+    assert: I64[0xffff].negate.i16 == 1
+    assert: I64[0xffff_ffff].negate.i32 == 1
     assert error: I64[-1].u8!
     assert error: I64[-1].u16!
     assert error: I64[-1].u32!
@@ -194,9 +194,9 @@
     assert: I64[-1].i16! == -1
     assert: I64[-1].i32! == -1
     assert: I64[-1].i64! == -1
-    assert error: I64[0xFF].negate.i8!
-    assert error: I64[0xFFFF].negate.i16!
-    assert error: I64[0xFFFF_FFFF].negate.i32!
+    assert error: I64[0xff].negate.i8!
+    assert error: I64[0xffff].negate.i16!
+    assert error: I64[0xffff_ffff].negate.i32!
 
   :it "converts from floating point to other numeric types"
     assert: F32[36].u32  == 36
@@ -484,21 +484,21 @@
 
   :it "implements bitwise analysis and special values for floating points"
     assert: F32[3.6].bits == 0x4066_6666
-    assert: F64[3.6].bits == 0x400C_CCCC_CCCC_CCCD
+    assert: F64[3.6].bits == 0x400c_cccc_cccc_cccd
     assert: F32.from_bits(0x4066_6666)           == 3.6
-    assert: F64.from_bits(0x400C_CCCC_CCCC_CCCD) == 3.6
-    assert: F32.nan.bits == 0x7FC0_0000
-    assert: F64.nan.bits == 0x7FF8_0000_0000_0000
+    assert: F64.from_bits(0x400c_cccc_cccc_cccd) == 3.6
+    assert: F32.nan.bits == 0x7fc0_0000
+    assert: F64.nan.bits == 0x7ff8_0000_0000_0000
     assert: F32.nan.is_nan
     assert: F64.nan.is_nan
     assert: F32[0].is_nan.is_false
     assert: F64[0].is_nan.is_false
     assert: (F32[0] / 0).is_nan
     assert: (F64[0] / 0).is_nan
-    assert: F32.infinity.bits == 0x7F80_0000
-    assert: F64.infinity.bits == 0x7FF0_0000_0000_0000
-    assert: F32.neg_infinity.bits == 0xFF80_0000
-    assert: F64.neg_infinity.bits == 0xFFF0_0000_0000_0000
+    assert: F32.infinity.bits == 0x7f80_0000
+    assert: F64.infinity.bits == 0x7ff0_0000_0000_0000
+    assert: F32.neg_infinity.bits == 0xff80_0000
+    assert: F64.neg_infinity.bits == 0xffF0_0000_0000_0000
     assert: F32.infinity == F32[1] / 0
     assert: F64.infinity == F64[1] / 0
     assert: F32.neg_infinity == F32[-1] / 0
@@ -608,8 +608,8 @@
     )
 
   :it "converts U64 integers from native to big/little endianness and vice versa"
-    u64 = U64[0x1234_5678_9ABC_DEF0]
-    u64_swapped = U64[0xF0DE_BC9A_7856_3412]
+    u64 = U64[0x1234_5678_9abc_def0]
+    u64_swapped = U64[0xf0de_bc9a_7856_3412]
 
     if Platform.is_little_endian (
       assert: u64.native_to_be == u64_swapped

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -120,7 +120,7 @@
     assert: "bar food foo".includes("").is_false
 
   :it "hashes the bytes of the string"
-    assert: ("string".hash == 0x4CF51F4A5B5CF110)
+    assert: ("string".hash == 0x4cf51f4a5b5cf110)
 
   :it "returns the byte at the given byte offset"
     assert: "example"[3]! == 'm'

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1083,19 +1083,19 @@ class Savi::Compiler::CodeGen
           if gtype.type_def.is_signed_numeric?(ctx)
             case bit_width_of(gtype)
             when 1 then llvm_type_of(gtype).const_int(0)
-            when 8 then llvm_type_of(gtype).const_int(0x7F)
-            when 16 then llvm_type_of(gtype).const_int(0x7FFF)
-            when 32 then llvm_type_of(gtype).const_int(0x7FFFFFFF)
-            when 64 then llvm_type_of(gtype).const_int(0x7FFFFFFFFFFFFFFF)
+            when 8 then llvm_type_of(gtype).const_int(0x7f)
+            when 16 then llvm_type_of(gtype).const_int(0x7fff)
+            when 32 then llvm_type_of(gtype).const_int(0x7fffffff)
+            when 64 then llvm_type_of(gtype).const_int(0x7fffffffffffffff)
             else raise NotImplementedError.new(bit_width_of(gtype))
             end
           else
             case bit_width_of(gtype)
             when 1 then llvm_type_of(gtype).const_int(1)
-            when 8 then llvm_type_of(gtype).const_int(0xFF)
-            when 16 then llvm_type_of(gtype).const_int(0xFFFF)
-            when 32 then llvm_type_of(gtype).const_int(0xFFFFFFFF)
-            when 64 then llvm_type_of(gtype).const_int(0xFFFFFFFFFFFFFFFF)
+            when 8 then llvm_type_of(gtype).const_int(0xff)
+            when 16 then llvm_type_of(gtype).const_int(0xffff)
+            when 32 then llvm_type_of(gtype).const_int(0xffffffff)
+            when 64 then llvm_type_of(gtype).const_int(0xffffffffffffffff)
             else raise NotImplementedError.new(bit_width_of(gtype))
             end
           end
@@ -2913,8 +2913,8 @@ class Savi::Compiler::CodeGen
   def gen_numeric_conv_f64_to_f32(value : LLVM::Value, partial : Bool)
     # If the value is F64 NaN, return F32 NaN.
     test_overflow = gen_numeric_conv_float_handle_nan(
-      value, @i64, 0x7FF0000000000000, 0x000FFFFFFFFFFFFF)
-    gen_return_value(@llvm.const_bit_cast(@i32.const_int(0x7FC00000), @f32), nil)
+      value, @i64, 0x7ff0000000000000, 0x000fffffffffffff)
+    gen_return_value(@llvm.const_bit_cast(@i32.const_int(0x7fc00000), @f32), nil)
 
     overflow = gen_block("overflow")
     test_underflow = gen_block("test_underflow")
@@ -2923,7 +2923,7 @@ class Savi::Compiler::CodeGen
 
     # Check if the F64 value overflows the maximum F32 value.
     finish_block_and_move_to(test_overflow)
-    f32_max = @llvm.const_bit_cast(@i32.const_int(0x7F7FFFFF), @f32)
+    f32_max = @llvm.const_bit_cast(@i32.const_int(0x7f7fffff), @f32)
     f32_max = @builder.fpext(f32_max, @f64, "f32_max")
     is_overflow = @builder.fcmp(LLVM::RealPredicate::OGT, value, f32_max)
     @builder.cond(is_overflow, overflow, test_underflow)
@@ -2933,12 +2933,12 @@ class Savi::Compiler::CodeGen
     if partial
       gen_raise_error(gen_none, nil)
     else
-      gen_return_value(@llvm.const_bit_cast(@i32.const_int(0x7F800000), @f32), nil)
+      gen_return_value(@llvm.const_bit_cast(@i32.const_int(0x7f800000), @f32), nil)
     end
 
     # Check if the F64 value underflows the minimum F32 value.
     finish_block_and_move_to(test_underflow)
-    f32_min = @llvm.const_bit_cast(@i32.const_int(0xFF7FFFFF), @f32)
+    f32_min = @llvm.const_bit_cast(@i32.const_int(0xff7fffff), @f32)
     f32_min = @builder.fpext(f32_min, @f64, "f32_min")
     is_underflow = @builder.fcmp(LLVM::RealPredicate::OLT, value, f32_min)
     @builder.cond(is_underflow, underflow, normal)
@@ -2948,7 +2948,7 @@ class Savi::Compiler::CodeGen
     if partial
       gen_raise_error(gen_none, nil)
     else
-      gen_return_value(@llvm.const_bit_cast(@i32.const_int(0xFF800000), @f32), nil)
+      gen_return_value(@llvm.const_bit_cast(@i32.const_int(0xff800000), @f32), nil)
     end
 
     # Otherwise, proceed with the floating-point truncation as normal.
@@ -2958,7 +2958,7 @@ class Savi::Compiler::CodeGen
 
   def gen_numeric_conv_f32_to_sint(value : LLVM::Value, to_type : LLVM::Type, partial : Bool)
     test_overflow = gen_numeric_conv_float_handle_nan(
-      value, @i32, 0x7F800000, 0x007FFFFF)
+      value, @i32, 0x7f800000, 0x007fffff)
     if partial
       gen_raise_error(gen_none, nil)
     else
@@ -2975,7 +2975,7 @@ class Savi::Compiler::CodeGen
 
   def gen_numeric_conv_f64_to_sint(value : LLVM::Value, to_type : LLVM::Type, partial : Bool)
     test_overflow = gen_numeric_conv_float_handle_nan(
-      value, @i64, 0x7FF0000000000000, 0x000FFFFFFFFFFFFF)
+      value, @i64, 0x7ff0000000000000, 0x000fffffffffffff)
     if partial
       gen_raise_error(gen_none, nil)
     else
@@ -2992,7 +2992,7 @@ class Savi::Compiler::CodeGen
 
   def gen_numeric_conv_f32_to_uint(value : LLVM::Value, to_type : LLVM::Type, partial : Bool)
     test_overflow = gen_numeric_conv_float_handle_nan(
-      value, @i32, 0x7F800000, 0x007FFFFF)
+      value, @i32, 0x7f800000, 0x007fffff)
     if partial
       gen_raise_error(gen_none, nil)
     else
@@ -3008,7 +3008,7 @@ class Savi::Compiler::CodeGen
 
   def gen_numeric_conv_f64_to_uint(value : LLVM::Value, to_type : LLVM::Type, partial : Bool)
     test_overflow = gen_numeric_conv_float_handle_nan(
-      value, @i64, 0x7FF0000000000000, 0x000FFFFFFFFFFFFF)
+      value, @i64, 0x7ff0000000000000, 0x000fffffffffffff)
     if partial
       gen_raise_error(gen_none, nil)
     else
@@ -3252,7 +3252,7 @@ class Savi::Compiler::CodeGen
     raise NotImplementedError.new("gen_reflection_mutator_of_type in Verona") \
       if @runtime.is_a?(VeronaRT)
     desc = gen_global_for_const(mutator_gtype.desc_type.const_struct [
-      @i32.const_int(0xFFFF_FFFF),         # 0: id
+      @i32.const_int(0xffff_ffff),         # 0: id
       @i32.const_int(abi_size_of(@ptr)),   # 1: size
       @i32_0,                              # 2: field_count (tuples only)
       @i32_0,                              # 3: field_offset


### PR DESCRIPTION
Prior to this change, it emitted `uppercase` hexadecimal letters by default.

The new official style recommendation for Savi is to prefer lowercase
for all hexadecimal numeric values, in all contexts.

Certain uppercase letters tend to be easier to confuse at a glance
than lowercase hexadecimal letters are.
- `B` is easily confused with the number `8`.
- `A` is somewhat easily confused with the number `4`.