### PR TITLE
Add a compilation error for invalid escapes in string literals.

### DIFF
--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -185,6 +185,25 @@ describe Savi::Parser do
     end
   end
 
+  it "complains when a string literal has an unknown escape character" do
+    source = Savi::Source.new_example <<-SOURCE
+    :actor Main
+      :new
+        greeting = "Hello, World\\?"
+    SOURCE
+
+    expected = <<-MSG
+    This is an invalid escape character:
+    from (example):3:
+        greeting = "Hello, World\\?"
+                                 ^
+    MSG
+
+    expect_raises Savi::Error, expected do
+      Savi::Parser.parse(source)
+    end
+  end
+
   it "handles nifty heredoc string literals" do
     source = Savi::Source.new_example <<-SOURCE
     :actor Main


### PR DESCRIPTION
This helps to prevent bugs wherein the user believes they have correctly written an escape code.

Prior to this commit, invalid escape code were treated as if they were literal characters, including the backslash character.

See discussion in #348