### PR TITLE
Fix a code generation bug for struct receivers.

### DIFF
--- a/spec/language/semantics/regression_spec.savi
+++ b/spec/language/semantics/regression_spec.savi
@@ -1,0 +1,10 @@
+:module RegressionSpec
+  :fun run(test MicroTest)
+    // In a past version of the compiler, this would generate invalid LLVM IR,
+    // failing to deal properly with the fact that we were calling `into_string`
+    // on a receiver that was either a struct or a class.
+    test["struct or class into string"].pass = "example: \(
+      try (@maybe_int_format! | "???")
+    )" == "example: 33"
+
+  :fun maybe_int_format!: 33.format.decimal

--- a/spec/language/semantics/test.savi
+++ b/spec/language/semantics/test.savi
@@ -11,6 +11,7 @@
     test = MicroTest.new(env)
     test.print_line_break // TODO: move to MicroTest constructor and finalizer
 
+    RegressionSpec.run(test)
     TrySpec.run(test)
     WhileSpec.run(test)
     ReturnSpec.run(test)

--- a/src/savi/compiler/code_gen/gen_func.cr
+++ b/src/savi/compiler/code_gen/gen_func.cr
@@ -115,7 +115,7 @@ class Savi::Compiler::CodeGen
       def gen_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value, value_expr : AST::Node?)
         if value_expr
           value_type = gfunc.reach_func.signature.ret
-          value = g.gen_assign_cast(value, value_type, value_expr)
+          value = g.gen_assign_cast(value, value_type, nil, value_expr)
         end
         g.builder.ret(value)
       end
@@ -152,7 +152,7 @@ class Savi::Compiler::CodeGen
       def gen_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value, value_expr : AST::Node?)
         if value_expr
           value_type = gfunc.reach_func.signature.ret
-          value = g.gen_assign_cast(value, value_type, value_expr)
+          value = g.gen_assign_cast(value, value_type, nil, value_expr)
         end
         tuple = llvm_func_ret_type(g, gfunc).undef
         tuple = g.builder.insert_value(tuple, value, 0)
@@ -185,7 +185,7 @@ class Savi::Compiler::CodeGen
       def gen_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value, value_expr : AST::Node?)
         if value_expr
           value_type = gfunc.reach_func.signature.ret
-          value = g.gen_assign_cast(value, value_type, value_expr)
+          value = g.gen_assign_cast(value, value_type, nil, value_expr)
         end
         cont = g.func_frame.continuation_value
         gfunc.continuation_info.set_as_finished(cont)
@@ -199,7 +199,7 @@ class Savi::Compiler::CodeGen
           values.zip(value_exprs).map_with_index do |(value, value_expr), index|
             next value unless value_expr
             cast_type = gfunc.reach_func.signature.yield_out[index]
-            g.gen_assign_cast(value, cast_type, value_expr)
+            g.gen_assign_cast(value, cast_type, nil, value_expr)
           end
 
         # Grab the continuation value from local memory and set the next func.
@@ -231,7 +231,7 @@ class Savi::Compiler::CodeGen
       def gen_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value, value_expr : AST::Node?)
         if value_expr
           value_type = gfunc.reach_func.signature.ret
-          value = g.gen_assign_cast(value, value_type, value_expr)
+          value = g.gen_assign_cast(value, value_type, nil, value_expr)
         end
         cont = g.func_frame.continuation_value
         gfunc.continuation_info.set_as_finished(cont)

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -258,8 +258,13 @@ class Savi::Compiler::CodeGen::PonyRT
     g.builder.call(g.mod.functions["pony_ctx"], "ALLOC_CTX")
   end
 
-  def cast_kind_of(g : CodeGen, type_ref : Reach::Ref, pos : Source::Pos) : Symbol
-    if type_ref.singular?
+  def cast_kind_of(
+    g : CodeGen,
+    type_ref : Reach::Ref,
+    llvm_type : LLVM::Type,
+    pos : Source::Pos
+  ) : Symbol
+    if type_ref.singular? && llvm_type.kind != LLVM::Type::Kind::Pointer
       type_def = type_ref.single_def!(g.ctx)
       if type_def.is_simple_value?(g.ctx)
         :simple_value

--- a/src/savi/compiler/code_gen/veronart.cr
+++ b/src/savi/compiler/code_gen/veronart.cr
@@ -408,7 +408,12 @@ class Savi::Compiler::CodeGen::VeronaRT
   end
 
   # When an assignment cast may need to happen, classify the kind of type.
-  def cast_kind_of(g : CodeGen, type_ref : Reach::Ref, pos : Source::Pos) : Symbol
+  def cast_kind_of(
+    g : CodeGen,
+    type_ref : Reach::Ref,
+    llvm_type : LLVM::Type?,
+    pos : Source::Pos
+  ) : Symbol
     # For now we only have supported this logic for singular types.
     raise NotImplementedError.new(type_ref.show_type) unless type_ref.singular?
     type_def = type_ref.single_def!(g.ctx)
@@ -487,7 +492,7 @@ class Savi::Compiler::CodeGen::VeronaRT
     infos.each do |info|
       case info
       when Lifetime::PassAsArgument
-        kind = cast_kind_of(g, g.type_of(expr), expr.pos)
+        kind = cast_kind_of(g, g.type_of(expr), nil, expr.pos)
         case kind
         when :simple_value, :no_allocation
           # Do nothing - we don't track lifetime of bare values.
@@ -505,7 +510,7 @@ class Savi::Compiler::CodeGen::VeronaRT
         end
       when Lifetime::ReleaseFromScope
         local_defn = g.func_frame.any_defn_for_local(info.local)
-        kind = cast_kind_of(g, g.type_of(local_defn), local_defn.pos)
+        kind = cast_kind_of(g, g.type_of(local_defn), nil, local_defn.pos)
         case kind
         when :simple_value, :no_allocation
           # Do nothing - we don't track lifetime of bare values.


### PR DESCRIPTION
Prior to this commit, when calling a method on a value that could be either a struct or a class (both of which have that method), then invalid LLVM IR could be generated.

This was causing failures in the HTTPServer example code in CI.

This commit fixes that bug and adds a regression test.