### PR TITLE
Add `Bytes.copy_from` method.

### DIFF
--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -139,6 +139,42 @@
   :fun ref fill_with_zeros(from USize = 0, to USize = @_size)
     @fill_with(0, from, to)
 
+  :: Copy all or some of the bytes from the `source` buffer into this buffer.
+  :: Returns this buffer.
+  ::
+  :: The `dest_offset`, if specified, will determine where in the buffer
+  :: the source range will be copied into. If not specified, the content will be
+  :: appended to the end of the buffer, growing the size of the buffer, so
+  :: specifying a `dest_offset` is only necessary to copy to an earlier offset.
+  :: If too high of a `dest_offset` is given it will be silently truncated
+  :: to the highest allowed offset (appending to the end of the buffer).
+  ::
+  :: The `from` and `to` parameters, if given, specify the range in the source
+  :: buffer to copy (and indirectly determine how many bytes will be copied).
+  :: If these are out of bounds in the source buffer, they will be silently
+  :: trimmed to the buffer bounds, and if the range is zero sized then the
+  :: overall operation will have no effect.
+  :fun ref copy_from(
+    source Bytes'box
+    from USize = 0
+    to USize = USize.max_value
+    dest_offset USize = USize.max_value
+  )
+    // Silently truncate the ranges to the respective bounds.
+    // Return early if the source range is zero-sized.
+    dest_offset = dest_offset.at_most(@_size)
+    to = to.at_most(source.size)
+    return @ if (from >= to)
+
+    // Reserve space in the buffer and copy into it.
+    copy_size = to - from
+    dest_end = dest_offset + copy_size
+    @reserve(dest_end)
+    source._ptr._offset(from)._copy_to(@_ptr._offset(dest_offset), copy_size)
+    if (@_size < dest_end) (@_size = dest_end)
+
+    @
+
   :fun format: Bytes.Format._new(@)
 
   :fun clone @'iso

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -173,6 +173,17 @@
     assert: b"foo bar".clone.fill_with_zeros(0, 9) ==
       b"\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
+  :it "copies all or part of its content from another bytes buffer"
+    assert: Bytes.new.copy_from(b"foo") == b"foo"
+    assert: b"foo ".clone.copy_from(b"bar") == b"foo bar"
+    assert: b"foo ".clone.copy_from(b"bar", 0, 3) == b"foo bar"
+    assert: b"foo ".clone.copy_from(b"bar", 0, 9999) == b"foo bar"
+    assert: b"foo ".clone.copy_from(b"bar", 9999, 3) == b"foo "
+    assert: b"foo ".clone.copy_from(b"bar", 1, 2, 3) == b"fooa"
+    assert: b"foo ".clone.copy_from(b"bar", 0, 3, 0) == b"bar "
+    assert: b"foo ".clone.copy_from(b"bar", 0, 3, 1) == b"fbar"
+    assert: b"foo ".clone.copy_from(b"bar", 0, 3, 9999) == b"foo bar"
+
   :it "clones itself into a new bytes buffer"
     string Bytes = b"example"
     assert: string.clone == b"example"


### PR DESCRIPTION
This copies some or all bytes from one buffer into another.