### PR TITLE
Expose `dirname` from `SourceCodePos`

### DIFF
--- a/core/SourceCodePos.savi
+++ b/core/SourceCodePos.savi
@@ -2,6 +2,10 @@
   // TODO: include more properties from the original Savi::Source::Pos?
   :var string String: ""
   :var filename String: ""
+  :: The filepath relative to the package
+  :var filepath_pkgrel String: ""
   :var dirname String: ""
+  :var pkgname String: ""
+  :var pkgpath String: ""
   :var row USize: 0
   :var col USize: 0

--- a/core/SourceCodePos.savi
+++ b/core/SourceCodePos.savi
@@ -2,5 +2,6 @@
   // TODO: include more properties from the original Savi::Source::Pos?
   :var string String: ""
   :var filename String: ""
+  :var dirname String: ""
   :var row USize: 0
   :var col USize: 0

--- a/core/SourceCodePos.savi
+++ b/core/SourceCodePos.savi
@@ -4,6 +4,8 @@
   :var filename String: ""
   :: The filepath relative to the package
   :var filepath_pkgrel String: ""
+  :: The filepath relative to the root package
+  :var filepath_rootpkgrel String: ""
   :var dirname String: ""
   :var pkgname String: ""
   :var pkgpath String: ""

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -3262,11 +3262,14 @@ class Savi::Compiler::CodeGen
   def gen_source_code_pos(pos : Source::Pos)
     @source_code_pos_globals.fetch pos do
       global = gen_global_const(@gtypes["SourceCodePosition"], {
-        "string"   => gen_string(pos.content),
-        "filename" => gen_string(pos.source.filename),
-        "dirname"  => gen_string(pos.source.dirname),
-        "row"      => @isize.const_int(pos.row),
-        "col"      => @isize.const_int(pos.col),
+        "string"  => gen_string(pos.content),
+        "filename"=> gen_string(pos.source.filename),
+        "dirname" => gen_string(pos.source.dirname),
+        "pkgname" => gen_string(pos.source.package.name),
+        "pkgpath" => gen_string(pos.source.package.path),
+        "row"     => @isize.const_int(pos.row),
+        "col"     => @isize.const_int(pos.col),
+        "filepath_pkgrel" => gen_string(pos.source.filepath_relative_to_package),
       })
 
       @source_code_pos_globals[pos] = global

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -3264,6 +3264,7 @@ class Savi::Compiler::CodeGen
       global = gen_global_const(@gtypes["SourceCodePosition"], {
         "string"   => gen_string(pos.content),
         "filename" => gen_string(pos.source.filename),
+        "dirname"  => gen_string(pos.source.dirname),
         "row"      => @isize.const_int(pos.row),
         "col"      => @isize.const_int(pos.col),
       })

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -3270,6 +3270,8 @@ class Savi::Compiler::CodeGen
         "row"     => @isize.const_int(pos.row),
         "col"     => @isize.const_int(pos.col),
         "filepath_pkgrel" => gen_string(pos.source.filepath_relative_to_package),
+        "filepath_rootpkgrel" => gen_string((Path.new(pos.source.dirname).relative_to(
+          Path.new(@ctx.not_nil!.root_package_link.path)) / pos.source.filename).to_s)
       })
 
       @source_code_pos_globals[pos] = global

--- a/src/savi/source.cr
+++ b/src/savi/source.cr
@@ -14,6 +14,14 @@ struct Savi::Source
     File.join(@dirname, @filename)
   end
 
+  def filepath_relative_to_package
+    if reldir = Path.new(@dirname).relative_to?(@package.path)
+      (reldir / @filename).to_s
+    else
+      raise "File #{path} not relative to package #{@package.path}"
+    end
+  end
+
   def entire_pos
     Source::Pos.index_range(self, 0, content.bytesize)
   end


### PR DESCRIPTION
This will enable `Spec` to print absolute or project-root relative file paths.