### PR TITLE
Add `--cross-compile` option to the `run` command.

### DIFF
--- a/main.cr
+++ b/main.cr
@@ -83,6 +83,7 @@ module Savi
         option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
         option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
+        option "-X", "--cross-compile=TRIPLE", desc: "Cross compile to the given target triple"
         option "-C", "--cd=DIR", desc: "Change the working directory"
         option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
         run do |opts, args|
@@ -95,6 +96,7 @@ module Savi
           options.llvm_keep_fns = true if opts.llvm_keep_fns
           options.auto_fix = true if opts.fix
           options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
+          options.cross_compile = opts.cross_compile.not_nil! if opts.cross_compile
           options.manifest_name = args.name.not_nil! if args.name
           Dir.cd(opts.cd.not_nil!) if opts.cd
           Cli.run options, opts.backtrace

--- a/src/savi/compiler/run.cr
+++ b/src/savi/compiler/run.cr
@@ -14,7 +14,9 @@ class Savi::Compiler::Run
   getter! exitcode : Int32
 
   def run(ctx)
-    bin_path = ctx.manifests.root.not_nil!.bin_path
+    target = Target.new(ctx.code_gen.target_machine.triple)
+    bin_path = Binary.path_for(ctx)
+    bin_path += ".exe" if target.windows?
 
     res = Process.run("/usr/bin/env", [bin_path], output: STDOUT, error: STDERR)
     @exitcode = res.exit_code


### PR DESCRIPTION
Most of the time it wouldn't make sense to cross-compile
something and then immediately run it within the same environment.

But there are certain use cases where this can make sense.

For example:

- Compiling a Windows `.exe` within WSL (which can run `.exe`).

- Compiling a MacOS x86_64 binary on MacOS arm64 (which can run it via Rosetta).