### PR TITLE
Add Kernel.framework/Headers search path for C compilation on MacOS.

### DIFF
--- a/spec/integration/run-ffi-link-c-files/vendor/mylib_add.c
+++ b/spec/integration/run-ffi-link-c-files/vendor/mylib_add.c
@@ -1,5 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+// We included some headers mainly to test that the compiler can find them.
+// We may or may not actually use features of them here.
 
 int mylib_add(int a, int b)
 {

--- a/spec/integration/run-ffi-link-c-files/vendor/mylib_sub.c
+++ b/spec/integration/run-ffi-link-c-files/vendor/mylib_sub.c
@@ -1,5 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
+// We included some headers mainly to test that the compiler can find them.
+// We may or may not actually use features of them here.
 
 int mylib_sub(int a, int b)
 {

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -235,8 +235,11 @@ class Savi::Compiler::BinaryObject
     compile_args << "-fgnuc-version=4.2.1" if target.macos?
     compile_args << c_file_path
 
+    is_debug = !ctx.options.no_debug
+
     llvm_module = LibLLVM.compile_c_for_savi(
       ctx.code_gen.llvm,
+      is_debug,
       compile_args.size, compile_args.map(&.to_unsafe),
       out out_ptr, out out_size,
     )

--- a/src/savi/ext/llvm/for_savi/LLVMCompileCForSavi.cc
+++ b/src/savi/ext/llvm/for_savi/LLVMCompileCForSavi.cc
@@ -31,6 +31,7 @@ extern "C" {
 
 LLVMModuleRef LLVMCompileCForSavi(
   LLVMContextRef Context,
+  bool IsDebug,
   int ArgC, const char **ArgV,
   const char** OutPtr, int* OutSize
 ) {
@@ -59,6 +60,10 @@ LLVMModuleRef LLVMCompileCForSavi(
       new clang::DiagnosticOptions()
     ),
     false
+  );
+
+  Compiler.getInvocation().getCodeGenOpts().setDebugInfo(
+    IsDebug ? clang::codegenoptions::FullDebugInfo : clang::codegenoptions::NoDebugInfo
   );
 
   // Compile (targetting an in-memory LLVM Module only).

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -39,6 +39,6 @@ lib LibLLVM
   fun link_for_savi = LLVMLinkForSavi(flavor : UInt8*, argc : Int32, argv : UInt8**, out_ptr : UInt8**, out_size : Int32*) : Bool
   fun optimize_for_savi = LLVMOptimizeForSavi(mod : ModuleRef, wants_full_optimization : Bool)
   fun default_c_flags_for_savi = LLVMDefaultCFlagsForSavi(target : UInt8*, out_args_ptr : UInt8***, out_args_count : Int32*)
-  fun compile_c_for_savi = LLVMCompileCForSavi(context : ContextRef, argc : Int32, argv : UInt8**, out_ptr : UInt8**, out_size : Int32*) : ModuleRef
+  fun compile_c_for_savi = LLVMCompileCForSavi(context : ContextRef, is_debug : Bool, argc : Int32, argv : UInt8**, out_ptr : UInt8**, out_size : Int32*) : ModuleRef
   fun remap_di_directory_for_savi = LLVMRemapDIDirectoryForSavi(mod : ModuleRef, before_dir : UInt8*, after_dir : UInt8*)
 end


### PR DESCRIPTION
This allows us to use headers like `stdarg.h` on MacOS.