### PR TITLE
Add the `:ffi_link_lib` declarator.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -356,6 +356,16 @@
     :optional
   :body optional
 
+:: Declare a link-time dependency on a particular dynamic library, by name.
+::
+:: This influences the linker arguments that the Savi compiler will use in the
+:: linker invocation when building the binary executable for the program.
+::
+:: For example, declaring `:ffi_link_lib foo` will pass `-lfoo` to the linker.
+:declarator ffi_link_lib
+  :intrinsic
+  :term name Name
+
 :: Declare a binding to an unsafe foreign functions (FFI), such as a C function.
 ::
 :: It is common to define such bindings on a dedicated private module, which is

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -91,6 +91,9 @@ class Savi::Compiler::Binary
     sdk_version = (target.arm64? ? "11.0.0" : "10.9.0")
     link_args << "-platform_version" << "macos" << sdk_version << sdk_version
 
+    # Link any additional libraries indicated by user code.
+    ctx.link_libraries.each { |name| link_args << "-l#{name}" }
+
     # Finally, specify the input object file and the output filename.
     link_args << obj_path
     link_args << "-o" << bin_path
@@ -114,6 +117,9 @@ class Savi::Compiler::Binary
     add_windows_lib(link_args, lib_paths, "libcmt")  # C runtime startup - always needed
     add_windows_lib(link_args, lib_paths, "DbgHelp") # used by runtime platform/ponyassert.c
     add_windows_lib(link_args, lib_paths, "WS2_32")  # used by runtime lang/socket.c
+
+    # Link any additional libraries indicated by user code.
+    ctx.link_libraries.each { |name| add_windows_lib(link_args, lib_paths, name) }
 
     # Finally, specify the input object file and the output filename.
     link_args << obj_path
@@ -183,6 +189,9 @@ class Savi::Compiler::Binary
     link_args << "-lc" << "-ldl" << "-lpthread" << "-lm"
     link_args << "-latomic" unless target.freebsd?
     link_args << "-lexecinfo" if target.musl? || target.freebsd?
+
+    # Link any additional libraries indicated by user code.
+    ctx.link_libraries.each { |name| link_args << "-l#{name}" }
 
     # Finally, specify the input object file and the output filename.
     link_args << obj_path

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -90,6 +90,9 @@ module Savi::Program::Intrinsic
         else
           raise NotImplementedError.new(declarator.name.value)
         end
+      when "ffi_link_lib"
+        name = terms["name"].as(AST::Identifier)
+        ctx.link_libraries.add(name.value)
       else
         raise NotImplementedError.new(declarator.pretty_inspect)
       end


### PR DESCRIPTION
This kind of declaration instructs the Savi program to add extra
libraries into the linker invocation when the binary executable
for the program is being generated.