### PR TITLE
Fix compiler alias analysis of the sendability of params with defaults.

### DIFF
--- a/spec/compiler/type_check.validation.savi.spec.md
+++ b/spec/compiler/type_check.validation.savi.spec.md
@@ -70,6 +70,15 @@ It allows non-sendable params to an elevated constructor if there are no fields:
 
 ---
 
+It allows the sendable param to an elevated constructor to have a default `iso` argument, without treating it as `iso'aliased`:
+
+```savi
+  :var inner String'iso: String.new_iso
+  :new iso new_iso(s String'iso = String.new_iso): @inner = --s
+```
+
+---
+
 It complains when a constant isn't of one of the supported types:
 
 ```savi


### PR DESCRIPTION
Prior to this change, an `iso` param that has a default value
was wrongly being treated as having cap `iso'aliased` when
analyzing its sendability for safety, because the inference
system was treating the result of the assignment as being
the value (which is an alias for normal assignment).

After this fix, both `DEFAULTPARAM` and `<<=` are treated as
special forms of assignment whose result value is not an alias.