### PR TITLE
Add `Numeric.Comparable.is_zero` and `is_nonzero` methods.

### DIFF
--- a/core/Numeric.savi
+++ b/core/Numeric.savi
@@ -464,6 +464,12 @@
 :trait Numeric.Comparable(T Numeric(T)'val)
   :is Comparable(T)
 
+  :: Return `True` if the value is equal to zero.
+  :fun val is_zero Bool
+
+  :: Return `True` if the value is not equal to zero.
+  :fun val is_nonzero Bool: @is_zero.not
+
   :: If this value is greater than the given minimum value, return it.
   :: Otherwise return the given minimum value.
   :fun val at_least(minimum T) T
@@ -557,6 +563,7 @@
   :fun ">"(other @'box) Bool: compiler intrinsic
   :fun ">="(other @'box) Bool: compiler intrinsic
   :fun val negate: @zero - @
+  :fun val is_zero Bool: @ == @zero
   :fun val at_least(minimum @) @: if (@ > minimum) (@ | minimum)
   :fun val at_most(maximum @) @: if (@ < maximum) (@ | maximum)
   :fun val max(other @) @: @at_least(other)

--- a/spec/core/Numeric.Comparable.Spec.savi
+++ b/spec/core/Numeric.Comparable.Spec.savi
@@ -24,6 +24,12 @@
     assert: I32[-30] < 6
     assert: I32[6] > -30
 
+  :it "checks if a number is zero or nonzero"
+    assert: U32.zero.is_zero
+    assert: U32.max_value.is_zero.is_false
+    assert: U32.zero.is_nonzero.is_false
+    assert: U32.max_value.is_nonzero
+
   :it "limits a value to be at least a given minimum or at most a given maximum"
     assert: 89.at_least(90) == 90
     assert: 90.at_least(90) == 90


### PR DESCRIPTION
These are convenience methods for `== 0` and `!= 0`, respectively.

The new methods take more characters to type than those forms, but they have the following advantages for some use cases:
- No need for extra parentheses surrounding the outer expression.
- On a cluttered line, with the `==`/`!=` symbols and parentheses, sometimes the intent can be difficult to read clearly. Using words can help with this over symbols.