### PR TITLE
Add `Bytes.fill_with` and `Bytes.fill_with_zeros`.

### DIFF
--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -84,6 +84,61 @@
 
   :fun ref clear: @_size = 0, @
 
+  :: Fill all or part of the buffer with a repetition of the given `byte` value.
+  ::
+  :: If specified, the fill range starts with the `from` parameter (inclusive)
+  :: and goes up to the `to` parameter (exclusive). If not specified, then all
+  :: currently populated bytes will be overwritten with the given `byte` value.
+  ::
+  :: If `to` is beyond the end of the currently populated bytes, the buffer
+  :: will be expanded as needed to that new size. If `from` is beyond the end
+  :: of the currently populated bytes, it will be silently moved to that point
+  :: such that all bytes added to the buffer will have the given `byte` value.
+  :: If `to` is less than `from`, this operation will have no effect.
+  ::
+  :: For the common case of filling with zeros, use `fill_with_zeros` instead.
+  :fun ref fill_with(byte U8, from USize = 0, to USize = @_size)
+    // Ensure that we won't leave a "hole" of undefined bytes.
+    from = from.at_most(@_size)
+
+    // If the fill range size is empty or negative, we have nothing to do.
+    return @ if (to <= from)
+
+    // We may need to expand the buffer, if the fill range goes beyond it.
+    if (@_size < to) (
+
+      // We may need to allocate a new pointer, if the fill range goes past it.
+      if (@_space < to) (
+        // If we're not filling the entire buffer, we need to reallocate the
+        // pointer so that existing data is copied. Otherwise we will allocate
+        // a new pointer with undefined data, because all of it will be memset.
+        if (from > 0) (@_ptr_reallocate(to) | @_ptr_allocate(to))
+      )
+      // The extended buffer has the size extended to include the fill range.
+      @_size = to
+    )
+
+    // Finally, fill the range.
+    _FFI.memset(@_ptr._offset(from), byte.i32, to - from)
+
+    @
+
+  :: Fill all or part of the buffer with zero-valued bytes.
+  ::
+  :: If specified, the fill range starts with the `from` parameter (inclusive)
+  :: and goes up to the `to` parameter (exclusive). If not specified, then all
+  :: currently populated bytes will be overwritten with the given `byte` value.
+  ::
+  :: If `to` is beyond the end of the currently populated bytes, the buffer
+  :: will be expanded as needed to that new size. If `from` is beyond the end
+  :: of the currently populated bytes, it will be silently moved to that point
+  :: such that all bytes added to the buffer will have the given `byte` value.
+  :: If `to` is less than `from`, this operation will have no effect.
+  ::
+  :: To fill with a byte value other than zero, use `fill_with` instead.
+  :fun ref fill_with_zeros(from USize = 0, to USize = @_size)
+    @fill_with(0, from, to)
+
   :fun format: Bytes.Format._new(@)
 
   :fun clone @'iso

--- a/core/_FFI.savi
+++ b/core/_FFI.savi
@@ -1,6 +1,7 @@
 :module _FFI
   :ffi puts(string CPointer(U8)) I32
   :ffi strlen(string CPointer(U8)) I32
+  :ffi memset(pointer CPointer(U8), char I32, count USize) None
   :ffi variadic snprintf(buffer CPointer(U8), buffer_size I32, fmt CPointer(U8)) I32
 
   :ffi pony_exitcode(code I32) None

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -161,6 +161,18 @@
     assert: (Bytes.new << b"example").clear.is_empty
     assert: (Bytes.new << b"example").clear.is_not_empty.is_false
 
+  :it "fills all or part of a range with zeros"
+    assert: Bytes.new.fill_with_zeros(0, 3) == b"\x00\x00\x00"
+    assert: b"foo bar".clone.fill_with_zeros(0, 3) == b"\x00\x00\x00 bar"
+    assert: b"foo bar".clone.fill_with_zeros(5, 9) == b"foo b\x00\x00\x00\x00"
+    assert: b"foo bar".clone.fill_with_zeros(5, 0) == b"foo bar"
+    assert: b"foo bar".clone.fill_with_zeros(7, 9) == b"foo bar\x00\x00"
+    assert: b"foo bar".clone.fill_with_zeros(8, 9) == b"foo bar\x00\x00"
+    assert: b"foo bar".clone.fill_with_zeros(9, 9) == b"foo bar\x00\x00"
+    assert: b"foo bar".clone.fill_with_zeros(10, 9) == b"foo bar\x00\x00"
+    assert: b"foo bar".clone.fill_with_zeros(0, 9) ==
+      b"\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
   :it "clones itself into a new bytes buffer"
     string Bytes = b"example"
     assert: string.clone == b"example"


### PR DESCRIPTION
`Bytes.fill_with_zeros` can be used to "zero out" all or part of the byte buffer, and `Bytes.fill_with` is the more general method for filling the byte buffer with any given value.

These are basically just safe wrappers for the `memset` C call.