### PR TITLE
Fix Latest CI Breakages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
         # in the triple, where we'd otherwise use `x86_64-unknown-linux-musl`.
         MAKE_EXTRA_ARGS: CLANG_TARGET_PLATFORM=x86_64-alpine-linux-musl
       container:
-        image: alpine:edge # TODO: use alpine:3.16 when released
+        image: alpine:3.16
 
     - name: arm64-unknown-linux-musl
       environment:
@@ -52,7 +52,7 @@ task:
         # We also need to use `aarch64` instead of `arm64` here...
         MAKE_EXTRA_ARGS: CLANG_TARGET_PLATFORM=aarch64-alpine-linux-musl
       arm_container:
-        image: alpine:edge # TODO: use alpine:3.16 when released
+        image: alpine:3.16
 
     # # TODO: Enable FreeBSD after getting it working:
     # - name: x86_64-unknown-freebsd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - crystal: "1.4.1"
+          - crystal: "1.5.0"
             os: ubuntu-20.04
             deps: sudo apt-get install -y libgc-dev
-          - crystal: "1.4.1"
+          - crystal: "1.5.0"
             os: macos-11
             deps: echo no system deps to download
     runs-on: ${{matrix.os}}

--- a/shard.yml
+++ b/shard.yml
@@ -19,6 +19,6 @@ dependencies:
     github: at-grandpa/clim
     version: 0.13.0
 
-crystal: 1.4.1
+crystal: 1.5.0
 
 license: MPLv2

--- a/src/savi/compiler/functions.cr.stash
+++ b/src/savi/compiler/functions.cr.stash
@@ -1,0 +1,166 @@
+##
+# The purpose of the Functions pass is to determine which functions (and
+# function-like members) will be considered to be part of each type,
+# including those directly declared in it and those inherited from elsewhere.
+#
+# This pass does not mutate the Program topology.
+# This pass does not mutate the AST.
+# This pass may raise a compilation error.
+# This pass keeps state at the program level.
+# This pass produces output state at the per type level.
+#
+module Savi::Compiler::Functions
+  def run(ctx)
+    ctx
+  end
+
+  struct Analysis
+    @parent : StructRef(Analysis)?
+
+    def initialize(parent : Analysis? = nil)
+      @parent = StructRef(Analysis).new(parent) if parent
+      @infos = {} of AST::Identifier => Refer::Info
+      @params = {} of String => Refer::TypeParam
+      @redirects = {} of Refer::Info => Refer::Info
+      @cache_deps_additional_namespaces = {} of Source => Namespace::Analysis
+    end
+
+    protected def observe_ident(ident : AST::Identifier, info : Refer::Info)
+      @infos[ident] = redirect_for?(info) || info
+    end
+
+    def [](ident : AST::Identifier) : Refer::Info
+      @infos[ident]
+    end
+
+    def []?(ident : AST::Identifier) : Refer::Info?
+      @infos[ident]?
+    end
+
+    protected def observe_type_param(param : Refer::TypeParam)
+      @params[param.ident.value] = param
+    end
+
+    def type_param_for?(name : String)
+      @params[name]? || @parent.try(&.type_param_for?(name))
+    end
+
+    # TODO: Can this be protected?
+    def redirect(from : Refer::Info, to : Refer::Info)
+      raise "can't redirect from unresolved" if from.is_a?(Refer::Unresolved)
+      @redirects[from] = to
+    end
+
+    def redirect_for?(from : Refer::Info) : Refer::Info?
+      @redirects[from]? || @parent.try(&.redirect_for?(from))
+    end
+  end
+
+  class Visitor < Savi::AST::Visitor
+    getter analysis : Analysis
+    getter package : Program::Package::Link
+    getter namespace : Namespace::Analysis
+    def initialize(@analysis, @package, @namespace)
+    end
+
+    def find_type?(ctx, node : AST::Identifier)
+      return Refer::Self::INSTANCE if node.value == "@"
+
+      found = @analysis.type_param_for?(node.value)
+      return found if found
+
+      if node.pos.source.package == @package.source_package
+        found = namespace[node.value]?
+      else
+        # If the identifier comes from a foreign source package, we need to use
+        # the distinct namespace analysis associated with that source package.
+        foreign_namespace = ctx.namespace[node.pos.source.package]?
+        if foreign_namespace
+          found = foreign_namespace[node.value]?
+          # If found in a foreign namespace analysis, we need to accure that
+          # analysis as a cache-invalidating dependency.
+          if found
+            analysis.cache_deps_additional_namespaces[node.pos.source] =
+              foreign_namespace
+          end
+        end
+      end
+
+      case found
+      when Program::Type::Link
+        Refer::Type.new(found)
+      when Program::TypeAlias::Link
+        Refer::TypeAlias.new(found)
+      when Program::TypeWithValue::Link
+        Refer::Type.new(found.resolve(ctx).target, found)
+      else
+        nil
+      end
+    end
+
+    # This visitor never replaces nodes, it just touches them and returns them.
+    def visit(ctx, node)
+      touch(ctx, node) if node.is_a?(AST::Identifier)
+      node
+    rescue exc : Exception
+      raise Error.compiler_hole_at(node, exc)
+    end
+
+    # For an Identifier, resolve it to any known type if possible.
+    # Otherwise, leave it missing from our infos map.
+    def touch(ctx, node : AST::Identifier)
+      info = find_type?(ctx, node)
+      @analysis.observe_ident(node, info) if info
+    end
+  end
+
+  class Pass < Compiler::Pass::Analyze(Analysis, Analysis, Analysis)
+    def observe_type_params(ctx, t, t_link, t_analysis)
+      # If the type has type parameters, collect them into the params map.
+      t.params.try do |type_params|
+        type_params.terms.each_with_index do |param, index|
+          param_ident, param_bound, param_default = AST::Extract.type_param(param)
+          t_analysis.observe_type_param(
+            Refer::TypeParam.new(
+              t_link,
+              index,
+              param_ident,
+              param_bound || AST::Identifier.new("any").from(param),
+              param_default,
+            )
+          )
+        end
+      end
+    end
+
+    def analyze_type(ctx, t, t_link) : Analysis
+      namespace = ctx.namespace[t_link.package]
+      prev = ctx.prev_ctx.try(&.refer_type)
+
+      prev_namespaces = prev.try(&.[]?(t_link)
+        .try(&.cache_deps_additional_namespaces
+          .keys.map { |source| ctx.namespace[source.package] }
+        )
+      )
+
+      deps = {namespace, prev_namespaces}
+      maybe_from_type_cache(ctx, prev, t, t_link, deps) do
+        t_analysis = Analysis.new
+        observe_type_params(ctx, t, t_link, t_analysis)
+
+        # Run as a visitor on the ident itself and every type param.
+        visitor = Visitor.new(t_analysis, t_link.package, namespace)
+        t.ident.accept(ctx, visitor)
+        t.params.try(&.accept(ctx, visitor))
+
+        # Take the new set of cache dep additional namespaces into account.
+        new_namespaces = visitor.analysis
+          .cache_deps_additional_namespaces.values
+        new_deps = {namespace, new_namespaces}
+        set_type_cache_deps(t, t_link, new_deps)
+
+        visitor.analysis
+      end
+    end
+  end
+end

--- a/src/savi/compiler/infer/meta_type/anti_nominal.cr
+++ b/src/savi/compiler/infer/meta_type/anti_nominal.cr
@@ -1,5 +1,5 @@
 struct Savi::Compiler::Infer::MetaType::AntiNominal
-  getter defn : ReifiedType
+  getter defn : ReifiedType | ReifiedTypeAlias | TypeParam
 
   def initialize(defn)
     raise NotImplementedError.new(defn) unless defn.is_a?(ReifiedType)
@@ -8,7 +8,7 @@ struct Savi::Compiler::Infer::MetaType::AntiNominal
 
   def inspect(io : IO)
     io << "-"
-    io << defn.link.name
+    io << defn.as(ReifiedType).link.name # TODO: support other defn types
     io << "'any"
   end
 
@@ -38,7 +38,7 @@ struct Savi::Compiler::Infer::MetaType::AntiNominal
   end
 
   def is_concrete?
-    defn.link.is_concrete?
+    defn.as(ReifiedType).link.is_concrete? # TODO: support other defn types
   end
 
   def negate : Inner

--- a/src/savi/compiler/infer/span.cr
+++ b/src/savi/compiler/infer/span.cr
@@ -507,11 +507,11 @@ module Savi::Compiler::Infer
         self
       end
 
-      def maybe_fallback_based_on_mt_simplify(other_options : Array({Symbol, Inner})) : Inner
+      def maybe_fallback_based_on_mt_simplify(options : Array({Symbol, Inner})) : Inner
         Fallback.build(
-          @default.value.maybe_fallback_based_on_mt_simplify(other_options),
+          @default.value.maybe_fallback_based_on_mt_simplify(options),
           @evaluate_mt,
-          @options.map { |(cond, inner)| {cond, inner.maybe_fallback_based_on_mt_simplify(other_options)} }
+          @options.map { |(cond, inner)| {cond, inner.maybe_fallback_based_on_mt_simplify(options)} }
         )
       end
 

--- a/src/savi/compiler/t_infer/meta_type/anti_nominal.cr
+++ b/src/savi/compiler/t_infer/meta_type/anti_nominal.cr
@@ -1,5 +1,5 @@
 struct Savi::Compiler::TInfer::MetaType::AntiNominal
-  getter defn : ReifiedType
+  getter defn : ReifiedType | ReifiedTypeAlias | TypeParam
 
   def initialize(defn)
     raise NotImplementedError.new(defn) unless defn.is_a?(ReifiedType)
@@ -8,7 +8,7 @@ struct Savi::Compiler::TInfer::MetaType::AntiNominal
 
   def inspect(io : IO)
     io << "-"
-    io << defn.link.name
+    io << defn.as(ReifiedType).link.name # TODO: support other defn types
   end
 
   def each_reachable_defn(ctx : Context) : Array(ReifiedType)
@@ -37,7 +37,7 @@ struct Savi::Compiler::TInfer::MetaType::AntiNominal
   end
 
   def is_concrete?
-    defn.link.is_concrete?
+    defn.as(ReifiedType).link.is_concrete? # TODO: support other defn types
   end
 
   def negate : Inner
@@ -124,7 +124,7 @@ struct Savi::Compiler::TInfer::MetaType::AntiNominal
     case defn
     when TypeParam
       index = type_params.index(defn)
-      index ? type_args[index].strip_cap.inner.negate : self
+      index ? type_args[index].inner.negate : self
     when ReifiedType
       args = defn.args.map do |arg|
         arg.substitute_type_params(type_params, type_args).as(MetaType)

--- a/src/savi/compiler/t_infer/span.cr
+++ b/src/savi/compiler/t_infer/span.cr
@@ -307,11 +307,11 @@ module Savi::Compiler::TInfer
         end
       end
 
-      def maybe_fallback_based_on_mt_simplify(other_options : Array({Symbol, Inner})) : Inner
+      def maybe_fallback_based_on_mt_simplify(options : Array({Symbol, Inner})) : Inner
         Fallback.build(
-          @default.value.maybe_fallback_based_on_mt_simplify(other_options),
+          @default.value.maybe_fallback_based_on_mt_simplify(options),
           @evaluate_mt,
-          @options.map { |(cond, inner)| {cond, inner.maybe_fallback_based_on_mt_simplify(other_options)} }
+          @options.map { |(cond, inner)| {cond, inner.maybe_fallback_based_on_mt_simplify(options)} }
         )
       end
 


### PR DESCRIPTION
There are some breakages in CI due to some things that implicitly use the latest version.

This includes:

- CI jobs for musl linux that were temporarily using `alpine:edge` while we waited for `alpine:3.16` to be released
  - they are now broken on `alpine:edge`, but we now pin them to `alpine:3.16` to keep them working and stable.
  
- CI jobs that use the latest version of Crystal (which is now 1.5.0)
  - the codebase was broken on Crystal 1.5.0, but has now been updated for compatibility and we'll keep using latest in CI.