### PR TITLE
Update to latest Savi runtime (`v0.20220929.0`).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built runtime bitcode from.
 # This needs to get bumped explicitly here when we do a new runtime build.
-RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/v0.20220912.1
+RUNTIME_BITCODE_RELEASE_URL?=https://github.com/savi-lang/runtime-bitcode/releases/download/v0.20220929.0
 $(eval $(call MAKE_VAR_CACHE_FOR,RUNTIME_BITCODE_RELEASE_URL))
 
 # This is the path where we look for the LLVM pre-built static libraries to be,


### PR DESCRIPTION
This adds support for `x86_64-unknown-dragonfly`,
and it also adds the possibility of using the
`-with-runtime-stats` variants of the bitcode.