### PR TITLE
Optimize vtables: skip functions with only concrete call sites.

### DIFF
--- a/src/savi/compiler/infer.cr
+++ b/src/savi/compiler/infer.cr
@@ -217,17 +217,18 @@ module Savi::Compiler::Infer
 
         called_mt.map_each_union_member { |union_member_mt|
           called_rt = union_member_mt.single!
+          is_union = called_mt != union_member_mt
 
           if func_names.is_a?(String)
             func_name = func_names
             called_link = Program::Function::Link.new(called_rt.link, func_name, nil)
             called_rf = ReifiedFunction.new(called_rt, called_link, called_mt)
-            yield({info, called_rf})
+            yield({info, called_rf, is_union})
           else
             func_names.as(Array(String)).each { |func_name|
               called_link = Program::Function::Link.new(called_rt.link, func_name, nil)
               called_rf = ReifiedFunction.new(called_rt, called_link, called_mt)
-              yield({info, called_rf})
+              yield({info, called_rf, is_union})
             }
           end
         }

--- a/src/savi/compiler/paint.cr
+++ b/src/savi/compiler/paint.cr
@@ -28,7 +28,7 @@ class Savi::Compiler::Paint
   def run(ctx)
     # Collect a mapping of the types that implement each function name.
     ctx.reach.each_type_def.each do |reach_def|
-      ctx.reach.reached_funcs_for(reach_def).each do |reach_func|
+      ctx.reach.abstractly_reached_funcs_for(reach_def).each do |reach_func|
         next if reach_func.link.is_hygienic?
         next if reach_func.reified.func(ctx).has_tag?(:ffi)
 


### PR DESCRIPTION
Prior to this change we have been including all reachable functions
in the virtual tables for virtual method dispatch, regardless of
whether the reached call sites were concrete or abstract.

Now we will only put an entry in the virtual table if there is
at least one abstract call site (including actor behavior messages).