### PR TITLE
Fix indentation of heredoc-like strings (`<<<>>>`) on Windows.

### DIFF
--- a/spec/language/semantics/string_spec.savi
+++ b/spec/language/semantics/string_spec.savi
@@ -18,3 +18,8 @@
       \x00\x11\x22\x33\x44\x55\x66\x77\
       \x88\x99\xaa\xbb\xcc\xdd\xee\xff\
     ".size == 16
+
+    test["heredoc-like string"].pass = <<<
+      Hello
+      World
+    >>> == "Hello\nWorld"

--- a/src/savi/parser/builder.cr
+++ b/src/savi/parser/builder.cr
@@ -89,8 +89,8 @@ module Savi::Parser::Builder
       AST::LiteralCharacter.new(value.ord.to_i64).with_pos(state.pos(main))
     when :heredoc
       value = state.slice(main)
-      if (leading_space = value[/(?<=\A\n)[ \t]+/]?; leading_space)
-        value = value.gsub("\n#{leading_space}", "\n").strip
+      if (leading_space = value[/\A\r?\n[ \t]+/]?; leading_space)
+        value = value.gsub("#{leading_space}", "\n").strip
       end
       AST::LiteralString.new(value).with_pos(state.pos(main))
     when :integer


### PR DESCRIPTION
The part of the compiler that processes these strings to remove indentation was previously not taking the possibility of Windows-style line endings (`\r\n`) into account. Now it does.