### PR TITLE
Add `\U` 32-bit Unicode escape sequence for string literals.

### DIFF
--- a/spec/language/semantics/string_spec.savi
+++ b/spec/language/semantics/string_spec.savi
@@ -5,6 +5,9 @@
     test["compose string 1"].pass = "foo \(bar) baz" == "foo bar baz"
     test["compose string 2"].pass = "\(bar)\(bar)\(bar)" == "barbarbar"
 
+    test["16-bit lowercase U escape"].pass = "\u0161" == "\xc5\xa1"
+    test["32-bit capital U escape"].pass = "\U0001fa01" == "\xf0\x9f\xa8\x81"
+
     test["byte string literal size"].pass =
       b"\xde\xad\xbe\xef\xde\xad\xbe\xef".size == 8
 

--- a/src/savi/parser/builder/state.cr
+++ b/src/savi/parser/builder/state.cr
@@ -106,7 +106,7 @@ module Savi::Parser::Builder
               end
               result.write Bytes[byte_value]
             when 'u' then
-              codepoint = 0
+              codepoint : UInt32 = 0
               4.times do
                 hex_char = reader.next_char
                 hex_value =
@@ -120,7 +120,25 @@ module Savi::Parser::Builder
                     Error.at pos_single_with_offset(token, reader.pos),
                       "This is an invalid unicode escape hex character"
                   end
-                codepoint = 16 * codepoint + hex_value
+                codepoint = 16_u32 * codepoint + hex_value
+              end
+              result << codepoint.chr
+            when 'U' then
+              codepoint = 0
+              8.times do
+                hex_char = reader.next_char
+                hex_value =
+                  if '0' <= hex_char <= '9'
+                    hex_char - '0'
+                  elsif 'a' <= hex_char <= 'f'
+                    10 + (hex_char - 'a')
+                  elsif 'A' <= hex_char <= 'F'
+                    10 + (hex_char - 'A')
+                  else
+                    Error.at pos_single_with_offset(token, reader.pos),
+                      "This is an invalid unicode escape hex character"
+                  end
+                codepoint = 16_u32 * codepoint + hex_value
               end
               result << codepoint.chr
             when '\r', '\n' then

--- a/src/savi/parser/grammar.cr
+++ b/src/savi/parser/grammar.cr
@@ -50,11 +50,13 @@ module Savi::Parser
 
     # Define what a string looks like.
     string_char =
-      str("\\\"") | str("\\\\") |
+      str("\\'") | str("\\\"") | str("\\\\") |
       str("\\b") | str("\\f") | str("\\n") | str("\\r") | str("\\t") |
       str("\b")  | str("\f")  | str("\n")  | str("\r")  | str("\t") |
-      (str("\\u") >> digithex >> digithex >> digithex >> digithex) |
       (str("\\x") >> digithex >> digithex) |
+      (str("\\u") >> digithex >> digithex >> digithex >> digithex) |
+      (str("\\U") >> digithex >> digithex >> digithex >> digithex >>
+                     digithex >> digithex >> digithex >> digithex) |
       (char('\\') >> char('\r').maybe >> char('\n') >> s) |
       str("\\") >> ~(~char('(')) >> parens |
       str("\\").maybe >> (~char('"') >> ~char('\\') >> range(' ', 0x10FFFF_u32))
@@ -67,11 +69,13 @@ module Savi::Parser
 
     # Define what a character string looks like.
     character_char =
-      str("\\'") | str("\\\\") |
+      str("\\'") | str("\\\"") | str("\\\\") |
       str("\\b") | str("\\f") | str("\\n") | str("\\r") | str("\\t") |
       str("\b")  | str("\f")  | str("\n")  | str("\r")  | str("\t") |
-      (str("\\u") >> digithex >> digithex >> digithex >> digithex) |
       (str("\\x") >> digithex >> digithex) |
+      (str("\\u") >> digithex >> digithex >> digithex >> digithex) |
+      (str("\\U") >> digithex >> digithex >> digithex >> digithex >>
+                     digithex >> digithex >> digithex >> digithex) |
       (~char('\'') >> ~char('\\') >> range(' ', 0x10FFFF_u32))
     character = char('\'') >> character_char.repeat.named(:char) >> char('\'')
 


### PR DESCRIPTION
Prior to this commit, we only had the `\u` 16-bit escape sequence.

These two escape sequence forms are taken from C conventions.

This commit also adds the `\'` escape sequence for `"` strings and the `\"` escape sequence for `\'` strings, for consistency. This allows the user to switch from one string type to the other without needing to change their escape sequences, provided that both forms of quotes are already escaped.