### PR TITLE
Add support for `SDK_ROOT` env var when targetting MacOS.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -258,7 +258,8 @@ class Savi::Compiler::Binary
   def each_sysroot_lib_glob(ctx, target)
     # For MacOS, we have just one valid sysroot path, so we can finish early.
     if target.macos?
-      yield "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib", nil
+      sdk_root = ENV["SDK_ROOT"]? || "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      yield "#{sdk_root}/usr/lib", nil
       return
     end
 


### PR DESCRIPTION
This allows for various use cases, such as:

- If on MacOS you have multiple SDKs installed, selecting the desired one.
- Cross-compiling from other systems, pointing to an SDK root you obtained, similar to the process described in [this Rust-related blog post]( https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html).