### PR TITLE
Add `-I`/`--include-dir` option to `savi ffigen` command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ format: PHONY $(SAVI)
 
 # Generate FFI code.
 ffigen: PHONY $(SAVI)
-	echo && $(SAVI) ffigen "$(header)" --backtrace
+	echo && $(SAVI) ffigen "$(header)" $(extra_args) --backtrace
 
 # Evaluate a Hello World example.
 example-eval: PHONY $(SAVI)

--- a/main.cr
+++ b/main.cr
@@ -263,9 +263,13 @@ module Savi
         argument "header", type: String, required: true, desc: "header file to parse"
         option "-b", "--backtrace", desc: "Show backtrace on error", type: Bool, default: false
         option "-C", "--cd=DIR", desc: "Change the working directory"
+        option "-I", "--include-dir=DIR", desc: "Add an include file search path", type: Array(String)
         run do |opts, args|
           Dir.cd(opts.cd.not_nil!) if opts.cd
-          Cli.ffigen(header: args.header, backtrace: opts.backtrace)
+          options = Savi::FFIGen::Options.new
+          options.header_name = args.header
+          options.include_dirs = opts.include_dir
+          Cli.ffigen(options, backtrace: opts.backtrace)
         end
       end
     end
@@ -382,9 +386,9 @@ module Savi
       end
     end
 
-    def self.ffigen(header : String, backtrace : Bool)
+    def self.ffigen(options : Savi::FFIGen::Options, backtrace : Bool)
       _add_backtrace backtrace do
-        gen = Savi::FFIGen.new(header)
+        gen = Savi::FFIGen.new(options)
         puts String.build { |io| gen.emit(io) }
 
         0

--- a/src/savi/spec_markdown.cr
+++ b/src/savi/spec_markdown.cr
@@ -279,8 +279,10 @@ class Savi::SpecMarkdown
         begin
           file_content = example.expected_ffigen.join("\n\n")
           file = File.tempfile("ffigen_example", ".h", &.print(file_content))
+          options = Savi::FFIGen::Options.new
+          options.header_name = file.path
           expected = example.code_blocks.join("\n\n")
-          actual = String.build { |io| FFIGen.new(file.path).emit(io) }
+          actual = String.build { |io| FFIGen.new(options).emit(io) }
 
           unless expected.strip == actual.strip
             puts "---"


### PR DESCRIPTION
This will allow the caller to specify search paths for other headers included from that header.