### PR TITLE
Add `:link_lib` declarator, nested under `:ffi` declarations.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -413,6 +413,12 @@
 
   :term name Name
 
+:declarator link_lib
+  :intrinsic
+  :context ffi
+
+  :term name Name
+
 // TODO: Document this.
 :declarator inline
   :intrinsic

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -111,6 +111,13 @@ class Savi::Compiler::BinaryObject
     # Otherwise we will only run a minimal set of passes.
     LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
 
+    # Now that we've optimized, only actually called functions remain,
+    # so we can mark for linking those libraries that are associated to
+    # specific functions that come from those libraries.
+    ctx.link_libraries_by_foreign_function.each { |ffi_name, lib_name|
+      ctx.link_libraries.add(lib_name) if mod.functions[ffi_name]?
+    }
+
     # Strip debug info from the module if requested.
     LibLLVM.strip_module_debug_info(mod.to_unsafe) if ctx.options.no_debug
 

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -842,6 +842,11 @@ class Savi::Compiler::CodeGen
 
     ffi_link_name = gfunc.func.metadata[:ffi_link_name].as(String)
 
+    ffi_link_lib = gfunc.func.metadata[:ffi_link_lib]?.as(String?)
+    if ffi_link_lib
+      ctx.link_libraries_by_foreign_function[ffi_link_name] = ffi_link_lib
+    end
+
     use_external_llvm_func(ffi_link_name, params, ret, is_variadic)
   end
 

--- a/src/savi/compiler/context.cr
+++ b/src/savi/compiler/context.cr
@@ -44,12 +44,11 @@ class Savi::Compiler::Context
   getter xtypes_graph = XTypes::Graph::Pass.new
 
   getter link_libraries = Set(String).new
+  getter link_libraries_by_foreign_function = Hash(String, String).new
 
   getter options : Compiler::Options
   property prev_ctx : Context?
   property! root_docs : Array(AST::Document)
-
-  getter link_libraries
 
   getter errors = [] of Error
 

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -562,6 +562,9 @@ module Savi::Program::Intrinsic
       when "foreign_name"
         name = terms["name"].as(AST::Identifier)
         scope.current_function.metadata[:ffi_link_name] = name.value
+      when "link_lib"
+        name = terms["name"].as(AST::Identifier)
+        scope.current_function.metadata[:ffi_link_lib] = name.value
       else
         raise NotImplementedError.new(declarator.pretty_inspect)
       end


### PR DESCRIPTION
This declaration is like the global `:ffi_link_lib` declaration, except that it will only be linked if the associated `:ffi` function is actually used in the final program.

This is useful for things like platform-specific link libraries.