### PR TITLE
Add `Pair.high`, `low`, `hi`, and `lo` convenience aliases.

### DIFF
--- a/core/Pair.savi
+++ b/core/Pair.savi
@@ -13,3 +13,9 @@
   // Convenience aliases for when this is used as a head/tail pair.
   :fun head: @first
   :fun tail: @second
+
+  // Convenience aliases for when this is used as a high/low pair.
+  :fun high: @first
+  :fun low: @second
+  :fun hi: @high
+  :fun lo: @low

--- a/spec/core/Integer.WideArithmetic.Spec.savi
+++ b/spec/core/Integer.WideArithmetic.Spec.savi
@@ -4,6 +4,6 @@
 
   :it "implements special multiplication without overflow by returning a pair"
     product = U8[99].wide_multiply(200)
-    assert: product.head == 0x4d
-    assert: product.tail == 0x58
-    assert: product.head.u16.bit_shl(8) + product.tail.u16 == U16[99] * 200
+    assert: product.hi == 0x4d
+    assert: product.lo == 0x58
+    assert: product.hi.u16.bit_shl(8) + product.lo.u16 == U16[99] * 200

--- a/spec/core/Main.savi
+++ b/spec/core/Main.savi
@@ -25,6 +25,7 @@
       Spec.Run(Savi.Numeric.Convertible.Spec).new(env)
       Spec.Run(Savi.Numeric.Representable.Spec).new(env)
       Spec.Run(Savi.Numeric.Spec).new(env)
+      Spec.Run(Savi.Pair.Spec).new(env)
       Spec.Run(Savi.Platform.Spec).new(env)
       Spec.Run(Savi.String.Spec).new(env)
     ])

--- a/spec/core/Pair.Spec.savi
+++ b/spec/core/Pair.Spec.savi
@@ -1,0 +1,30 @@
+:class Savi.Pair.Spec
+  :is Spec
+  :const describes: "Pair"
+
+  :it "has two elements"
+    pair = Pair(String, U64).new("example", 99)
+    assert: pair.first  == "example"
+    assert: pair.second == 99
+    assert: pair.last   == 99
+
+  :it "calls its elements a key and a value"
+    pair = Pair(String).new("color", "red")
+    assert: pair.key == "color"
+    assert: pair.value == "red"
+
+  :it "calls its elements a head and a tail"
+    pair = Pair(String, Pair(String, String)).new(
+      "one"
+      Pair(String, String).new("two", "three")
+    )
+    assert: pair.head == "one"
+    assert: pair.tail.head == "two"
+    assert: pair.tail.tail == "three"
+
+  :it "calls its elements a high and a low"
+    pair = Pair(U32).new(0xFEDCBA98, 0x7654321)
+    assert: pair.high == 0xFEDCBA98
+    assert: pair.low  == 0x7654321
+    assert: pair.hi == 0xFEDCBA98
+    assert: pair.lo == 0x7654321


### PR DESCRIPTION
These are useful when treating a pair as the high and low bits of an extended bit representation.