### PR TITLE
Update to LLVM 14.0.3 and re-enable full optimizations.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,13 +31,13 @@ task:
         DEPS_INSTALL: "\
           apk add --no-cache --update \
             bash curl alpine-sdk coreutils \
-            gcc g++ clang make linux-headers llvm12-dev zlib-static \
+            gcc g++ clang make linux-headers llvm13-dev zlib-static \
             pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
         MAKE_EXTRA_ARGS: CLANG_TARGET_PLATFORM=x86_64-alpine-linux-musl
       container:
-        image: alpine:3.15
+        image: alpine:edge # TODO: use alpine:3.16 when released
 
     - name: arm64-unknown-linux-musl
       environment:
@@ -45,14 +45,14 @@ task:
         DEPS_INSTALL: "\
           apk add --no-cache --update \
             bash curl alpine-sdk coreutils \
-            gcc g++ clang make linux-headers llvm12-dev zlib-static \
+            gcc g++ clang make linux-headers llvm13-dev zlib-static \
             pcre-dev libevent-static gc-dev crystal shards libexecinfo-dev"
         # For some reason clang doesn't like it if we omit the "alpine" vendor
         # in the triple, where we'd otherwise use `arm64-unknown-linux-musl`.
         # We also need to use `aarch64` instead of `arm64` here...
         MAKE_EXTRA_ARGS: CLANG_TARGET_PLATFORM=aarch64-alpine-linux-musl
       arm_container:
-        image: alpine:3.15
+        image: alpine:edge # TODO: use alpine:3.16 when released
 
     # # TODO: Enable FreeBSD after getting it working:
     # - name: x86_64-unknown-freebsd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - crystal: "1.2.1"
+          - crystal: "1.4.1"
             os: ubuntu-20.04
             deps: sudo apt-get install -y libgc-dev
-          - crystal: "1.2.1"
+          - crystal: "1.4.1"
             os: macos-11
             deps: echo no system deps to download
     runs-on: ${{matrix.os}}

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
-LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/20220112
+LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/v14.0.3-20220506
 $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built runtime bitcode from.

--- a/shard.yml
+++ b/shard.yml
@@ -19,6 +19,6 @@ dependencies:
     github: at-grandpa/clim
     version: 0.13.0
 
-crystal: 1.2.1
+crystal: 1.4.1
 
 license: MPLv2

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -87,6 +87,9 @@ class Savi::Compiler::BinaryObject
     # Otherwise we will only run a minimal set of passes.
     LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
 
+    # Emit the combined/optimized LLVM IR to a file if requested to do so.
+    mod.print_to_file("#{Binary.path_for(ctx)}.ll") if ctx.options.llvm_ir
+
     # Write the program to disk as a binary object file.
     obj_path = "#{ctx.manifests.root.not_nil!.bin_path}.o"
     FileUtils.mkdir_p(File.dirname(obj_path))

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -83,11 +83,9 @@ class Savi::Compiler::BinaryObject
     # Link the runtime bitcode module into the generated application module.
     LibLLVM.link_modules(mod.to_unsafe, runtime.to_unsafe)
 
-    # # Now run LLVM passes, doing full optimization if in release mode.
-    # # Otherwise we will only run a minimal set of passes.
-    # # TODO: Re-enable this once we've troubleshooted the issues it is causing
-    # # on some platforms with preventing program termination/quiescence.
-    # LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
+    # Now run LLVM passes, doing full optimization if in release mode.
+    # Otherwise we will only run a minimal set of passes.
+    LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
 
     # Write the program to disk as a binary object file.
     obj_path = "#{ctx.manifests.root.not_nil!.bin_path}.o"

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -398,28 +398,6 @@ class Savi::Compiler::CodeGen
           "the dumped LLVM IR file located at: #{Binary.path_for(ctx)}.ll"}
       ]
     end
-
-    # Run the LLVM optimizer passes.
-    begin
-      registry = LLVM::PassRegistry.instance
-      registry.initialize_all
-
-      pass_manager_builder = LLVM::PassManagerBuilder.new
-      pass_manager_builder.opt_level = ctx.options.release ? 3 : 0
-      pass_manager_builder.size_level = 0
-      pass_manager_builder.use_inliner_with_threshold = ctx.options.release ? 275 : 0
-
-      fun_pass_manager = @mod.new_function_pass_manager
-      pass_manager_builder.populate fun_pass_manager
-
-      mod_pass_manager = LLVM::ModulePassManager.new
-      pass_manager_builder.populate mod_pass_manager
-
-      fun_pass_manager.run @mod
-      mod_pass_manager.run @mod
-    end
-
-    @mod.print_to_file("#{Binary.path_for(ctx)}.ll") if ctx.options.llvm_ir
   end
 
   def gen_wrapper # TODO: Bring back the JIT or remove this code.

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -167,19 +167,16 @@ class Savi::Compiler::CodeGen::PonyRT
       ]},
       {"pony_alloc_final", [@ptr, @isize], @ptr, [
         LLVM::Attribute::NoUnwind, LLVM::Attribute::InaccessibleMemOrArgMemOnly,
-        {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::NoAlias},
         {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::DereferenceableOrNull, HEAP_MIN},
         {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::Alignment, align_width},
       ]},
       {"pony_alloc_small_final", [@ptr, @i32], @ptr, [
         LLVM::Attribute::NoUnwind, LLVM::Attribute::InaccessibleMemOrArgMemOnly,
-        {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::NoAlias},
         {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::Dereferenceable, HEAP_MIN},
         {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::Alignment, align_width},
       ]},
       {"pony_alloc_large_final", [@ptr, @isize], @ptr, [
         LLVM::Attribute::NoUnwind, LLVM::Attribute::InaccessibleMemOrArgMemOnly,
-        {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::NoAlias},
         {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::Dereferenceable, HEAP_MAX << 1},
         {LLVM::AttributeIndex::ReturnIndex, LLVM::Attribute::Alignment, align_width},
       ]},

--- a/src/savi/ext/llvm/for_savi/LLVMLinkForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMLinkForSavi.cc
@@ -42,15 +42,15 @@ bool LLVMLinkForSavi(
   // Invoke the linker.
   bool LinkResult = false;
   if (0 == strcmp(Flavor, "elf")) {
-    LinkResult = lld::elf::link(Args, false, Output, Output);
+    LinkResult = lld::elf::link(Args, Output, Output, false, false);
   } else if (0 == strcmp(Flavor, "mach_o")) {
-    LinkResult = lld::macho::link(Args, false, Output, Output);
+    LinkResult = lld::macho::link(Args, Output, Output, false, false);
   } else if (0 == strcmp(Flavor, "mingw")) {
-    LinkResult = lld::mingw::link(Args, false, Output, Output);
+    LinkResult = lld::mingw::link(Args, Output, Output, false, false);
   } else if (0 == strcmp(Flavor, "coff")) {
-    LinkResult = lld::coff::link(Args, false, Output, Output);
+    LinkResult = lld::coff::link(Args, Output, Output, false, false);
   } else if (0 == strcmp(Flavor, "wasm")) {
-    LinkResult = lld::wasm::link(Args, false, Output, Output);
+    LinkResult = lld::wasm::link(Args, Output, Output, false, false);
   } else {
     Output << "Unsupported lld link flavor: " << Flavor;
   }

--- a/src/savi/ext/llvm/for_savi/LLVMOptimizeForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMOptimizeForSavi.cc
@@ -33,9 +33,7 @@ void LLVMOptimizeForSavi(LLVMModuleRef ModRef, LLVMBool WantsFullOptimization) {
   // Create the top-level module pass manager using the default LLVM pipeline.
   // Respect the parameter that either requests or declines full optimization.
   ModulePassManager MPM = PB.buildPerModuleDefaultPipeline(
-    WantsFullOptimization
-      ? PassBuilder::OptimizationLevel::O3
-      : PassBuilder::OptimizationLevel::O0
+    WantsFullOptimization ? OptimizationLevel::O3 : OptimizationLevel::O0
   );
   MPM.run(*unwrap(ModRef), MAM);
 }


### PR DESCRIPTION
Update to LLVM 14.0.3.

In LLVM 13.0.0 we had observed a bug in which, when using
the new LLVM PassBuilder, some functions were being generated
without return instructions, causing the instruction pointer
to just blunder off the end of one function definition
into the next one in the executable binary's memory layout,
likely violating stack/argument assumptions of that function,
ultimately leading to some form of memory corruption.

This is why we had disabled use of those optimizations
temporarily in an earlier PR (#203), though it was only
diagnosed in detail this morning.

We update to the latest available LLVM release (14.0.3)
to avoid this issue and also to keep up with the times.

Note that in this update to 14.0.3 an issue was discovered in Pony
with the use of `NoAlias` attributes on allocation functions
for those functions that allocate an object with a finalizer.
These attributes were technically incorrect, and a new optimization
present in 14.0.3 now can optimize away code that shouldn't be
removed if it trusts the erroneous use of that attribute.
See https://github.com/ponylang/ponyc/pull/4055

This bug had not been observed directly in Savi because we do
not yet support allocations with finalizers. But the attributes
are updated here nonetheless, as it's easy to fix this correctness
issue now while it's at top of mind.

---

Go back to using the new LLVM PassBuilder for optimization.

This reverts PR #203, in which we temporarily disabled these
optimizations due to an LLVM bug. We no longer observe this bug
after upgrading LLVM from 13.0.0 to 14.0.3 (see above).

We also move the emission of LLVM IR to ensure it happens after
optimizations (in the new place where they are, after linking to the
runtime bitcode and thus allowing link time optimization with it).
