### PR TITLE
Add `savi info` subcommand for clean CLI info fetching.

### DIFF
--- a/main.cr
+++ b/main.cr
@@ -40,6 +40,25 @@ module Savi
         Dir.cd(opts.cd.not_nil!) if opts.cd
         Cli.compile options, opts.backtrace
       end
+      sub "info" do
+        desc "get information"
+        usage "savi info [version|llvm-version|bin-path]"
+        help short: "-h"
+        argument "kind", type: String, desc: "kind of information to get"
+        run do |opts, args|
+          case args.kind
+          when "version"
+            puts Savi::VERSION
+          when "llvm-version"
+            puts Savi::LLVM_VERSION
+          when "bin-path"
+            puts File.dirname(Process.executable_path.not_nil!)
+          else
+            STDERR.puts "Unrecognized savi info argument: #{args.kind}"
+            exit 1
+          end
+        end
+      end
       sub "server" do
         alias_name "s"
         desc "run lsp server"


### PR DESCRIPTION
The `savi info` subcommand is intended for cleanly getting one piece of information about the Savi compiler/environment per call, without requiring the caller to use grep or similar for filtering.

Currently, the following three information items are supported:

- `version` - the release tag of Savi, or `unknown` if not a tagged release.
- `llvm-version` - the release tag of Savi's statically-linked LLVM, as given by `llvm-config --version`.
- `bin-path` - the absolute path to the `savi` binary on disk.

The main motivation for adding this feature at the moment is a desire to automate installation of built Savi programs into the same bin-path as the location where the `savi` binary is installed, because this location is likely to either be in the user's PATH or shimmed by `asdf`, and is the most appropriate place for installed application binaries to go.

Think use cases like Savi-built CLI tools in the Savi ecosystem, such as the `capnpc-savi` plugin in the `CapnProto` library, which the `capnp` tool will invoke for compiling `.capnp` files to `.savi`.