### PR TITLE
Add `Numeric.Comparable.at_most` and `.at_least`.

### DIFF
--- a/core/Array.savi
+++ b/core/Array.savi
@@ -13,11 +13,11 @@
     @_ptr = CPointer(A)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.at_least(space).at_least(8)
     @_ptr = CPointer(A)._alloc(@_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.at_least(space).at_least(8)
     @_ptr = @_ptr._realloc(@_space)
 
   :new (space USize = 0)
@@ -36,11 +36,11 @@
   :fun is_not_empty: @_size != 0
   :fun ref clear: @_size = 0, @
 
-  :fun ref truncate(size): @_size = @_size.min(size)
+  :fun ref truncate(size): @_size = @_size.at_most(size)
 
   :fun val trim(from USize, to USize = -1)
-    to = to.min(@_size)
-    from = from.min(to)
+    to = to.at_most(@_size)
+    from = from.at_most(to)
     size = to - from
 
     space = if (to == @_size) (
@@ -65,8 +65,8 @@
     @val_from_cpointer(ptr, size, space)
 
   :fun ref trim_in_place(from USize, to USize = -1)
-    to = to.min(@_size)
-    from = from.min(to)
+    to = to.at_most(@_size)
+    from = from.at_most(to)
     size = to - from
 
     if (to == @_size) (
@@ -195,7 +195,7 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     while (index < to) (
       yield (@_ptr._get_at(index), index)
@@ -209,7 +209,7 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.min(from) -! 1
+      index USize = @_size.at_most(from) -! 1
       while (index >= to) (
         yield (@_ptr._get_at(index), index)
         index = index -! stride

--- a/core/BitArray.savi
+++ b/core/BitArray.savi
@@ -13,11 +13,11 @@
     @_ptr = CPointer(U64)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(64)
+    @_space = space.next_pow2.at_least(space).at_least(64)
     @_ptr = CPointer(U64)._alloc(@_u64_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(64)
+    @_space = space.next_pow2.at_least(space).at_least(64)
     @_ptr = @_ptr._realloc(@_u64_space)
 
   :fun _ptr_get_at(index USize) Bool
@@ -65,7 +65,7 @@
   :fun is_not_empty: @_size != 0
   :fun ref clear: @_size = 0, @
 
-  :fun ref truncate(size): @_size = @_size.min(size)
+  :fun ref truncate(size): @_size = @_size.at_most(size)
 
   :: Reserve enough total space for the given number of bits.
   :: The size (number of actual bits present in the array) does not change.
@@ -145,7 +145,7 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     while (index < to) (
       // TODO: it should be possible to do fewer underlying pointer loads
@@ -163,7 +163,7 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.min(from) -! 1
+      index USize = @_size.at_most(from) -! 1
       while (index >= to) (
         // TODO: it should be possible to do fewer underlying pointer loads
         // by batching with an inner loop when the stride is less than 64

--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -19,11 +19,11 @@
     @_ptr = CPointer(U8)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.at_least(space).at_least(8)
     @_ptr = CPointer(U8)._alloc(@_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.at_least(space).at_least(8)
     @_ptr = @_ptr._realloc(@_space)
 
   :new ref (space USize = 0)
@@ -174,7 +174,7 @@
   :: so this method cannot violate memory safety in terms of address space.
 
   :fun ref resize_possibly_including_uninitialized_memory(size USize)
-    @_size = size.min(@_space)
+    @_size = size.at_most(@_space)
     @
 
   :fun "[]!"(index): @byte_at!(index)
@@ -195,7 +195,7 @@
 
   :fun val trim(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).at_most(@size)
 
     if (start < @_size && start < finish) (
       size = finish - start
@@ -210,7 +210,7 @@
 
   :fun ref trim_in_place(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).at_most(@size)
 
     if (start < @_size && start < finish) (
       @_size = finish - start
@@ -231,7 +231,7 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     while (index < to) (
       yield (@_ptr._get_at(index), index)
@@ -245,7 +245,7 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.min(from) -! 1
+      index USize = @_size.at_most(from) -! 1
       while (index >= to) (
         yield (@_ptr._get_at(index), index)
         index = index -! stride
@@ -277,7 +277,7 @@
     to = ISize.max_value
   )
     start = other._offset_to_index(from)
-    finish = other._offset_to_index(to).min(other.size)
+    finish = other._offset_to_index(to).at_most(other.size)
 
     if (start < other._size && start < finish) (
       size = finish - start
@@ -350,11 +350,11 @@
     @
 
   :fun "<"(other Bytes'box)
-    min_size = @size.min(other.size)
+    shared_size = @size.at_most(other.size)
     index USize = 0
     result = False
     try (
-      while (index < min_size) (
+      while (index < shared_size) (
         a = @_ptr._get_at(index)
         b = other._ptr._get_at(index)
         case (
@@ -368,11 +368,11 @@
     result
 
   :fun "<="(other Bytes'box)
-    min_size = @size.min(other.size)
+    shared_size = @size.at_most(other.size)
     index USize = 0
     result = False
     try (
-      while (index < min_size) (
+      while (index < shared_size) (
         a = @_ptr._get_at(index)
         b = other._ptr._get_at(index)
         case (
@@ -401,13 +401,13 @@
 
   :: Discard all bytes after the given offset.
   :fun ref truncate(offset USize)
-    offset = offset.min(@_size)
+    offset = offset.at_most(@_size)
     @_size = offset
     @
 
   :: Discard all bytes to the left of the given offset.
   :fun ref truncate_left(offset USize)
-    offset = offset.min(@_size)
+    offset = offset.at_most(@_size)
     @_ptr = @_ptr._offset(offset)
     @_size -= offset
     @_space -= offset
@@ -424,7 +424,7 @@
   :: If the left side later expands its size, it will then reallocate and copy,
   :: because the right side has retained claim over the right-adjacent memory.
   :fun ref chop_left(offset USize) Bytes'iso
-    offset = offset.min(@_size)
+    offset = offset.at_most(@_size)
     chopped = Bytes.iso_from_cpointer(@_ptr, offset, offset)
     @_size -= offset
     @_space -= offset
@@ -442,7 +442,7 @@
   :: If the left side later expands its size, it will then reallocate and copy,
   :: because the right side has retained claim over the right-adjacent memory.
   :fun ref chop_right(offset USize) Bytes'iso
-    offset = offset.min(@_size)
+    offset = offset.at_most(@_size)
     chopped = Bytes.iso_from_cpointer(
       if (@_space > offset) (@_ptr._offset(offset) | @_ptr._null)
       @_size - offset

--- a/core/Numeric.savi
+++ b/core/Numeric.savi
@@ -464,11 +464,19 @@
 :trait Numeric.Comparable(T Numeric(T)'val)
   :is Comparable(T)
 
-  :: Return whichever value is the minimum of this value and the other value.
-  :fun val min(other T) T
+  :: If this value is greater than the given minimum value, return it.
+  :: Otherwise return the given minimum value.
+  :fun val at_least(minimum T) T
 
-  :: Return whichever value is the maximum of this value and the other value.
+  :: DEPRECATED: use the `at_least` method instead.
   :fun val max(other T) T
+
+  :: If this value is less than the given maximum value, return it.
+  :: Otherwise return the given maximum value.
+  :fun val at_most(maximum T) T
+
+  :: DEPRECATED: use the `at_most` method instead.
+  :fun val min(other T) T
 
   :: Return the result of subtracting this value from zero, which will usually
   :: return a negative value of the same magnitude as the original positive,
@@ -549,8 +557,10 @@
   :fun ">"(other @'box) Bool: compiler intrinsic
   :fun ">="(other @'box) Bool: compiler intrinsic
   :fun val negate: @zero - @
-  :fun val min(other @) @: if (@ < other) (@ | other)
-  :fun val max(other @) @: if (@ > other) (@ | other)
+  :fun val at_least(minimum @) @: if (@ > minimum) (@ | minimum)
+  :fun val at_most(maximum @) @: if (@ < maximum) (@ | maximum)
+  :fun val max(other @) @: @at_least(other)
+  :fun val min(other @) @: @at_most(other)
   :fun val abs: if (@is_signed && @ < @zero) (@zero - @ | @)
 
 :: The standard 8-bit unsigned integer numeric type.

--- a/core/String.savi
+++ b/core/String.savi
@@ -18,11 +18,11 @@
     @_ptr = CPointer(U8)._null
 
   :fun ref _ptr_allocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.at_least(space).at_least(8)
     @_ptr = CPointer(U8)._alloc(@_space)
 
   :fun ref _ptr_reallocate(space USize)
-    @_space = space.next_pow2.max(space).max(8)
+    @_space = space.next_pow2.at_least(space).at_least(8)
     @_ptr = @_ptr._realloc(@_space)
 
   :new ref (space USize = 0)
@@ -189,7 +189,7 @@
 
   :fun val trim(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).at_most(@size)
 
     if (start < @_size && start < finish) (
       @_slice(start, finish)
@@ -199,7 +199,7 @@
 
   :fun ref trim_in_place(from ISize = 0, to = ISize.max_value)
     start = @_offset_to_index(from)
-    finish = @_offset_to_index(to).min(@size)
+    finish = @_offset_to_index(to).at_most(@size)
 
     if (start < @_size && start < finish) (
       @_size = finish - start
@@ -216,7 +216,7 @@
     @
 
   :fun each_byte(from USize = 0, to = USize.max_value, stride USize = 1)
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     while (index < to) (
       yield @_ptr._get_at(index)
@@ -227,7 +227,7 @@
   :fun each_byte_until(from USize = 0, to = USize.max_value, stride USize = 1)
     :yields for Bool
     early_stop = False
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     while (index < to && !early_stop) (
       early_stop = yield @_ptr._get_at(index)
@@ -236,7 +236,7 @@
     early_stop
 
   :fun each_byte_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     while (index < to) (
       yield (@_ptr._get_at(index), index)
@@ -263,7 +263,7 @@
   :fun each_char_with_index_and_width(from USize = 0, to = USize.max_value)
     codepoint U32 = 0
     state U8 = 0
-    to = @_size.min(to)
+    to = @_size.at_most(to)
     index = from
     start_index = index
 
@@ -305,7 +305,7 @@
     to = ISize.max_value
   )
     start = other._offset_to_index(from)
-    finish = other._offset_to_index(to).min(other.size)
+    finish = other._offset_to_index(to).at_most(other.size)
 
     if (start < other._size && start < finish) (
       size = finish - start
@@ -385,11 +385,11 @@
     @val_from_cpointer(@_ptr._offset(start), size, size)
 
   :fun "<"(other String'box)
-    min_size = @size.min(other.size)
+    shared_size = @size.at_most(other.size)
     index USize = 0
     result = False
     try (
-      while (index < min_size) (
+      while (index < shared_size) (
         a = @_ptr._get_at(index)
         b = other._ptr._get_at(index)
         case (
@@ -403,11 +403,11 @@
     result
 
   :fun "<="(other String'box)
-    min_size = @size.min(other.size)
+    shared_size = @size.at_most(other.size)
     index USize = 0
     result = False
     try (
-      while (index < min_size) (
+      while (index < shared_size) (
         a = @_ptr._get_at(index)
         b = other._ptr._get_at(index)
         case (

--- a/spec/core/Numeric.Spec.savi
+++ b/spec/core/Numeric.Spec.savi
@@ -331,11 +331,14 @@
     assert: I8[-128] / -1 == 0
     assert: I8[-128] / -1 == 0
 
-  :it "finds the minimum or maximum value between the two compared values"
-    assert: U32[6].min(30) == 6
-    assert: U32[30].min(6) == 6
-    assert: U32[30].max(6) == 30
-    assert: U32[6].max(30) == 30
+  :it "limits a value to be at least a given minimum or at most a given maximum"
+    assert: 89.at_least(90) == 90
+    assert: 90.at_least(90) == 90
+    assert: 91.at_least(90) == 91
+
+    assert: 99.at_most(100) == 99
+    assert: 100.at_most(100) == 100
+    assert: 101.at_most(100) == 100
 
   :it "finds the absolute value"
     assert: U32[36]  .abs == 36


### PR DESCRIPTION
These replace the now-deprecated `min` and `max`, respectively.

The new naming is less likely to confuse the reader in the
very common usage of using these methods to enforce a given
maximum limit (using `min`/`at_most`) or
minimum limit (using `max`/`at_least`).

See discussion in https://savi.zulipchat.com/#narrow/stream/294906-libraries/topic/Numeric.2Emin.20and.20Numeric.2Emax