### PR TITLE
Fix Crystal backtrace printing using `-gdwarf-4`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 # This bitcode needs to get linked into our Savi compiler executable.
 $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 	mkdir -p `dirname $@`
-	${CLANGXX} -v -emit-llvm -g \
+	${CLANGXX} -v -emit-llvm -g -gdwarf-4 \
 		-c `$(LLVM_CONFIG) --cxxflags` \
 		-target $(CLANG_TARGET_PLATFORM) \
 		$(CRYSTAL_PATH)/llvm/ext/llvm_ext.cc \
@@ -244,7 +244,7 @@ $(BUILD)/llvm_ext.bc: $(LLVM_PATH)
 # This bitcode needs to get linked into our Savi compiler executable.
 $(BUILD)/llvm_ext_for_savi.bc: $(LLVM_PATH) $(shell find src/savi/ext/llvm/for_savi -name '*.cc')
 	mkdir -p `dirname $@`
-	${CLANGXX} -v -emit-llvm -g \
+	${CLANGXX} -v -emit-llvm -g -gdwarf-4 \
 		-c `$(LLVM_CONFIG) --cxxflags` \
 		-target $(CLANG_TARGET_PLATFORM) \
 		src/savi/ext/llvm/for_savi/main.cc \


### PR DESCRIPTION
Even though Crystal claims to support DWARF 5
(https://github.com/crystal-lang/crystal/pull/11399), it actually chokes if encountering a DWARF 5 attribute, giving broken exception backtraces with a message like this:

```
Unable to load dwarf information: Unknown DW_FORM_strx1 (Exception)
```

Starting with clang-14, Clang will prefer DWARF 5 by default, which will make Savi un-debuggable when hitting an exception.

Thus, when generating the LLVM ext, we need to ask Clang to use DWARF 4 instead, for Crystal's sake.