### PR TITLE
Fix emission of LLVM IR to create directory if needed.

### DIFF
--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -108,6 +108,7 @@ class Savi::Compiler::BinaryObject
     LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
 
     # Emit the combined/optimized LLVM IR to a file if requested to do so.
+    FileUtils.mkdir_p(File.dirname(Binary.path_for(ctx)))
     mod.print_to_file("#{Binary.path_for(ctx)}.ll") if ctx.options.llvm_ir
 
     # Write the program to disk as a binary object file.

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -396,6 +396,7 @@ class Savi::Compiler::CodeGen
     begin
       @mod.verify
     rescue ex
+      FileUtils.mkdir_p(File.dirname(Binary.path_for(ctx)))
       @mod.print_to_file("#{Binary.path_for(ctx)}.ll")
       Error.at Source::Pos.none, "LLVM #{ex.message}", [
         {Source::Pos.none,


### PR DESCRIPTION
Prior to this, if trying to emit LLVM IR before the dir exists, the compiler would fail with an internal exception like this:

```
Unhandled exception: No such file or directory (Exception)
```

This commit fixes that issue.