### PR TITLE
Don't enforce indentation format rules within string literals.

### DIFF
--- a/spec/compiler/format.indent.savi.spec.md
+++ b/spec/compiler/format.indent.savi.spec.md
@@ -212,3 +212,76 @@ Multi-line function signatures should be indented correctly.
     "four"
   ]
 ```
+
+---
+
+No particular indentation is enforced inside literal string content.
+
+```savi
+  :fun example_1:
+    <<<
+      This is the most common kind of multi-line string,
+      with indentation consistently one level deeper than the outside.
+    >>>
+
+  :fun example_2:
+    <<<
+      But that isn't enforced and it's totally valid
+        to have string content that is indented at different levels,
+          because the extra indentation bytes will be part of the string!
+    >>>
+
+  :fun example_3:
+    "Sometimes you'll also want to write a
+multi-line string like this with normal quotes,
+where any indentation will end up as part of the string,
+which you might want to avoid.
+"
+
+  :fun example_4:
+    "The most common reason to use normal quotes
+is if you need to do something with string interpolation.
+But it's worth noting that interpolated code will end up
+having its indentation enforced, based on the indentation
+of the code around the string literal rather than the
+indentation of the literal content.
+
+So the following interpolation will end up being 6 spaces deep: \(
+@this_will_be(6).spaces_deep
+)
+"
+```
+```savi format.Indentation
+  :fun example_1:
+    <<<
+      This is the most common kind of multi-line string,
+      with indentation consistently one level deeper than the outside.
+    >>>
+
+  :fun example_2:
+    <<<
+      But that isn't enforced and it's totally valid
+        to have string content that is indented at different levels,
+          because the extra indentation bytes will be part of the string!
+    >>>
+
+  :fun example_3:
+    "Sometimes you'll also want to write a
+multi-line string like this with normal quotes,
+where any indentation will end up as part of the string,
+which you might want to avoid.
+"
+
+  :fun example_4:
+    "The most common reason to use normal quotes
+is if you need to do something with string interpolation.
+But it's worth noting that interpolated code will end up
+having its indentation enforced, based on the indentation
+of the code around the string literal rather than the
+indentation of the literal content.
+
+So the following interpolation will end up being 6 spaces deep: \(
+      @this_will_be(6).spaces_deep
+    )
+"
+```


### PR DESCRIPTION
Sometimes string literals want interior indentation levels based on the content of the string, but the Savi parser has no idea about this, so it cannot enforce a correct indentation there when it has no idea about the semantics of whatever language is inside the string literal's content.