### PR TITLE
Another small fix for Windows linker pathing.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -262,8 +262,8 @@ class Savi::Compiler::Binary
 
       # Try various combinations of leaves of those trees.
       sdk_roots.each { |sdk_root|
-        yield "#{sdk_root}/**/x64", "lib/um/x64"      # MSVC style
-        yield "#{sdk_root}/**/x64", "lib/x64"         # MSVC style
+        yield "#{sdk_root}/**/x64", "um/x64"             # MSVC style
+        yield "#{sdk_root}/**/x64", "lib/x64"            # MSVC style
         yield "#{sdk_root}/**/x86_64", "lib/um/x86_64"   # xwin style
         yield "#{sdk_root}/**/x86_64", "lib/ucrt/x86_64" # xwin style
         yield "#{sdk_root}/**/x86_64", "lib/x86_64"      # xwin style


### PR DESCRIPTION
I made a mistake in the previous commit that I wasn't able to
notice and detect until after the release because I'm testing
this on a Windows CI machine using published Savi releases.

Hopefully this is the last thing I need to fix to get the CI
library-check builds working on Windows, but I wouldn't count on that.