### PR TITLE
Fix build on DragonFly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,11 +191,14 @@ ifneq (,$(findstring dragonfly,$(TARGET_PLATFORM)))
 	# * -flto=thin is not accepted
 	# * we have to explicitly state the linker
 	# * we cannot link libclang statically
+	# * compile with clang++
 	SAVI_LD_FLAGS=-fuse-ld=lld -L/usr/lib -L/usr/local/lib
 	LIB_CLANG=-lclang
+	SAVI_CC="${CLANGXX}"
 else
 	SAVI_LD_FLAGS=-flto=thin -no-pie
 	LIB_CLANG=`sh -c 'ls $(LLVM_PATH)/lib/libclang*.a'`
+	SAVI_CC="${CLANG}"
 endif
 
 
@@ -297,7 +300,7 @@ $(BUILD)/savi-spec.o: spec/all.cr $(LLVM_PATH) $(shell find src lib spec -name '
 # This variant of the target compiles in release mode.
 $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc lib/libsavi_runtime
 	mkdir -p `dirname $@`
-	${CLANGXX} -O3 -o $@ $(SAVI_LD_FLAGS) \
+	${SAVI_CC} -O3 -o $@ $(SAVI_LD_FLAGS) \
 		$(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
@@ -312,7 +315,7 @@ $(BUILD)/savi-release: $(BUILD)/savi-release.o $(BUILD)/llvm_ext.bc $(BUILD)/llv
 # This variant of the target compiles in debug mode.
 $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc lib/libsavi_runtime
 	mkdir -p `dirname $@`
-	${CLANGXX} -O0 -o $@ $(SAVI_LD_FLAGS) \
+	${SAVI_CC} -O0 -o $@ $(SAVI_LD_FLAGS) \
 		$(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \
@@ -327,7 +330,7 @@ $(BUILD)/savi-debug: $(BUILD)/savi-debug.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ex
 # This variant of the target will be used when running tests.
 $(BUILD)/savi-spec: $(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc lib/libsavi_runtime
 	mkdir -p `dirname $@`
-	${CLANGXX} -O0 -o $@ $(SAVI_LD_FLAGS) \
+	${SAVI_CC} -O0 -o $@ $(SAVI_LD_FLAGS) \
 		$(BUILD)/savi-spec.o $(BUILD)/llvm_ext.bc $(BUILD)/llvm_ext_for_savi.bc \
 		 ${CRYSTAL_RT_LIBS} \
 		-target $(CLANG_TARGET_PLATFORM) \

--- a/platform.sh
+++ b/platform.sh
@@ -35,6 +35,12 @@ elif uname | grep -iq 'FreeBSD'; then
   else
     fail "On FreeBSD, the only arch currently supported is: x86_64"
   fi
+elif uname | grep -iq 'DragonFly'; then
+  if uname -m | grep -iq 'x86_64'; then
+    echo 'x86_64-unknown-dragonfly'
+  else
+    fail "On DragonFly, the only arch currently supported is: x86_64"
+  fi
 elif uname | grep -iq 'Darwin'; then
   if uname -m | grep -iq 'x86_64'; then
     echo 'x86_64-apple-macosx'

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -49,6 +49,10 @@ class Savi::Compiler::BinaryObject
       if target.x86_64?
         return "x86_64-unknown-freebsd"
       end
+    elsif target.dragonfly?
+      if target.x86_64?
+        return "x86_64-unknown-dragonfly"
+      end
     elsif target.macos?
       if target.x86_64?
         return "x86_64-apple-macosx"


### PR DESCRIPTION
With this commit I can successfully build `savi-release` on DragonFly with:

	gmake build/savi-release \
		LLVM_PATH=/usr/local/llvm14 \
		CLANGXX=clang++14 \
		CLANG=clang14 \
		LIB_GC=/usr/local/lib/libgc-threaded.a \
		LIB_EVENT=/usr/local/lib/libevent.a \
		LIB_PCRE=/usr/local/lib/libpcre.a \
		LIB_CXX_KIND=""

Supersedes #379 