### PR TITLE
Fix CI breakage related to unicode escapes.

### DIFF
--- a/src/savi/parser/builder/state.cr
+++ b/src/savi/parser/builder/state.cr
@@ -122,7 +122,7 @@ module Savi::Parser::Builder
                   end
                 codepoint = 16 * codepoint + hex_value
               end
-              result << codepoint
+              result << codepoint.chr
             when '\r', '\n' then
               while (
                 case reader.peek_next_char


### PR DESCRIPTION
Apparently unicode escapes haven't been working this entire time, but I just hadn't used them in a real program yet, and hadn't tested them, so I hadn't noticed.

PR #351 added a test that exercised this, but we didn't see a CI failure somehow and it got merged anyway.

This commit fixes the broken code for handling unicode escapes.