### PR TITLE
WIP - Add `BCD.U64`

### DIFF
--- a/core/BCD.savi
+++ b/core/BCD.savi
@@ -1,0 +1,116 @@
+:: Binary Coded Decimal (BCD) representation of an U64 integer.
+:: 
+:: Each digit is represented by a nibble (4 bits), requiring
+:: a total of 80 bits for up to 20 digits of the U64.
+:: Digits are stored in reverse order, so the the decimal `123`
+:: is internally stored as `0x321`.
+::
+:: In addition, we store a termination nibble `0xF` after the last
+:: digit, so decimal `123` is internally stored `0xF321`.
+:: At bit position 58 of the high word, we store the number of digits
+:: (requires 5 bits).
+::
+:: TODO: The code would become trivial if we had a `U128` type or a
+:: bit-shift connected pair of two U64.
+::
+:struct val BCD.U64
+  :is IntoString
+
+  :let _high U64
+  :let _low U64
+
+  :new (u64 U64)
+    high U64 = 0 
+    low U64 = 0xF
+    ndigits U64 = 0
+    while (True) (
+      ndigits = ndigits + 1
+      digit = u64 % 10
+      high = high.bit_shl(4).bit_or(low.bit_shr(60).bit_and(0xF))
+      low = low.bit_shl(4).bit_or(u64 % 10)
+      u64 = u64 / 10
+      if (u64 == 0) (
+        break
+      )
+    )
+    @_high = high.bit_or(ndigits.bit_shl(58))
+    @_low = low
+
+  :new _from_high_low(@_high, @_low)
+
+  :fun box is_zero Bool
+    @_low.bit_and(0xFF) == 0xF0
+
+  :: Converts the BCD back to an U64
+  :fun box u64 U64
+    n U64 = 0
+    @each_digit -> (digit|
+      n = (n * 10) + digit.u64
+    )
+    n
+
+  :: Returns the number of digits.
+  ::
+  :fun box ndigits USize
+    @_high.bit_shr(58).bit_and(0b11111).usize
+
+  :: Given a BCD representing `321`, pushing digit 4
+  :: to the left will return a new BCD representing `4321`.
+  :fun val push_digit_left!(digit U8) @'val
+    if (digit > 9) (
+      error!
+    )
+    ndigits = @ndigits
+    if (ndigits >= 20) (
+      error!
+    )
+    
+    low = @_low
+    // only the lower 20 bits of high are used for digits (including sentinel 0xF)
+    high = @_high.bit_and(0xF_FFFF)
+    ndigits = ndigits + 1
+
+    high = high.bit_shl(4).bit_or(low.bit_shr(60).bit_and(0xF))
+    low = low.bit_shl(4).bit_or(digit.u64)
+    high = high.bit_or(ndigits.u64.bit_shl(58))
+
+    BCD.U64._from_high_low(high, low)
+
+  :: Returns digit at position `pos`.
+  :fun box digit!(pos USize) U8
+    // 1234  -> 0xF_4321
+    // pos=0 ->     ^-- index=3       == ndigits - (pos + 1)
+    // pos=3 ->        ^-- index=0    == ndigits - (pos + 1)
+    index USize = if (pos < @ndigits) (@ndigits - (pos + 1) | error!)
+
+    case (
+    | index < 16 |
+      // digits 0..15 in the lower word
+      @_low.bit_shr((index * 4).u8).u8.bit_and(U8[0xF])
+    |
+      // digits 16..19 in the higher word
+      @_high.bit_shr(((index - 16) * 4).u8).u8.bit_and(U8[0xF])
+    )
+      
+
+  :fun box each_digit
+    :yields U8 for None 
+    high = @_high
+    low = @_low
+    while (low.bit_and(0xF) != 0xF) (
+      yield low.bit_and(0xF).u8
+      low = low.bit_shr(4).bit_or(high.bit_and(0xF).bit_shl(60))
+      high = high.bit_shr(4)
+    )
+
+  :fun box into_string_space USize
+    @ndigits
+
+  :fun box into_string(out String'iso) String'iso
+    @each_digit -> (digit|
+      out.push_byte('0'.u8 + digit)
+    )
+
+    --out
+
+

--- a/spec/core/BCD.Spec.savi
+++ b/spec/core/BCD.Spec.savi
@@ -1,0 +1,43 @@
+:class Savi.BCD.U64.Spec
+  :is Spec
+  :const describes: "BCD.U64"
+
+  :it "can be converted back into an U64"
+    assert: BCD.U64.new(0).u64 == U64[0]
+    assert: BCD.U64.new(12345).u64 == U64[12345]
+
+  :it "can access digits by position"
+    bcd = BCD.U64.new(123)
+    assert: bcd.digit!(0) == 3
+    assert: bcd.digit!(1) == 2
+    assert: bcd.digit!(2) == 1
+    assert error: bcd.digit!(3)
+
+  :it "can test for zero"
+    assert: BCD.U64.new(0).is_zero
+    assert: BCD.U64.new(1).is_zero.is_false
+
+  :it "can retrieve number of digits"
+    assert: BCD.U64.new(0).ndigits == 1
+    assert: BCD.U64.new(9).ndigits == 1
+    assert: BCD.U64.new(10).ndigits == 2
+    assert: BCD.U64.new(12345).ndigits == 5
+
+  :it "can push digits to the left"
+    assert no_error: (
+    	bcd = BCD.U64.new(0).push_digit_left!(9)
+	assert: "\(bcd)" == "90"
+    )
+    assert no_error: (
+    	bcd = BCD.U64.new(1).push_digit_left!(9)
+	assert: "\(bcd)" == "91"
+    )
+    assert no_error: (
+    	bcd = BCD.U64.new(1).push_digit_left!(9).push_digit_left!(0).push_digit_left!(0).push_digit_left!(5)
+	assert: bcd.ndigits == 5
+	assert: "\(bcd)" == "50091"
+    )
+
+  :it "displays as decimal string representation"
+    bcd = BCD.U64.new(123)
+    assert: "\(bcd)" == "123"

--- a/spec/core/Main.savi
+++ b/spec/core/Main.savi
@@ -27,4 +27,5 @@
       Spec.Run(Savi.Numeric.Spec).new(env)
       Spec.Run(Savi.Platform.Spec).new(env)
       Spec.Run(Savi.String.Spec).new(env)
+      Spec.Run(Savi.BCD.U64.Spec).new(env)
     ])


### PR DESCRIPTION
Not sure if this is of any use. It emerged out of the idea of converting decimals via BCDs :)

I think what could be useful is a `BitArrayPair(T)`, that takes two `T` (e.g. `U64`) and provides operations that operate on both (bit shifting, rotation etc.). Most of the complexity of the code below comes from simulating bit shifts via two U64.