### PR TITLE
Refactor the `namespace` pass to track by package instead of file.

### DIFF
--- a/spec/compiler/infer/meta_type_spec.cr
+++ b/spec/compiler/infer/meta_type_spec.cr
@@ -11,7 +11,7 @@ describe Savi::Compiler::Infer::MetaType do
 
   it "implements logical operators that keep the expression in DNF form" do
     package = Savi::Program::Package.new(
-      Savi::Source::Package.new("(example)")
+      Savi::Source::Package.new("", "(example)")
     )
 
     new_type = ->(s : String, is_abstract : Bool) {

--- a/spec/compiler/namespace_spec.cr
+++ b/spec/compiler/namespace_spec.cr
@@ -9,7 +9,7 @@ describe Savi::Compiler::Namespace do
     ctx1 = Savi.compiler.test_compile([source], :namespace)
     ctx2 = Savi.compiler.test_compile([source], :namespace)
 
-    ctx1.namespace[source].should eq ctx2.namespace[source]
+    ctx1.namespace[source.package].should eq ctx2.namespace[source.package]
   end
 
   # TODO: Figure out how to test these in our test suite - they need a package.

--- a/spec/compiler/refer_spec.cr
+++ b/spec/compiler/refer_spec.cr
@@ -13,10 +13,10 @@ describe Savi::Compiler::Refer do
     ctx1 = Savi.compiler.test_compile([source], :refer)
     ctx2 = Savi.compiler.test_compile([source], :refer)
 
-    t_link_g = ctx1.namespace[source]["Greeting"].as(Savi::Program::Type::Link)
+    t_link_g = ctx1.namespace[source.package]["Greeting"].as(Savi::Program::Type::Link)
     f_link_g = t_link_g.make_func_link_simple("greet")
 
-    t_link_m = ctx1.namespace[source]["Main"].as(Savi::Program::Type::Link)
+    t_link_m = ctx1.namespace[source.package]["Main"].as(Savi::Program::Type::Link)
     f_link_m = t_link_m.make_func_link_simple("new")
 
     # Prove that the output states are the same.

--- a/spec/compiler/refer_type_spec.cr
+++ b/spec/compiler/refer_type_spec.cr
@@ -15,10 +15,10 @@ describe Savi::Compiler::ReferType do
     ctx1.errors.should be_empty
     ctx2.errors.should be_empty
 
-    t_link_g = ctx1.namespace[source]["Greeting"].as(Savi::Program::Type::Link)
+    t_link_g = ctx1.namespace[source.package]["Greeting"].as(Savi::Program::Type::Link)
     f_link_g = t_link_g.make_func_link_simple("greet")
 
-    t_link_m = ctx1.namespace[source]["Main"].as(Savi::Program::Type::Link)
+    t_link_m = ctx1.namespace[source.package]["Main"].as(Savi::Program::Type::Link)
     f_link_m = t_link_m.make_func_link_simple("new")
 
     # Prove that the output states are the same.

--- a/spec/compiler/reparse_spec.cr
+++ b/spec/compiler/reparse_spec.cr
@@ -153,7 +153,7 @@ describe Savi::Compiler::Reparse do
       ]
     ]
 
-    type = ctx.namespace[source]["Example"].resolve(ctx).as(Savi::Program::Type)
+    type = ctx.namespace[source.package]["Example"].resolve(ctx).as(Savi::Program::Type)
     func = ctx.namespace.find_func!(ctx, source, "Example", "example")
     type.params.not_nil!.to_a.should eq [:group, "(", [:relate,
       [:ident, "T"],

--- a/spec/compiler/t_infer/meta_type_spec.cr
+++ b/spec/compiler/t_infer/meta_type_spec.cr
@@ -1,7 +1,7 @@
 describe Savi::Compiler::TInfer::MetaType do
   it "implements logical operators that keep the expression in DNF form" do
     package = Savi::Program::Package.new(
-      Savi::Source::Package.new("(example)")
+      Savi::Source::Package.new("", "(example)")
     )
 
     new_type = ->(s : String, is_abstract : Bool) {

--- a/spec/compiler/type_context_spec.cr
+++ b/spec/compiler/type_context_spec.cr
@@ -16,7 +16,7 @@ describe Savi::Compiler::TypeContext do
     ctx = Savi.compiler.test_compile([source], :type_context)
     ctx.errors.should be_empty
 
-    t_link = ctx.namespace[source]["Container"].as(Savi::Program::Type::Link)
+    t_link = ctx.namespace[source.package]["Container"].as(Savi::Program::Type::Link)
     f_link = t_link.make_func_link_simple("string")
     func = f_link.resolve(ctx)
     type_context = ctx.type_context[f_link]

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -233,7 +233,7 @@ class Savi::Compiler
     loop {
       sources =
         if options.skip_manifest
-          source_service.get_directory_sources(dirname)
+          source_service.get_directory_sources(dirname, Source::Package::NONE)
         else
           source_service.get_manifest_sources_at_or_above(dirname)
         end

--- a/src/savi/compiler/namespace.cr
+++ b/src/savi/compiler/namespace.cr
@@ -7,80 +7,62 @@
 # This pass does not mutate the AST.
 # This pass may raise a compilation error.
 # This pass keeps state at the program level.
-# This pass produces output state at the source and source package level.
+# This pass produces output state at the source package level.
 #
 class Savi::Compiler::Namespace
-  struct Analysis
-    getter source : Source
-    protected getter types
-
-    def initialize(@source)
-      @types = {} of String => (
-        Program::Type::Link | Program::TypeAlias::Link | Program::TypeWithValue::Link \
-      )
-    end
-
-    def [](name : String); @types[name]; end
-    def []?(name : String); @types[name]?; end
-  end
+  alias Analysis = Hash(String,
+    Program::Type::Link | Program::TypeAlias::Link | Program::TypeWithValue::Link
+  )
 
   def initialize
-    @types_by_package_name = Hash(String, Hash(String,
-      Program::Type::Link | Program::TypeAlias::Link | Program::TypeWithValue::Link
-    )).new
-    @source_analyses = Hash(Source, Analysis).new
+    @packages_by_name = Hash(String, Program::Package::Link).new
+    @types_by_package = Hash(Program::Package::Link, Analysis).new
+    @accessible_types_by_package = Hash(Program::Package::Link, Analysis).new
   end
 
   def main_type!(ctx); main_type?(ctx).not_nil! end
   def main_type?(ctx): Program::Type::Link?
-    @types_by_package_name[ctx.root_package_link.name]["Main"]?.as(Program::Type::Link?)
+    @types_by_package[ctx.root_package_link]["Main"]?.as(Program::Type::Link?)
   end
 
   def run(ctx)
-    # Take note of the package and source file in which each type occurs.
+    # Take note of all packages and types within them.
     ctx.program.packages.each do |package|
+      @packages_by_name[package.name] ||= package.make_link
+      @types_by_package[package.make_link] = Analysis.new
+      @accessible_types_by_package[package.make_link] = Analysis.new
+
       package.types.each do |t|
         check_valid_name(ctx, t)
         check_conflicting_functions(ctx, t, t.make_link(package))
         add_type_to_package(ctx, t, package)
-        add_type_to_source(t, package)
+        add_type_to_accessible_types(t, package)
       end
       package.aliases.each do |t|
         check_valid_name(ctx, t)
         add_type_to_package(ctx, t, package)
-        add_type_to_source(t, package)
+        add_type_to_accessible_types(t, package)
       end
       package.enum_members.each do |t|
         check_valid_name(ctx, t)
         add_type_to_package(ctx, t, package)
-        add_type_to_source(t, package)
+        add_type_to_accessible_types(t, package)
       end
     end
 
-    # Every source file implicitly has access to all core Savi types.
-    @source_analyses.each do |source, source_analysis|
-      add_core_savi_types_to_source(ctx, source, source_analysis)
+    # Every package implicitly has access to all core Savi types.
+    @accessible_types_by_package.each do |package_link, analysis|
+      add_core_savi_types_to_accessible_types(ctx, package_link, analysis)
     end
 
-    # Every source file implicitly has access to all types in the same package.
-    ctx.program.packages.each do |package|
-      @source_analyses.each do |source, source_analysis|
-        next unless source.package == package.source_package
-
-        types_map = @types_by_package_name[package.name]?
-        next unless types_map
-
-        source_analysis.types.merge!(types_map)
-      end
-    end
-
-    # Every source file has access to types loaded via its package manifest.
+    # Every package has access to types loaded via its package manifest.
     unless ctx.options.skip_manifest
-      @source_analyses.each { |source, source_analysis|
-        manifest = ctx.manifests.manifests_by_name[source.package.name]? || \
+      ctx.program.packages.each { |package|
+        manifest =
+          ctx.manifests.manifests_by_name[package.source_package.name]? || \
           ctx.manifests.root.not_nil!
 
-        add_dependencies_to_source(ctx, source, source_analysis, manifest)
+        add_dependencies_to_accessible_types(ctx, package, manifest)
       }
     end
   end
@@ -89,27 +71,39 @@ class Savi::Compiler::Namespace
   def add_lambda_type_later(ctx : Context, new_type : Program::Type, package : Program::Package)
     check_conflicting_functions(ctx, new_type, new_type.make_link(package))
     add_type_to_package(ctx, new_type, package)
-    add_type_to_source(new_type, package)
+    add_type_to_accessible_types(new_type, package)
   end
 
-  # When given a Source, return the set of analysis for that source.
-  def [](source : Source) : Analysis
-    @source_analyses[source]
+  # When given a package link, return the set of types accessible within it.
+  def [](package : Program::Package::Link) : Analysis
+    @accessible_types_by_package[package]
   end
-  def []?(source : Source) : Analysis?
-    @source_analyses[source]?
+  def []?(package : Program::Package::Link) : Analysis?
+    @accessible_types_by_package[package]?
+  end
+
+  # When given a source package, return the set of types accessible within it.
+  def [](source_package : Source::Package) : Analysis
+    @accessible_types_by_package[Program::Package.link(source_package)]
+  end
+  def []?(source_package : Source::Package) : Analysis?
+    @accessible_types_by_package[Program::Package.link(source_package)]?
+  end
+
+  def core_savi_package_link
+    @packages_by_name["Savi"]
   end
 
   # When given a String name, try to find the type in the core_savi package.
   # This is a way to resolve a builtin type by name without more context.
   def core_savi_type(ctx, name : String) : Program::Type::Link
-    @types_by_package_name["Savi"][name].as(Program::Type::Link)
+    @types_by_package[core_savi_package_link][name].as(Program::Type::Link)
   end
 
   # TODO: Remove this method?
   # This is only for use in testing.
   def find_func!(ctx, source, type_name, func_name)
-    self[source][type_name].as(Program::Type::Link).resolve(ctx).find_func!(func_name)
+    self[source.package][type_name].as(Program::Type::Link).resolve(ctx).find_func!(func_name)
   end
 
   private def check_valid_name(ctx, t)
@@ -133,12 +127,7 @@ class Savi::Compiler::Namespace
   private def add_type_to_package(ctx, new_type, package)
     name = new_type.ident.value
 
-    package_name = package.source_package.name
-    return unless package_name
-
-    types = @types_by_package_name[package_name] ||= Hash(String,
-      Program::Type::Link | Program::TypeAlias::Link | Program::TypeWithValue::Link
-    ).new
+    types = @types_by_package[package.make_link]
 
     already_type_link = types[name]?
     if already_type_link
@@ -153,23 +142,22 @@ class Savi::Compiler::Namespace
     types[name] = new_type.make_link(package)
   end
 
-  private def add_type_to_source(new_type, package)
-    source = new_type.ident.pos.source
+  private def add_type_to_accessible_types(new_type, package)
     name = new_type.ident.value
 
-    source_analysis = @source_analyses[source] ||= Analysis.new(source)
+    types = @accessible_types_by_package[package.make_link]
 
-    source_analysis.types[name] = new_type.make_link(package)
+    types[name] = new_type.make_link(package)
   end
 
-  private def add_core_savi_types_to_source(ctx, source, source_analysis)
-    return if source.package.path == ctx.compiler.source_service.core_savi_package_path
+  private def add_core_savi_types_to_accessible_types(ctx, package_link, analysis)
+    return if package_link.path == ctx.compiler.source_service.core_savi_package_path
 
-    @types_by_package_name["Savi"].each do |name, new_type_link|
+    @types_by_package[core_savi_package_link].each do |name, new_type_link|
       new_type = new_type_link.resolve(ctx)
       next if new_type.ident.value.starts_with?("_") # skip private types
 
-      already_type = source_analysis.types[name]?.try(&.resolve(ctx))
+      already_type = analysis[name]?.try(&.resolve(ctx))
       if already_type
         ctx.error_at already_type.ident.pos,
           "This type's name conflicts with a mandatory built-in type", [
@@ -178,21 +166,24 @@ class Savi::Compiler::Namespace
         next
       end
 
-      source_analysis.types[name] = new_type_link
+      analysis[name] = new_type_link
     end
   end
 
-  private def add_dependencies_to_source(ctx, source, source_analysis, manifest)
+  private def add_dependencies_to_accessible_types(ctx, package, manifest)
+    analysis = @accessible_types_by_package[package.make_link]
+
     manifest.dependencies.each { |dep|
       next if dep.transitive?
 
       dep_manifest = ctx.manifests.manifests_by_name[dep.name.value]
+      dep_package = @packages_by_name[dep.name.value]
 
-      @types_by_package_name[dep_manifest.name.value].each { |name, new_type_link|
+      @types_by_package[dep_package].each { |name, new_type_link|
         new_type = new_type_link.resolve(ctx)
         next if new_type.ident.value.starts_with?("_") # skip private types
 
-        already_type = source_analysis.types[name]?.try(&.resolve(ctx))
+        already_type = analysis[name]?.try(&.resolve(ctx))
         if already_type
           ctx.error_at already_type.ident.pos,
             "This type's name conflicts with a type defined in another package", [
@@ -201,7 +192,7 @@ class Savi::Compiler::Namespace
           next
         end
 
-        source_analysis.types[name] = new_type_link
+        analysis[name] = new_type_link
       }
     }
   end

--- a/src/savi/compiler/populate.cr
+++ b/src/savi/compiler/populate.cr
@@ -97,13 +97,13 @@ class Savi::Compiler::Populate
       case ret
       when AST::Identifier
         source_ident = ret
-        source_link = ctx.namespace[source_ident.pos.source][source_ident.value]?
+        source_link = ctx.namespace[source_ident.pos.source.package][source_ident.value]?
         Error.at ret, "This type couldn't be resolved" unless source_link
         source_link = source_link.as(Program::Type::Link) # TODO: handle cases of Program::TypeAlias::Link or type param
         source_defn = source_link.resolve(ctx)
       when AST::Qualify
         source_ident = ret.term.as(AST::Identifier)
-        source_link = ctx.namespace[source_ident.pos.source][source_ident.value]?
+        source_link = ctx.namespace[source_ident.pos.source.package][source_ident.value]?
         Error.at ret, "This type couldn't be resolved" unless source_link
         source_link = source_link.as(Program::Type::Link) # TODO: handle cases of Program::TypeAlias::Link or type param
         source_defn = source_link.resolve(ctx)

--- a/src/savi/compiler/reparse.cr
+++ b/src/savi/compiler/reparse.cr
@@ -70,7 +70,7 @@ class Savi::Compiler::Reparse < Savi::AST::CopyOnMutateVisitor
 
   def self.run(ctx, package)
     package = package.types_map_cow do |t|
-      t_namespace = ctx.namespace[t.ident.pos.source]
+      t_namespace = ctx.namespace[t.ident.pos.source.package]
       t_deps = {t_namespace}
 
       t = t_cached_or_run ctx, package, t, t_deps do
@@ -78,7 +78,7 @@ class Savi::Compiler::Reparse < Savi::AST::CopyOnMutateVisitor
       end
 
       t.functions_map_cow do |f|
-        f_namespace = ctx.namespace[f.ident.pos.source]
+        f_namespace = ctx.namespace[f.ident.pos.source.package]
         f_deps = {f_namespace}
 
         cached_or_run ctx, package, t, f, f_deps do
@@ -88,7 +88,7 @@ class Savi::Compiler::Reparse < Savi::AST::CopyOnMutateVisitor
     end
 
     package = package.aliases_map_cow do |t|
-      t_namespace = ctx.namespace[t.ident.pos.source]
+      t_namespace = ctx.namespace[t.ident.pos.source.package]
       t_deps = {t_namespace}
 
       ta_cached_or_run ctx, package, t, t_deps do

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -73,9 +73,13 @@ class Savi::Program
       Link.new(source_package.path, source_package.name)
     end
 
+    def self.link(source_package : Source::Package)
+      Link.new(source_package.path, source_package.name)
+    end
+
     struct Link
       getter path : String
-      getter name : String?
+      getter name : String
       def initialize(@path, @name)
       end
       def source_package
@@ -472,6 +476,7 @@ class Savi::Program
       def initialize(@type, @name, @hygienic_id)
       end
       def is_hygienic?; hygienic_id != nil; end
+      def package; type.package; end
       def resolve(ctx : Compiler::Context)
         functions = @type.resolve(ctx).functions
         if hygienic_id

--- a/src/savi/server.cr
+++ b/src/savi/server.cr
@@ -167,7 +167,7 @@ class Savi::Server
   def handle(req : LSP::Message::Formatting)
     filename = req.params.text_document.uri.path.not_nil!
     dirname = File.dirname(filename)
-    sources = Savi.compiler.source_service.get_directory_sources(dirname)
+    sources = Savi.compiler.source_service.get_directory_sources(dirname, Source::Package::NONE)
     options = Savi::Compiler::Options.new
     options.skip_manifest = true
 
@@ -190,7 +190,7 @@ class Savi::Server
   def handle(req : LSP::Message::RangeFormatting)
     filename = req.params.text_document.uri.path.not_nil!
     dirname = File.dirname(filename)
-    sources = Savi.compiler.source_service.get_directory_sources(dirname)
+    sources = Savi.compiler.source_service.get_directory_sources(dirname, Source::Package::NONE)
     options = Savi::Compiler::Options.new
     options.skip_manifest = true
 
@@ -214,7 +214,7 @@ class Savi::Server
   def handle(req : LSP::Message::OnTypeFormatting)
     filename = req.params.text_document.uri.path.not_nil!
     dirname = File.dirname(filename)
-    sources = Savi.compiler.source_service.get_directory_sources(dirname)
+    sources = Savi.compiler.source_service.get_directory_sources(dirname, Source::Package::NONE)
     options = Savi::Compiler::Options.new
     options.skip_manifest = true
 
@@ -235,7 +235,7 @@ class Savi::Server
   def handle(req : LSP::Message::Completion)
     pos = req.params.position
     path = req.params.text_document.uri.path
-    source = Savi.compiler.source_service.get_source_at(path)
+    source = Savi.compiler.source_service.get_source_at(path, Source::Package::NONE)
     text = source.content
 
     @wire.respond req do |msg|

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -28,12 +28,12 @@ end
 
 struct Savi::Source::Package
   property path : String
-  property name : String?
+  property name : String
 
-  def initialize(@path, @name = nil)
+  def initialize(@path, @name)
   end
 
-  NONE = new("")
+  NONE = new("", "(none)")
   def self.none; NONE end
 
   def self.for_manifest(manifest : Packaging::Manifest)


### PR DESCRIPTION
Now that we have the new package management system,
the set of types available in any given context is determined
by the dependencies declared for that package, rather than
being able to load different sets of dependencies for each source file.

We can now simplify and reduce the memory and CPU footprint of the
namespace pass as a result of that language change.