### PR TITLE
Allow `_` in numbers

### DIFF
--- a/spec/compiler/format.numbers.savi.spec.md
+++ b/spec/compiler/format.numbers.savi.spec.md
@@ -1,0 +1,17 @@
+---
+pass: format
+---
+
+Number separators should not be lost.
+
+```savi
+    1234
+    1000_000
+    123.3_4
+```
+```savi format.Indentation
+    1234
+    1000_000
+    123.3_4
+```
+

--- a/spec/language/semantics/number_spec.savi
+++ b/spec/language/semantics/number_spec.savi
@@ -1,0 +1,6 @@
+:module NumberSpec
+  :fun run(test MicroTest)
+    test["number separator hex"].pass = U64[0xFFFF_FFFF] == U64[0xFFFFFFFF]
+    test["number separator bin"].pass = U64[0b0000_1000] == U64[0b00001000]
+    test["number separator dec"].pass = U64[120_000_000] == U64[120000000]
+    test["number separator float"].pass = F64[123_456.789_1] == F64[123456.7891]

--- a/spec/language/semantics/test.savi
+++ b/spec/language/semantics/test.savi
@@ -24,5 +24,6 @@
     TraitNonSpec.run(test)
     EnumSpec.run(test)
     StringSpec.run(test)
+    NumberSpec.run(test)
 
     test.print_line_break // TODO: move to MicroTest constructor and finalizer

--- a/src/savi/parser/builder.cr
+++ b/src/savi/parser/builder.cr
@@ -107,7 +107,7 @@ module Savi::Parser::Builder
         end
       AST::LiteralInteger.new(value).with_pos(state.pos(main))
     when :float
-      value = state.slice(main).to_f
+      value = state.slice(main).gsub('_', "").to_f
       AST::LiteralFloat.new(value).with_pos(state.pos(main))
     when :op
       value = state.slice(main)

--- a/src/savi/parser/grammar.cr
+++ b/src/savi/parser/grammar.cr
@@ -18,14 +18,15 @@ module Savi::Parser
     digit = range('0', '9')
     digithex = digit | range('a', 'f') | range('A', 'F')
     digitbin = range('0', '1')
-    digits = digit.repeat(1) | char('_')
+    numsep = char('_')
+    digits = digit >> (digit | numsep).repeat
     int =
-      (str("0x") >> (digithex | char('_')).repeat(1)) |
-      (str("0b") >> (digitbin | char('_')).repeat(1)) |
-      (char('-') >> digit19 >> digits) |
-      (char('-') >> digit) |
-      (digit19 >> digits) |
-      digit
+      (str("0x") >> numsep.repeat >> digithex >> (digithex | numsep).repeat) |
+      (str("0b") >> numsep.repeat >> digitbin >> (digitbin | numsep).repeat) |
+      (char('-') >> digit19 >> (digit | numsep).repeat) |
+      (char('-') >> char('0')) |
+      (digit19 >> (digit | numsep).repeat) |
+      char('0')
     frac = char('.') >> digits
     exp = (char('e') | char('E')) >> (char('+') | char('-')).maybe >> digits
     integer = int.named(:integer)

--- a/src/savi/parser/grammar.cr
+++ b/src/savi/parser/grammar.cr
@@ -21,8 +21,8 @@ module Savi::Parser
     numsep = char('_')
     digits = digit >> (digit | numsep).repeat
     int =
-      (str("0x") >> numsep.repeat >> digithex >> (digithex | numsep).repeat) |
-      (str("0b") >> numsep.repeat >> digitbin >> (digitbin | numsep).repeat) |
+      (str("0x") >> digithex >> (digithex | numsep).repeat) |
+      (str("0b") >> digitbin >> (digitbin | numsep).repeat) |
       (char('-') >> digit19 >> (digit | numsep).repeat) |
       (char('-') >> char('0')) |
       (digit19 >> (digit | numsep).repeat) |


### PR DESCRIPTION
- Where is the appropriate place to add test cases for this?

- This currently allows trailing "_", which in Ruby for instance is not allowed.

Related issues: #370