### PR TITLE
Add support for (cross-compiling to) Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built runtime bitcode from.
 # This needs to get bumped explicitly here when we do a new runtime build.
-RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/20220206
+RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/v0.20220505.0
 $(eval $(call MAKE_VAR_CACHE_FOR,RUNTIME_BITCODE_RELEASE_URL))
 
 # This is the path where we look for the LLVM pre-built static libraries to be,

--- a/main.cr
+++ b/main.cr
@@ -21,6 +21,7 @@ module Savi
       option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
       option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
+      option "-X", "--cross-compile=TRIPLE", desc: "Cross compile to the given target triple"
       option "-C", "--cd=DIR", desc: "Change the working directory"
       option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
       run do |opts, args|
@@ -33,6 +34,7 @@ module Savi
         options.llvm_keep_fns = true if opts.llvm_keep_fns
         options.auto_fix = true if opts.fix
         options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
+        options.cross_compile = opts.cross_compile.not_nil! if opts.cross_compile
         Dir.cd(opts.cd.not_nil!) if opts.cd
         Cli.compile options, opts.backtrace
       end
@@ -111,6 +113,7 @@ module Savi
         option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
         option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
+        option "-X", "--cross-compile=TRIPLE", desc: "Cross compile to the given target triple"
         option "-C", "--cd=DIR", desc: "Change the working directory"
         run do |opts, args|
           options = Savi::Compiler::Options.new(
@@ -122,6 +125,7 @@ module Savi
           options.llvm_keep_fns = true if opts.llvm_keep_fns
           options.auto_fix = true if opts.fix
           options.manifest_name = args.name.not_nil! if args.name
+          options.cross_compile = opts.cross_compile.not_nil! if opts.cross_compile
           Dir.cd(opts.cd.not_nil!) if opts.cd
           Cli.compile options, opts.backtrace
         end

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -11,6 +11,7 @@ class Savi::Compiler
     property llvm_ir = false
     property llvm_keep_fns = false
     property auto_fix = false
+    property cross_compile : String? = nil
     property manifest_name : String?
     property target_pass : Symbol?
 

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -55,6 +55,10 @@ class Savi::Compiler::BinaryObject
       elsif target.arm64?
         return "arm64-apple-macosx"
       end
+    elsif target.windows?
+      if target.x86_64? && target.msvc?
+        return "x86_64-unknown-windows-msvc"
+      end
     end
 
     raise NotImplementedError.new(target.inspect)

--- a/src/savi/compiler/context.cr
+++ b/src/savi/compiler/context.cr
@@ -4,8 +4,8 @@ class Savi::Compiler::Context
   getter program = Program.new
 
   getter classify = Classify::Pass.new
-  getter code_gen = CodeGen.new(CodeGen::PonyRT)
-  getter code_gen_verona = CodeGen.new(CodeGen::VeronaRT)
+  getter code_gen : CodeGen
+  getter code_gen_verona : CodeGen
   getter completeness = Completeness::Pass.new
   getter run = Run.new
   getter flow = Flow::Pass.new
@@ -54,6 +54,8 @@ class Savi::Compiler::Context
   getter errors = [] of Error
 
   def initialize(@compiler, @options = Compiler::Options.new, @prev_ctx = nil)
+    @code_gen = CodeGen.new(CodeGen::PonyRT, @options)
+    @code_gen_verona = CodeGen.new(CodeGen::VeronaRT, @options)
   end
 
   def root_package


### PR DESCRIPTION
Note that because Crystal doesn't fully support Windows yet,
the Savi compiler still cannot run on native Windows.
But Savi programs can, after being cross-compiled.

After this change, it is possible to build 64-bit Windows binaries
from a Linux host running the Savi compiler, after setting the
`SDK_ROOT` environment variable to point to a directory tree where
the Windows SDK libraries can be found (such as an MSVC installation),
using a command like this:

```savi
savi build --cross-compile=x86_64-unknown-windows-msvc
```

Note that the Savi compiler includes the `lld` linker inside it,
so it is not necessary to have access to the full MSVC toolchain -
only the `.lib` files must be reachable within the `SDK_ROOT` tree.

One convenient way to automate the downloading of these libraries
on non-Windows platforms is [`xwin`](https://github.com/Jake-Shadle/xwin).
For example, running the following commands should be sufficient
(after reviewing the Windows SDK license and agreeing to its terms):
```savi
xwin --accept-license 1 splat --output /tmp/xwin
env SDK_ROOT=/tmp/xwin savi build --cross-compile=x86_64-unknown-windows-msvc
```

Note that not all of the Savi standard library works on Windows yet -
getting this new compiler with cross-compilation support for Windows
will allow the Savi team to iterate on bringing each library into
full Windows support and adding Windows CI to all repos.