### PR TITLE
Fix missing truncate implementation in signed numeric conversion.

### DIFF
--- a/spec/core/Numeric.Convertible.Spec.savi
+++ b/spec/core/Numeric.Convertible.Spec.savi
@@ -2,7 +2,7 @@
   :is Spec
   :const describes: "Numeric.Convertible"
 
-  :it "converts from integer to other numeric types"
+  :it "converts from unsigned integer to other numeric types"
     assert: U32[36].u8     == 36
     assert: U32[36].u8!    == 36
     assert: U32[36].u16    == 36
@@ -27,6 +27,32 @@
     assert: U32[36].f32!   == 36
     assert: U32[36].f64    == 36
     assert: U32[36].f64!   == 36
+
+  :it "converts from signed integer to other numeric types"
+    assert: I32[36].u8     == 36
+    assert: I32[36].u8!    == 36
+    assert: I32[36].u16    == 36
+    assert: I32[36].u16!   == 36
+    assert: I32[36].u32    == 36
+    assert: I32[36].u32!   == 36
+    assert: I32[36].u64    == 36
+    assert: I32[36].u64!   == 36
+    assert: I32[36].usize  == 36
+    assert: I32[36].usize! == 36
+    assert: I32[36].i8     == 36
+    assert: I32[36].i8!    == 36
+    assert: I32[36].i16    == 36
+    assert: I32[36].i16!   == 36
+    assert: I32[36].i32    == 36
+    assert: I32[36].i32!   == 36
+    assert: I32[36].i64    == 36
+    assert: I32[36].i64!   == 36
+    assert: I32[36].isize  == 36
+    assert: I32[36].isize! == 36
+    assert: I32[36].f32    == 36
+    assert: I32[36].f32!   == 36
+    assert: I32[36].f64    == 36
+    assert: I32[36].f64!   == 36
 
   :it "handles edge cases for conversions from integer"
     assert: U64[0x0124].u8                 == 36

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -2902,7 +2902,7 @@ class Savi::Compiler::CodeGen
         if from_width > to_width
           @builder.sext(to_min, value.type)
         elsif from_width < to_width
-          raise "this should never happen"
+          @builder.trunc(to_min, value.type)
         else
           to_min
         end


### PR DESCRIPTION
Prior to this commit, this code was assumed that underflow testing on partial numeric conversion would only be used when the source type is a signed integer and the dest type has a smaller width. But this can also happen when the dest type has a greater or equal width when the dest type is unsigned, because all negative numbers are treated as underflow in that case.

This commit fixes the issue by implementing that case.