### PR TITLE
Refactor to strip debug symbols without using a shell command.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -43,12 +43,6 @@ class Savi::Compiler::Binary
       raise NotImplementedError.new(target.inspect)
     end
 
-    # If requested, strip debugging symbols from the binary.
-    if ctx.options.no_debug && !target.macos?
-      res = Process.run("/usr/bin/env", ["strip", bin_path], output: STDOUT, error: STDERR)
-      raise "strip failed" unless res.exit_code == 0
-    end
-
     # MacOS has a different way of dealing with debugging symbols - they are
     # in a subdirectory whose name matches the binary but is suffixed with .dSYM
     # rather than being embedded in the binary itself, as on other platforms.

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -111,6 +111,9 @@ class Savi::Compiler::BinaryObject
     # Otherwise we will only run a minimal set of passes.
     LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
 
+    # Strip debug info from the module if requested.
+    LibLLVM.strip_module_debug_info(mod.to_unsafe) if ctx.options.no_debug
+
     # Emit the combined/optimized LLVM IR to a file if requested to do so.
     FileUtils.mkdir_p(File.dirname(Binary.path_for(ctx)))
     mod.print_to_file("#{Binary.path_for(ctx)}.ll") if ctx.options.llvm_ir

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -15,6 +15,7 @@ lib LibLLVM
   fun is_unnamed_addr = LLVMIsUnnamedAddr(global : ValueRef) : Int32
   fun parse_bitcode_in_context = LLVMParseBitcodeInContext(context : ContextRef, mem_buf : MemoryBufferRef, out_m : ModuleRef*, out_message : UInt8**) : Int32
   fun link_modules = LLVMLinkModules2(dest : ModuleRef, src : ModuleRef) : Int32
+  fun strip_module_debug_info = LLVMStripModuleDebugInfo(mod : ModuleRef) : Bool
   fun const_lshr = LLVMConstLShr(lhs : ValueRef, rhs : ValueRef) : ValueRef
   fun const_and = LLVMConstAnd(lhs : ValueRef, rhs : ValueRef) : ValueRef
   fun const_shl = LLVMConstShl(lhs : ValueRef, rhs : ValueRef) : ValueRef


### PR DESCRIPTION
Instead of shelling out to the `strip` tool, we can just use the existing LLVM mechanism for stripping it from the LLVM IR for the module, before emitting to a binary.

This avoids a dependency on the `strip` tool being available in the environment that we're compiling in, and also avoids issues with cross-compilation causing `strip` to try to be used on binary files whose arch it does not understand.