### PR TITLE
Fix build on DragonFly (part 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,10 @@ ifneq (,$(findstring freebsd,$(TARGET_PLATFORM)))
 	CRYSTAL_RT_LIBS+=-L/usr/local/lib
 endif
 
+ifneq (,$(findstring dragonfly,$(TARGET_PLATFORM)))
+	CRYSTAL_RT_LIBS+=-L/usr/local/lib
+endif
+
 # This is the path to the Crystal standard library source code,
 # including the LLVM extensions C++ file we need to build and link.
 CRYSTAL_PATH?=$(shell env $(shell crystal env) printenv CRYSTAL_PATH | rev | cut -d ':' -f 1 | rev)

--- a/platform.sh
+++ b/platform.sh
@@ -35,6 +35,12 @@ elif uname | grep -iq 'FreeBSD'; then
   else
     fail "On FreeBSD, the only arch currently supported is: x86_64"
   fi
+elif uname | grep -iq 'DragonFly'; then
+  if uname -m | grep -iq 'x86_64'; then
+    echo 'x86_64-unknown-dragonfly'
+  else
+    fail "On DragonFly, the only arch currently supported is: x86_64"
+  fi
 elif uname | grep -iq 'Darwin'; then
   if uname -m | grep -iq 'x86_64'; then
     echo 'x86_64-apple-macosx'

--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -33,7 +33,7 @@ class Savi::Compiler::Binary
     # Use a linker to turn make an executable binary from the object file.
     # We use an embedded lld linker, passing link arguments of our own crafting,
     # based on information about the target platform and finding system paths.
-    if target.linux? || target.freebsd?
+    if target.linux? || target.freebsd? || target.dragonfly?
       link_for_linux_or_bsd(ctx, target, obj_path, bin_path)
     elsif target.macos?
       link_for_macosx(ctx, target, obj_path, bin_path)
@@ -188,7 +188,7 @@ class Savi::Compiler::Binary
     link_args << "-lgcc" << "-lgcc_s"
     link_args << "-lc" << "-ldl" << "-lpthread" << "-lm"
     link_args << "-latomic" unless target.freebsd?
-    link_args << "-lexecinfo" if target.musl? || target.freebsd?
+    link_args << "-lexecinfo" if target.musl? || target.freebsd? || target.dragonfly?
 
     # Link any additional libraries indicated by user code.
     ctx.link_libraries.each { |name| link_args << "-l#{name}" }
@@ -219,6 +219,10 @@ class Savi::Compiler::Binary
 
     if target.freebsd?
       return "/libexec/ld-elf.so.1"
+    end
+
+    if target.dragonfly?
+      return "/libexec/ld-elf.so.2"
     end
 
     raise NotImplementedError.new(target.inspect)

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -49,6 +49,10 @@ class Savi::Compiler::BinaryObject
       if target.x86_64?
         return "x86_64-unknown-freebsd"
       end
+    elsif target.dragonfly?
+      if target.x86_64?
+        return "x86_64-unknown-dragonfly"
+      end
     elsif target.macos?
       if target.x86_64?
         return "x86_64-apple-macosx"


### PR DESCRIPTION
There are still problems when linking the final `savi` binary, but that seems to be related to not having the static LLVM binaries available on DragonFly (yet).

There are two open tasks for getting Savi on DragonFly:

* build static LLVM libraries (working on that). 
* build `libsavi_runtime`

Both are more difficult to build via github actions or cirrus CI, as they don't have DragonFly runners.

Once I get things working, I can provide a `savi` port for DragonFly that can be installed as `pkg ins savi`. Though, I am a bit concerned about the LLVM dependency... building non-standard LLVM as a dependency of a `savi` port take too much CPU. Hoping that they change the default of shipping with the static libs in the next version (of the DragonFly / FreeBSD port).