### PR TITLE
Add FFI-only `savi_cast_pointer` function.

### DIFF
--- a/core/BitArray.savi
+++ b/core/BitArray.savi
@@ -85,7 +85,7 @@
     other_ptr._unsafe._copy_to(@_ptr, size)
 
   :fun val as_bytes
-    ptr = CPointer(U8).from_address(@_ptr.address)
+    ptr = _FFI.Cast(CPointer(U64), CPointer(U8)).pointer(@_ptr)
     Bytes.val_from_cpointer(ptr._unsafe, @_u8_space, @_u8_space)
 
   :fun val as_native_u64_array

--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -460,7 +460,8 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U16.
   :fun read_native_u16!(offset USize) U16
     if ((offset + U16.byte_width.usize) > @_size) error!
-    CPointer(U16).from_address(@_ptr._offset(offset).address)._unsafe._get_at(0)
+    _FFI.Cast(CPointer(U8), CPointer(U16)'box).pointer(@_ptr._offset(offset))
+      ._get_at(0)
 
   :: Write a U16 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -468,7 +469,7 @@
   :: Use push_native_u16 instead if writing past the end is needed.
   :fun ref write_native_u16!(offset USize, number U16)
     if ((offset + U16.byte_width.usize) > @_size) error!
-    CPointer(U16).from_address(@_ptr._offset(offset).address)._unsafe
+    _FFI.Cast(CPointer(U8), CPointer(U16)'ref).pointer(@_ptr._offset(offset))
       ._assign_at(0, number)
     @
 
@@ -476,7 +477,7 @@
   :: This is not suitable for protocols using a platform-independent byte order.
   :fun ref push_native_u16(number U16)
     @reserve(@_size + U16.byte_width.usize)
-    CPointer(U16).from_address(@_ptr._offset(@_size).address)._unsafe
+    _FFI.Cast(CPointer(U8), CPointer(U16)'ref).pointer(@_ptr._offset(@_size))
       ._assign_at(0, number)
     @_size += U16.byte_width.usize
     @
@@ -486,7 +487,8 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U32.
   :fun read_native_u32!(offset USize) U32
     if ((offset + U32.byte_width.usize) > @_size) error!
-    CPointer(U32).from_address(@_ptr._offset(offset).address)._unsafe._get_at(0)
+    _FFI.Cast(CPointer(U8), CPointer(U32)'box).pointer(@_ptr._offset(offset))
+      ._get_at(0)
 
   :: Write a U32 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -494,7 +496,7 @@
   :: Use push_native_u32 instead if writing past the end is needed.
   :fun ref write_native_u32!(offset USize, number U32)
     if ((offset + U32.byte_width.usize) > @_size) error!
-    CPointer(U32).from_address(@_ptr._offset(offset).address)._unsafe
+    _FFI.Cast(CPointer(U8), CPointer(U32)'ref).pointer(@_ptr._offset(offset))
       ._assign_at(0, number)
     @
 
@@ -502,7 +504,7 @@
   :: This is not suitable for protocols using a platform-independent byte order.
   :fun ref push_native_u32(number U32)
     @reserve(@_size + U32.byte_width.usize)
-    CPointer(U32).from_address(@_ptr._offset(@_size).address)._unsafe
+    _FFI.Cast(CPointer(U8), CPointer(U32)'ref).pointer(@_ptr._offset(@_size))
       ._assign_at(0, number)
     @_size += U32.byte_width.usize
     @
@@ -512,7 +514,8 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U64.
   :fun read_native_u64!(offset USize) U64
     if ((offset + U64.byte_width.usize) > @_size) error!
-    CPointer(U64).from_address(@_ptr._offset(offset).address)._unsafe._get_at(0)
+    _FFI.Cast(CPointer(U8), CPointer(U64)'box).pointer(@_ptr._offset(offset))
+      ._get_at(0)
 
   :: Write a U64 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -520,7 +523,7 @@
   :: Use push_native_u64 instead if writing past the end is needed.
   :fun ref write_native_u64!(offset USize, number U64)
     if ((offset + U64.byte_width.usize) > @_size) error!
-    CPointer(U64).from_address(@_ptr._offset(offset).address)._unsafe
+    _FFI.Cast(CPointer(U8), CPointer(U64)'ref).pointer(@_ptr._offset(offset))
       ._assign_at(0, number)
     @
 
@@ -528,7 +531,7 @@
   :: This is not suitable for protocols using a platform-independent byte order.
   :fun ref push_native_u64(number U64)
     @reserve(@_size + U64.byte_width.usize)
-    CPointer(U64).from_address(@_ptr._offset(@_size).address)._unsafe
+    _FFI.Cast(CPointer(U8), CPointer(U64)'ref).pointer(@_ptr._offset(@_size))
       ._assign_at(0, number)
     @_size += U64.byte_width.usize
     @

--- a/core/CPointer.savi
+++ b/core/CPointer.savi
@@ -142,16 +142,3 @@
 
   :: Return the address of this pointer as an unsigned integer.
   :fun tag address USize: compiler intrinsic
-
-  :: DEPRECATED: Use `address` instead.
-  :fun tag usize: @address
-
-  // TODO: Remove this method. It's not compatible with CHERI hardware.
-  // To replace it, we need a method to convert a pointer of one type
-  // into a (`tag`) pointer of another type, so we can replace the places
-  // where `address` and `from_address` are being used together for conversion.
-  // To do that, we need to have generic functions, which we don't have yet.
-  :fun non from_address(number USize) @'tag: compiler intrinsic
-
-  :: DEPRECATED: Use `from_address` instead.
-  :fun tag from_usize(number): @from_address(number)

--- a/core/_FFI.savi
+++ b/core/_FFI.savi
@@ -12,3 +12,18 @@
   :ffi pony_os_std_write(
     fp CPointer(None)'ref, buffer CPointer(U8), length USize
   ) None
+
+:module _FFI.Cast(A, B)
+  :: An FFI-only utility function for bit-casting type A to B.
+  ::
+  :: This is only meant to be used for pointer types, and will
+  :: fail badly if either A or B is not an ABI pointer type
+  ::
+  :: Obviously this utility function makes it easy to break
+  :: memory safety, so it should be used with great care.
+  ::
+  :: Being private, It is only accessible from within the core library,
+  :: though other libraries can set up similar mechanisms as well,
+  :: provided that they are explicitly allowed by the root manifest to use FFI.
+  :ffi pointer(input A) B
+    :foreign_name savi_cast_pointer

--- a/spec/core/Array.Spec.savi
+++ b/spec/core/Array.Spec.savi
@@ -31,23 +31,23 @@
 
   :it "won't reallocate when reserving space within the current allocation"
     data = Array(None).new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     data.reserve(16)
     assert: data.space == 16
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
     data.reserve(0)
     assert: data.space == 16
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
     data = Array(None).new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     // Go to a much larger size in a different allocator pool,
     // to ensure that we actually get a new pointer address.
@@ -56,7 +56,7 @@
     assert: data.space == 2048
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize != orig_pointer_address
+    assert: data.cpointer.address != orig_pointer_address
 
   :it "pushes a new element onto the end of the array and reads them back out"
     array = Array(U64).new << 3 << 6

--- a/spec/core/BitArray.Spec.savi
+++ b/spec/core/BitArray.Spec.savi
@@ -31,23 +31,23 @@
 
   :it "won't reallocate when reserving space within the current allocation"
     data = BitArray.new(63)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     data.reserve(64)
     assert: data.space == 64
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
     data.reserve(0)
     assert: data.space == 64
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
     data = BitArray.new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     // Go to a much larger size in a different allocator pool,
     // to ensure that we actually get a new pointer address.
@@ -56,7 +56,7 @@
     assert: data.space == 131072
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize != orig_pointer_address
+    assert: data.cpointer.address != orig_pointer_address
 
   :it "pushes new bits onto the end of the array and reads them back out"
     // Bool values can be given in numeric form (0/1), or named (True/False).

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -26,23 +26,23 @@
 
   :it "won't reallocate when reserving space within the current allocation"
     data = Bytes.new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     data.reserve(16)
     assert: data.space == 16
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
     data.reserve(0)
     assert: data.space == 16
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
     data = Bytes.new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     // Go to a much larger size in a different allocator pool,
     // to ensure that we actually get a new pointer address.
@@ -51,7 +51,7 @@
     assert: data.space == 2048
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize != orig_pointer_address
+    assert: data.cpointer.address != orig_pointer_address
 
   :it "reallocates to a size that includes a null terminator when appending"
     data = Bytes.new
@@ -219,8 +219,8 @@
     assert: right == b"le"
 
     // The three buffers are adjacent in memory.
-    assert: left.cpointer(2).usize == center.cpointer.usize
-    assert: center.cpointer(3).usize == right.cpointer.usize
+    assert: left.cpointer(2).address == center.cpointer.address
+    assert: center.cpointer(3).address == right.cpointer.address
 
     // The first two buffers have a space exactly the same as their size,
     // and the right buffer retains whatever space padding was in the original.
@@ -238,10 +238,10 @@
 
     // After the pushes above, The buffers are no longer adjacent in memory,
     // checking with a pointer offset of both the original size and new size.
-    assert: left.cpointer(2).usize != center.cpointer.usize
-    assert: left.cpointer(3).usize != center.cpointer.usize
-    assert: center.cpointer(3).usize != right.cpointer.usize
-    assert: center.cpointer(4).usize != right.cpointer.usize
+    assert: left.cpointer(2).address != center.cpointer.address
+    assert: left.cpointer(3).address != center.cpointer.address
+    assert: center.cpointer(3).address != right.cpointer.address
+    assert: center.cpointer(4).address != right.cpointer.address
 
     // Also now the first two buffers have some padding in their space,
     // since they reserved more space when they were forced to reallocate.

--- a/spec/core/CPointer.Spec.savi
+++ b/spec/core/CPointer.Spec.savi
@@ -2,10 +2,12 @@
   :is Spec
   :const describes: "CPointer"
 
-  :it "converts to and from USize"
+  :it "returns the address of the pointer as an unsigned integer"
     assert: CPointer(U8).null.address == 0
-    assert: CPointer(U8).from_address(0xdeadbeef).address == 0xdeadbeef
+    assert: (static_address_of_function Bytes.join).address != 0
 
   :it "tests if it is a null pointer or not"
     assert: CPointer(U8).null.is_null
     assert: CPointer(U8).null.is_not_null.is_false
+    assert: (static_address_of_function Bytes.join).is_null.is_false
+    assert: (static_address_of_function Bytes.join).is_not_null

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -26,23 +26,23 @@
 
   :it "won't reallocate when reserving space within the current allocation"
     data = String.new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     data.reserve(16)
     assert: data.space == 16
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
     data.reserve(0)
     assert: data.space == 16
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize == orig_pointer_address
+    assert: data.cpointer.address == orig_pointer_address
 
   :it "will reallocate when reserving space beyond the current allocation"
     data = String.new(12)
-    orig_pointer_address = data.cpointer.usize
+    orig_pointer_address = data.cpointer.address
 
     // Go to a much larger size in a different allocator pool,
     // to ensure that we actually get a new pointer address.
@@ -51,7 +51,7 @@
     assert: data.space == 2048
     assert: data.size == 0
     assert: data.cpointer.is_not_null
-    assert: data.cpointer.usize != orig_pointer_address
+    assert: data.cpointer.address != orig_pointer_address
 
   :it "reallocates to a size that includes a null terminator when appending"
     data = String.new


### PR DESCRIPTION
This can be used by any library that has explicit permission for FFI, to "break memory safety" by converting from any arbitrary pointer type to any other pointer type.

Previously, doing this would require compiling a C shim library to be linked into the Savi program. We provide this FFI function as a convenience because FFI use can already compromise memory safety.

As with all other FFI usage, it is intended to be governed by explicitly granted permission in the root application manifest, allowing application authors visibility into and allow-list control over the libraries that are allowed to do unsafe things with FFI.

As with all other FFI usage, application authors should only grant this permission to libraries that they trust to provide a fully safe abstraction over the unsafe internal FFI mechanisms that they use.

This commit also refactors internal code for Array and String to use this new `savi_cast_pointer` function, and removes a deprecated `from_address` function that would not be portable to platforms like CHERI (wherein the pointer value includes more beyond just the address).