### PR TITLE
Add `:foreign_name` - a way to override an `:ffi` function's C name.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -389,12 +389,19 @@
 :declarator ffi
   :intrinsic
   :context type
+  :begins ffi
 
   :term variadic enum (variadic)
     :optional
   :term name_and_params NameMaybeWithParams
   :term ret Type
     :optional
+
+:declarator foreign_name
+  :intrinsic
+  :context ffi
+
+  :term name Name
 
 // TODO: Document this.
 :declarator inline

--- a/spec/language/micro_test/micro_test.savi
+++ b/spec/language/micro_test/micro_test.savi
@@ -1,10 +1,11 @@
 :module _FFI
-  :ffi variadic printf(format CPointer(U8)) I32
+  :ffi variadic libc_printf(format CPointer(U8)) I32
+    :foreign_name printf // (we use this just to test `:foreign_name` here)
 
 :class MicroTest
   :var env Env
   :new (@env)
-  :fun non _printf(f String, t String): _FFI.printf(f.cstring, t.cstring)
+  :fun non _printf(f String, t String): _FFI.libc_printf(f.cstring, t.cstring)
   :fun non print_line_break: @_printf("%s", "\n")
   :fun "[]"(text String) MicroTestInstance
     MicroTestInstance.new(@env, text)

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -544,6 +544,16 @@ module Savi::Program::Intrinsic
         raise NotImplementedError.new(declarator.pretty_inspect)
       end
 
+    # Declarations within an ffi definition.
+    when "ffi"
+      case declarator.name.value
+      when "foreign_name"
+        name = terms["name"].as(AST::Identifier)
+        scope.current_function.metadata[:ffi_link_name] = name.value
+      else
+        raise NotImplementedError.new(declarator.pretty_inspect)
+      end
+
     # Declarations within a function definition.
     when "function"
       case declarator.name.value


### PR DESCRIPTION
This allows us to bind to functions whose name is not practical
as a function name in Savi - such as an uppercase function name,
which is likely to be mistaken for a type name.

It also allows multiple FFI bindings to the same underlying C function
by allowing the Savi bindings to have different names (and possibly
different, but ABI-compatible type signatures) while binding
to the same common C function.
