### PR TITLE
Fix memory safety edge case in `String.<<` and `Bytes.<<`.

### DIFF
--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -256,10 +256,11 @@
   :fun ref "<<"(other Bytes'box)
     if (other._size > 0) (
       new_size = @_size + other._size
-      @reserve(new_size)
       if other.is_null_terminated (
+        @reserve(new_size + 1)
         other._ptr._copy_to(@_ptr._offset(@_size), other.size + 1)
       |
+        @reserve(new_size)
         other._ptr._copy_to(@_ptr._offset(@_size), other.size)
       )
       @_size = new_size

--- a/core/String.savi
+++ b/core/String.savi
@@ -288,10 +288,11 @@
   :fun ref "<<"(other String'box)
     if (other._size > 0) (
       new_size = @_size + other._size
-      @reserve(new_size)
       if other.is_null_terminated (
+        @reserve(new_size + 1)
         other._ptr._copy_to(@_ptr._offset(@_size), other.size + 1)
       |
+        @reserve(new_size)
         other._ptr._copy_to(@_ptr._offset(@_size), other.size)
       )
       @_size = new_size

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -53,6 +53,20 @@
     assert: data.cpointer.is_not_null
     assert: data.cpointer.usize != orig_pointer_address
 
+  :it "reallocates to a size that includes a null terminator when appending"
+    data = Bytes.new
+    assert: data.space == 0
+    assert: data.size == 0
+
+    // This 8-byte literal has a null terminator and thus 9 bytes to copy in.
+    literal = b"Hi there"
+    // So when we reallocate the buffer for the string, it must be 16 bytes,
+    // instead of only the 8 bytes you might expect if you weren't thinking
+    // about the null terminator or weren't planning to copy it in.
+    data << literal
+    assert: data.space == 16
+    assert: data.size == 8
+
   :it "reserves additional space beyond the current size"
     data = b"0123456789012345678901234567890123456789" // 40 bytes
     assert: data.clone.reserve(32)           .space == 64

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -53,6 +53,20 @@
     assert: data.cpointer.is_not_null
     assert: data.cpointer.usize != orig_pointer_address
 
+  :it "reallocates to a size that includes a null terminator when appending"
+    data = String.new
+    assert: data.space == 0
+    assert: data.size == 0
+
+    // This 8-byte literal has a null terminator and thus 9 bytes to copy in.
+    literal = "Hi there"
+    // So when we reallocate the buffer for the string, it must be 16 bytes,
+    // instead of only the 8 bytes you might expect if you weren't thinking
+    // about the null terminator or weren't planning to copy it in.
+    data << literal
+    assert: data.space == 16
+    assert: data.size == 8
+
   :it "converts to and from an array of bytes"
     assert: "string".as_array == ['s', 't', 'r', 'i', 'n', 'g']
     assert: String.from_array("string".as_array) == "string"


### PR DESCRIPTION
Prior to this change, if the new size of the string/bytes after
appending the other one onto it was going to be exactly a
power of two, and if we were also copying an additional null
terminator byte from the other one, then this method was
violating memory safety.

Specifically, it would reserve space only for the new size,
without reserving an extra byte for the null terminator it
was going to copy. Thus when it came time to copy in the
null terminator byte, it was possibly getting written into
the first byte of another object!

In practice this was resulting in a change to the type
descriptor pointer for that other object, causing it to
behave like a different type for type match purposes
and for virtual calls, which led to further corruption
of memory and a cascade of strange behavior in the program.