### PR TITLE
Add `.format.literal` and `.format.hex_dump` for the `Bytes` type.

### DIFF
--- a/core/Bytes.Format.savi
+++ b/core/Bytes.Format.savi
@@ -1,0 +1,112 @@
+:: Format the given `Bytes` value using one of the available format types.
+:: Call one of the methods of this struct to choose which format type to use.
+:struct box Bytes.Format
+  :let _value Bytes'box
+  :new box _new(@_value)
+
+  :fun literal: Bytes.Format.Literal._new(@_value)
+  :fun hex_dump: Bytes.Format.HexDump._new(@_value)
+
+  :fun lit: @literal
+  :fun xxd: @hex_dump
+
+:: Format the given `Bytes` as they could appear in Savi source code. That is,
+:: as a string literal with the `b` prefix and non-printable bytes escaped.
+:struct box Bytes.Format.Literal
+  :is IntoString
+
+  :let _value Bytes'box
+  :new box _new(@_value)
+
+  :fun into_string(out String'iso) String'iso
+    out.push_byte('b')
+    out.push_byte('"')
+    @_value.each -> (byte |
+      case (
+      | byte >= 0x7f | out = byte.format.hex.with_prefix("\\x").into_string(--out)
+      | byte == '"'  | out.push_byte('\\').push_byte('"')
+      | byte >= 0x20 | out.push_byte(byte)
+      | byte == '\n' | out.push_byte('\\').push_byte('n')
+      | byte == '\r' | out.push_byte('\\').push_byte('r')
+      | byte == '\t' | out.push_byte('\\').push_byte('t')
+      |                out = byte.format.hex.with_prefix("\\x").into_string(--out)
+      )
+    )
+    out.push_byte('"')
+    --out
+
+  :fun into_string_space USize
+    // Use a conservative estimate, assuming all bytes will be escaped hex.
+    // Each escaped hex byte takes 4 bytes to display, and there are 3 bytes
+    // of overhead involved in displaying the leading `b"` and final `"`.
+    @_value.size * 4 + 3
+
+:: Format the given `Bytes` into a "hex dump", much like the output of the
+:: `xxd` command-line utility found on many UNIX platforms.
+::
+:: This format shows addresses, hex bytes, and corresponding ASCII characters,
+:: in a way that is intended to facilitate debugging of large data sequences.
+:struct val Bytes.Format.HexDump
+  :is IntoString
+
+  :let _value Bytes'box
+  :new box _new(@_value)
+
+  :fun _row_count
+    // Divide by 16 bytes per row, rounding up to the nearest row.
+    (@_value.size + 15) / 16
+
+  :fun into_string_space USize
+    // It takes 68 bytes to show each row of the hex dump.
+    @_row_count * 68
+
+  :fun into_string(out String'iso) String'iso
+    @_row_count.times -> (row_index |
+      row_address = row_index * 16
+
+      // Emit the address shown on the left.
+      out = row_address.u32.format.hex.bare.into_string(--out)
+      out.push_byte(':')
+
+      // Emit the hex view shown in the center.
+      USize[8].times -> (pair_index |
+        out.push_byte(' ')
+        out = @_emit_hex_pair(--out, row_address + pair_index * 2)
+      )
+      out.push_byte(' ')
+
+      // Emit the ASCII view shown on the right.
+      USize[16].times -> (byte_index |
+        out = @_emit_ascii(--out, row_address + byte_index)
+      )
+
+      // Emit a final newline for this row.
+      out.push_byte('\n')
+    )
+    --out
+
+  :fun _emit_hex_pair(out String'iso, pair_address USize)
+    out = @_emit_hex(--out, pair_address)
+    out = @_emit_hex(--out, pair_address + 1)
+    --out
+
+  :fun _emit_hex(out String'iso, byte_address USize)
+    try (
+      out = @_value[byte_address]!.format.hex.bare.into_string(--out)
+    |
+      out.push_byte(' ').push_byte(' ')
+    )
+    --out
+
+  :fun _emit_ascii(out String'iso, byte_address USize)
+    try (
+      byte = @_value[byte_address]!
+      if (byte > 0x20 && byte < 0x7f) (
+        out.push_byte(byte)
+      |
+        out.push_byte('.')
+      )
+    |
+      out.push_byte(' ')
+    )
+    --out

--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -84,6 +84,8 @@
 
   :fun ref clear: @_size = 0, @
 
+  :fun format: Bytes.Format._new(@)
+
   :fun clone @'iso
     copy = @new_iso(@size)
     _ptr_tag CPointer(U8)'tag = @_ptr // TODO: this indirection shouldn't be needed

--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -18,25 +18,10 @@
   :fun into(output String'iso, input Any'box) String'iso // TODO: use `box` instead of `Any'box` // TODO: use something like Crystal IO instead of String?
     case input <: (
     | _InspectCustom | input.inspect_into(--output)
+    | Bytes'box | input.format.literal.into_string(--output)
     | String'box |
       output.push_byte('"')
       output << input.clone // TODO: show some characters as escaped.
-      output.push_byte('"')
-      --output
-    | Bytes'box |
-      output.push_byte('b')
-      output.push_byte('"')
-      input.each -> (byte |
-        case (
-        | byte >= 0x7f | output = byte.format.hex.with_prefix("\\x").into_string(--output)
-        | byte == '"'  | output.push_byte('\\').push_byte('"')
-        | byte >= 0x20 | output.push_byte(byte)
-        | byte == '\n' | output.push_byte('\\').push_byte('n')
-        | byte == '\r' | output.push_byte('\\').push_byte('r')
-        | byte == '\t' | output.push_byte('\\').push_byte('t')
-        |                output = byte.format.hex.with_prefix("\\x").into_string(--output)
-        )
-      )
       output.push_byte('"')
       --output
     | _InspectEach |

--- a/spec/core/Bytes.Format.Spec.savi
+++ b/spec/core/Bytes.Format.Spec.savi
@@ -1,0 +1,20 @@
+:class Savi.Bytes.Format.Spec
+  :is Spec
+  :const describes: "Bytes.Format"
+
+  :it "can format as a hex dump"
+    value = Bytes.new
+    U8[0x89].times -> (byte | value.push(byte))
+
+    assert: "\(value.format.hex_dump)" == String.join([
+      "00000000: 0001 0203 0405 0607 0809 0a0b 0c0d 0e0f ................"
+      "00000010: 1011 1213 1415 1617 1819 1a1b 1c1d 1e1f ................"
+      "00000020: 2021 2223 2425 2627 2829 2a2b 2c2d 2e2f .!\"#$%&'()*+,-./"
+      "00000030: 3031 3233 3435 3637 3839 3a3b 3c3d 3e3f 0123456789:;<=>?"
+      "00000040: 4041 4243 4445 4647 4849 4a4b 4c4d 4e4f @ABCDEFGHIJKLMNO"
+      "00000050: 5051 5253 5455 5657 5859 5a5b 5c5d 5e5f PQRSTUVWXYZ[\\]^_"
+      "00000060: 6061 6263 6465 6667 6869 6a6b 6c6d 6e6f `abcdefghijklmno"
+      "00000070: 7071 7273 7475 7677 7879 7a7b 7c7d 7e7f pqrstuvwxyz{|}~."
+      "00000080: 8081 8283 8485 8687 88                  .........       "
+      ""
+    ], "\n")

--- a/spec/core/Main.savi
+++ b/spec/core/Main.savi
@@ -5,6 +5,7 @@
       Spec.Run(Savi.BitArray.Spec).new(env)
       Spec.Run(Savi.Bool.Spec).new(env)
       Spec.Run(Savi.Bytes.Spec).new(env)
+      Spec.Run(Savi.Bytes.Format.Spec).new(env)
       Spec.Run(Savi.CPointer.Spec).new(env)
       Spec.Run(Savi.Indexable.Spec).new(env)
       Spec.Run(Savi.Inspect.Spec).new(env)


### PR DESCRIPTION
`Bytes.Format.Literal` formats `Bytes` as they could appear in Savi source code.
That is, as a string literal with the `b` prefix and non-printable bytes escaped.

`Bytes.Format.HexDump` formats `Bytes` into a "hex dump", much like the output
of the `xxd` command-line utility found on many UNIX platforms.

This latter format shows addresses, hex bytes, and corresponding ASCII characters,
in a way that is intended to facilitate debugging of large data sequences.