### PR TITLE
Add `:field_order` declaration for platform-specific field orders.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -464,6 +464,16 @@
   :body optional
 
 // TODO: Document this.
+// TODO: Make this more general / less boutique.
+:declarator field_order
+  :intrinsic
+  :context type
+
+  :term fields NameList
+  :keyword on
+  :term platform enum (windows) // TODO: more options?
+
+// TODO: Document this.
 :declarator is
   :intrinsic
   :context type

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -22,7 +22,7 @@ class Savi::Compiler::Binary
   end
 
   def run(ctx)
-    target = Target.new(ctx.code_gen.target_machine.triple)
+    target = ctx.code_gen.target_info
     bin_path = Binary.path_for(ctx)
     bin_path += ".exe" if target.windows?
 

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -17,6 +17,7 @@ class Savi::Compiler::CodeGen
   getter llvm : LLVM::Context
   getter target : LLVM::Target
   getter target_machine : LLVM::TargetMachine
+  getter target_info : Target
   getter mod : LLVM::Module
   getter builder : LLVM::Builder
 
@@ -104,6 +105,7 @@ class Savi::Compiler::CodeGen
     ).as(String)
     @target = LLVM::Target.from_triple(@target_triple)
     @target_machine = @target.create_target_machine(@target_triple).as(LLVM::TargetMachine)
+    @target_info = Target.new(@target_machine.triple)
     @llvm = LLVM::Context.new
     @mod = @llvm.new_module("main")
     @builder = @llvm.new_builder

--- a/src/savi/compiler/code_gen/gen_type.cr
+++ b/src/savi/compiler/code_gen/gen_type.cr
@@ -16,7 +16,7 @@ class Savi::Compiler::CodeGen
       @gfuncs_by_sig_name = Hash(String, GenFunc).new
 
       # Take down info on all fields.
-      @fields = @type_def.fields
+      @fields = @type_def.ordered_fields(g.ctx, g.target_info)
 
       # Take down info on all functions.
       @vtable_size = 0

--- a/src/savi/compiler/run.cr
+++ b/src/savi/compiler/run.cr
@@ -14,7 +14,7 @@ class Savi::Compiler::Run
   getter! exitcode : Int32
 
   def run(ctx)
-    target = Target.new(ctx.code_gen.target_machine.triple)
+    target = ctx.code_gen.target_info
     bin_path = Binary.path_for(ctx)
     bin_path += ".exe" if target.windows?
 

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -224,7 +224,7 @@ class Savi::Program
     def initialize(@cap, @ident, @params = nil)
       @functions = [] of Function
       @tags = Set(Symbol).new
-      @metadata = Hash(Symbol, UInt64 | Bool).new
+      @metadata = Hash(Symbol, UInt64 | Bool | Array(String)).new
     end
 
     def dup_init(new_functions = nil)

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -401,6 +401,15 @@ module Savi::Program::Intrinsic
         displace_func = Program::Function.new(displace_cap, displace_ident, displace_params, displace_ret, displace_body)
         displace_func.add_tag(:let) if is_let
         type.functions << displace_func
+      when "field_order"
+        fields = terms["fields"].as(AST::Group).terms.map(&.as(AST::Identifier).value)
+        platform = terms["platform"].as(AST::Identifier).value
+        case platform
+        when "windows"
+          scope.current_type.metadata[:field_order_windows] = fields
+        else
+          raise NotImplementedError.new(platform)
+        end
       when "is"
         scope.current_type.functions << Program::Function.new(
           AST::Identifier.new("non").from(declare.terms.first),


### PR DESCRIPTION
This new declaration allows us to change the order of a type's fields
during code generation on a specified platform.

For now the only specifiable platform for this is `windows`,
with the "normal" field order being used for all other platforms.

This is not necessarily a great way to build out this language
feature - in the long run it needs more thought and better
generality. But for now this serves the needs of one very
specific case where we need to use this in the `IO` library,
so the feature is going in as-is for now and we'll reassess before
`v1.0.0`.