### PR TITLE
Add `clamp` methods to the `Numeric.Comparable` trait.

### DIFF
--- a/core/Array.savi
+++ b/core/Array.savi
@@ -13,11 +13,11 @@
     @_ptr = CPointer(A)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(8)
     @_ptr = CPointer(A)._alloc(@_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(8)
     @_ptr = @_ptr._realloc(@_space)
 
   :new (space USize = 0)
@@ -36,11 +36,11 @@
   :fun is_not_empty: @_size != 0
   :fun ref clear: @_size = 0, @
 
-  :fun ref truncate(size): @_size = @_size.min(size)
+  :fun ref truncate(size): @_size = @_size.clamp_max(size)
 
   :fun val trim(from USize, to USize = -1)
-    to = to.min(@_size)
-    from = from.min(to)
+    to = to.clamp_max(@_size)
+    from = from.clamp_max(to)
     size = to - from
 
     space = if (to == @_size) (
@@ -65,8 +65,8 @@
     @val_from_cpointer(ptr, size, space)
 
   :fun ref trim_in_place(from USize, to USize = -1)
-    to = to.min(@_size)
-    from = from.min(to)
+    to = to.clamp_max(@_size)
+    from = from.clamp_max(to)
     size = to - from
 
     if (to == @_size) (
@@ -195,7 +195,7 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     while (index < to) (
       yield (@_ptr._get_at(index), index)
@@ -209,7 +209,7 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.min(from) -! 1
+      index USize = @_size.clamp_max(from) -! 1
       while (index >= to) (
         yield (@_ptr._get_at(index), index)
         index = index -! stride

--- a/core/BitArray.savi
+++ b/core/BitArray.savi
@@ -13,11 +13,11 @@
     @_ptr = CPointer(U64)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(64)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(64)
     @_ptr = CPointer(U64)._alloc(@_u64_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(64)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(64)
     @_ptr = @_ptr._realloc(@_u64_space)
 
   :fun _ptr_get_at(index USize) Bool
@@ -65,7 +65,7 @@
   :fun is_not_empty: @_size != 0
   :fun ref clear: @_size = 0, @
 
-  :fun ref truncate(size): @_size = @_size.min(size)
+  :fun ref truncate(size): @_size = @_size.clamp_max(size)
 
   :: Reserve enough total space for the given number of bits.
   :: The size (number of actual bits present in the array) does not change.
@@ -145,7 +145,7 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     while (index < to) (
       // TODO: it should be possible to do fewer underlying pointer loads
@@ -163,7 +163,7 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.min(from) -! 1
+      index USize = @_size.clamp_max(from) -! 1
       while (index >= to) (
         // TODO: it should be possible to do fewer underlying pointer loads
         // by batching with an inner loop when the stride is less than 64

--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -19,11 +19,11 @@
     @_ptr = CPointer(U8)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(8)
     @_ptr = CPointer(U8)._alloc(@_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(8)
     @_ptr = @_ptr._realloc(@_space)
 
   :new ref (space USize = 0)
@@ -174,7 +174,7 @@
   :: so this method cannot violate memory safety in terms of address space.
 
   :fun ref resize_possibly_including_uninitialized_memory(size USize)
-    @_size = size.min(@_space)
+    @_size = size.clamp_max(@_space)
     @
 
   :fun "[]!"(index): @byte_at!(index)
@@ -195,7 +195,7 @@
 
   :fun val trim(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).clamp_max(@size)
 
     if (start < @_size && start < finish) (
       size = finish - start
@@ -210,7 +210,7 @@
 
   :fun ref trim_in_place(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).clamp_max(@size)
 
     if (start < @_size && start < finish) (
       @_size = finish - start
@@ -231,7 +231,7 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     while (index < to) (
       yield (@_ptr._get_at(index), index)
@@ -245,7 +245,7 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.min(from) -! 1
+      index USize = @_size.clamp_max(from) -! 1
       while (index >= to) (
         yield (@_ptr._get_at(index), index)
         index = index -! stride
@@ -277,7 +277,7 @@
     to = ISize.max_value
   )
     start = other._offset_to_index(from)
-    finish = other._offset_to_index(to).min(other.size)
+    finish = other._offset_to_index(to).clamp_max(other.size)
 
     if (start < other._size && start < finish) (
       size = finish - start
@@ -401,13 +401,13 @@
 
   :: Discard all bytes after the given offset.
   :fun ref truncate(offset USize)
-    offset = offset.min(@_size)
+    offset = offset.clamp_max(@_size)
     @_size = offset
     @
 
   :: Discard all bytes to the left of the given offset.
   :fun ref truncate_left(offset USize)
-    offset = offset.min(@_size)
+    offset = offset.clamp_max(@_size)
     @_ptr = @_ptr._offset(offset)
     @_size -= offset
     @_space -= offset
@@ -424,7 +424,7 @@
   :: If the left side later expands its size, it will then reallocate and copy,
   :: because the right side has retained claim over the right-adjacent memory.
   :fun ref chop_left(offset USize) Bytes'iso
-    offset = offset.min(@_size)
+    offset = offset.clamp_max(@_size)
     chopped = Bytes.iso_from_cpointer(@_ptr, offset, offset)
     @_size -= offset
     @_space -= offset
@@ -442,7 +442,7 @@
   :: If the left side later expands its size, it will then reallocate and copy,
   :: because the right side has retained claim over the right-adjacent memory.
   :fun ref chop_right(offset USize) Bytes'iso
-    offset = offset.min(@_size)
+    offset = offset.clamp_max(@_size)
     chopped = Bytes.iso_from_cpointer(
       if (@_space > offset) (@_ptr._offset(offset) | @_ptr._null)
       @_size - offset

--- a/core/Numeric.savi
+++ b/core/Numeric.savi
@@ -465,10 +465,43 @@
   :is Comparable(T)
 
   :: Return whichever value is the minimum of this value and the other value.
+  ::
+  :: Use the `clamp_max` alias for readability when the given other value is
+  :: meant to be seen as an upper limit for the range of possible values.
+  :: The behavior is the same, but it is confusing to the reader when the
+  :: `min` method is used to enforce a "maximum" limit on the range of values.
   :fun val min(other T) T
 
   :: Return whichever value is the maximum of this value and the other value.
+  ::
+  :: Use the `clamp_min` alias for readability when the given other value is
+  :: meant to be seen as a lower limit for the range of possible values.
+  :: The behavior is the same, but it is confusing to the reader when the
+  :: `max` method is used to enforce a "minimum" limit on the range of values.
   :fun val max(other T) T
+
+  :: If this value is less than the given maximum value, return it.
+  :: Otherwise return the given maximum value.
+  ::
+  :: This is an alias for the `min` method, which has the same behavior,
+  :: but this alias is provided to reduce reader confusion in cases where the
+  :: intent is to enforce a maximum limit (where the name `min` may confuse).
+  :fun val clamp_max(max T) T: @min(max)
+
+  :: If this value is greater than the given minimum value, return it.
+  :: Otherwise return the given minimum value.
+  ::
+  :: This is an alias for the `max` method, which has the same behavior,
+  :: but this alias is provided to reduce reader confusion in cases where the
+  :: intent is to enforce a minimum limit (where the name `max` may confuse).
+  :fun val clamp_min(min T) T: @max(min)
+
+  :: If this value is between the given minimum and maximum value, return it.
+  :: Otherwise return the given minimum value or maximum value,
+  :: depending on which of the two boundaries the value was beyond.
+  ::
+  :: This is a convenience wrapper for the `clamp_min` and `clamp_max` methods.
+  :fun val clamp(min T, max T) T: @clamp_min(min).clamp_max(max)
 
   :: Return the result of subtracting this value from zero, which will usually
   :: return a negative value of the same magnitude as the original positive,

--- a/core/String.savi
+++ b/core/String.savi
@@ -18,11 +18,11 @@
     @_ptr = CPointer(U8)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(8)
     @_ptr = CPointer(U8)._alloc(@_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.clamp_min(space).clamp_min(8)
     @_ptr = @_ptr._realloc(@_space)
 
   :new ref (space USize = 0)
@@ -189,7 +189,7 @@
 
   :fun val trim(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).clamp_max(@size)
 
     if (start < @_size && start < finish) (
       @_slice(start, finish)
@@ -199,7 +199,7 @@
 
   :fun ref trim_in_place(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).clamp_max(@size)
 
     if (start < @_size && start < finish) (
       @_size = finish - start
@@ -216,7 +216,7 @@
     @
 
   :fun each_byte(from USize = 0, to = USize.max_value, stride USize = 1)
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     while (index < to) (
       yield @_ptr._get_at(index)
@@ -227,7 +227,7 @@
   :fun each_byte_until(from USize = 0, to = USize.max_value, stride USize = 1)
     :yields for Bool
     early_stop = False
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     while (index < to && !early_stop) (
       early_stop = yield @_ptr._get_at(index)
@@ -236,7 +236,7 @@
     early_stop
 
   :fun each_byte_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     while (index < to) (
       yield (@_ptr._get_at(index), index)
@@ -263,7 +263,7 @@
   :fun each_char_with_index_and_width(from USize = 0, to = USize.max_value)
     codepoint U32 = 0
     state U8 = 0
-    to = @_size.min(to)
+    to = @_size.clamp_max(to)
     index = from
     start_index = index
 
@@ -305,7 +305,7 @@
     to = ISize.max_value
   )
     start = other._offset_to_index(from)
-    finish = other._offset_to_index(to).min(other.size)
+    finish = other._offset_to_index(to).clamp_max(other.size)
 
     if (start < other._size && start < finish) (
       size = finish - start

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -337,6 +337,21 @@
     assert: U32[30].max(6) == 30
     assert: U32[6].max(30) == 30
 
+  :it "clamps the value to be between the given minimum and/or maximum values"
+    assert: 89.clamp_min(90) == 90
+    assert: 90.clamp_min(90) == 90
+    assert: 91.clamp_min(90) == 91
+    assert: 99.clamp_max(100) == 99
+    assert: 100.clamp_max(100) == 100
+    assert: 101.clamp_max(100) == 100
+
+    assert: 89.clamp(90, 100) == 90
+    assert: 90.clamp(90, 100) == 90
+    assert: 91.clamp(90, 100) == 91
+    assert: 99.clamp(90, 100) == 99
+    assert: 100.clamp(90, 100) == 100
+    assert: 101.clamp(90, 100) == 100
+
   :it "finds the absolute value"
     assert: U32[36]  .abs == 36
     assert: U32[-36] .abs == -36 // -36 is an underflow literal when unsigned


### PR DESCRIPTION
These are convenience wrappers/aliases for the `min` and `max` methods,
but are rephrased to be less confusing for the case of using
`min` to set a maximum limit, or `max` to set a minimum limit.

See discussion in https://savi.zulipchat.com/#narrow/stream/294906-libraries/topic/Numeric.2Emin.20and.20Numeric.2Emax