### PR TITLE
Fix compiler crash on identity comparison of floating-point values.

### DIFF
--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -284,6 +284,30 @@
     assert: I32[-30] < 6
     assert: I32[6] > -30
 
+  :it "checks identity equality of integers by value"
+    assert: U32[12] === U32[12]
+    assert: I32[12] === I32[12]
+    assert: (U32[12] === U32[36]).is_false
+    assert: (I32[12] === I32[36]).is_false
+    assert: (U32[12] !== U32[12]).is_false
+    assert: (I32[12] !== I32[12]).is_false
+    assert: U32[12] !== U32[36]
+    assert: I32[12] !== I32[36]
+
+  :it "checks identity equality of floating point values by their bits"
+    assert: F32[12] === F32[12]
+    assert: F64[12] === F64[12]
+    assert: (F32[12] === F32[36]).is_false
+    assert: (F64[12] === F64[36]).is_false
+    assert: (F32[12] !== F32[12]).is_false
+    assert: (F64[12] !== F64[12]).is_false
+    assert: F32[12] !== F32[36]
+    assert: F64[12] !== F64[36]
+    assert: F32.nan === F32.nan // NaN values are comparable by their bits
+    assert: F64.nan === F64.nan // NaN values are comparable by their bits
+    assert: F32.nan !== F32[36]
+    assert: F64.nan !== F64[36]
+
   :it "applies arithmetic operations"
     assert: U32[6]  + 30  == 36
     assert: I32[-6] + 30  == 24

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -2160,6 +2160,20 @@ class Savi::Compiler::CodeGen
     rhs = gen_expr(relate.rhs)
     pred = positive_check ? LLVM::IntPredicate::EQ : LLVM::IntPredicate::NE
 
+    # If the values are floating point values, they should be compared by their
+    # bits, so that we can avoid complexities with things like NaN comparison.
+    # We define floating point identity to be defined in terms of its bits.
+    if lhs.type.kind == LLVM::Type::Kind::Double
+      lhs = @builder.bit_cast(lhs, @i64)
+    elsif lhs.type.kind == LLVM::Type::Kind::Float
+      lhs = @builder.bit_cast(lhs, @i32)
+    end
+    if rhs.type.kind == LLVM::Type::Kind::Double
+      rhs = @builder.bit_cast(rhs, @i64)
+    elsif rhs.type.kind == LLVM::Type::Kind::Float
+      rhs = @builder.bit_cast(rhs, @i32)
+    end
+
     if lhs.type.kind == LLVM::Type::Kind::Integer \
     && rhs.type.kind == LLVM::Type::Kind::Integer
       if lhs.type == rhs.type


### PR DESCRIPTION
Prior to this change, the compiler was crashing if you tried to compare the identity equality of two floating-point values of the same type. Now, the case is handled.

Values are compared by comparing their integer bits, so that there are no edge cases around things like `NaN` or various infinite values, failing to compare as they would with value equality. Identity equality is about not being able to distinguish the two operands, and any different floating-point encoded values are distinguishable by calling their `bits` method, which can reveal different results even when the bits encode a conceptually equivalent value (different bit encodings of the same real number). Similarly, NaN values even if they do not compare with `==` should have identity equality if they have exactly the same bits.