### PR TITLE
Upgrade to LLVM 15.0.6

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,15 +70,15 @@ task:
       freebsd_instance:
         image: freebsd-13-1-release-amd64
 
-    - name: x86_64-apple-macosx
+    - name: arm64-apple-macosx
       environment:
-        TRIPLE: x86_64-apple-macosx
+        TRIPLE: arm64-apple-macosx
         DEPS_INSTALL: brew update --preinstall && brew install libiconv crystal && brew cleanup
         # Set up the SDKROOT path specific to the present XCode version.
-        SDKROOT: /Applications/Xcode-12.5.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+        SDKROOT: /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1" # optimizes brew install
       macos_instance:
-        image: big-sur-xcode-12.5
+        image: ghcr.io/cirruslabs/macos-ventura-xcode:14.2
       # Caching some homebrew directories helps save some of the otherwise huge
       # amount of time that it takes to update brew from the CI base image.
       brew_cache:
@@ -86,33 +86,33 @@ task:
       brew_usr_local_cache:
         folder: "/usr/local/Homebrew"
 
-    - name: arm64-apple-macosx
+    - name: x86_64-apple-macosx
       environment:
-        TRIPLE: arm64-apple-macosx
+        TRIPLE: x86_64-apple-macosx
         IS_CROSS_COMPILE: "1"
-        # Download arm64 versions of the libraries needed by Crystal runtime.
+        # Download x86_64 versions of the libraries needed by Crystal runtime.
         DEPS_INSTALL: "
           brew update --preinstall && brew install crystal && brew cleanup && \
-          mkdir /tmp/arm64 && \
-          brew fetch --bottle-tag=arm64_big_sur libgc && \
-          brew fetch --bottle-tag=arm64_big_sur libevent && \
-          brew fetch --bottle-tag=arm64_big_sur pcre && \
-          tar -xvf `brew --cache --bottle-tag=arm64_big_sur libgc` -C /tmp/arm64 --strip-components=2 && \
-          tar -xvf `brew --cache --bottle-tag=arm64_big_sur libevent` -C /tmp/arm64 --strip-components=2 && \
-          tar -xvf `brew --cache --bottle-tag=arm64_big_sur pcre` -C /tmp/arm64 --strip-components=2 && \
-          ls /tmp/arm64/lib"
-        # Tell make to use those arm64 versions we downloaded above.
+          mkdir /tmp/x86_64 && \
+          brew fetch --bottle-tag=ventura libgc && \
+          brew fetch --bottle-tag=ventura libevent && \
+          brew fetch --bottle-tag=ventura pcre && \
+          tar -xvf `brew --cache --bottle-tag=ventura libgc` -C /tmp/x86_64 --strip-components=2 && \
+          tar -xvf `brew --cache --bottle-tag=ventura libevent` -C /tmp/x86_64 --strip-components=2 && \
+          tar -xvf `brew --cache --bottle-tag=ventura pcre` -C /tmp/x86_64 --strip-components=2 && \
+          ls /tmp/x86_64/lib"
+        # Tell make to use those x86_64 versions we downloaded above.
         MAKE_EXTRA_ARGS: " \
-          TARGET_PLATFORM=arm64-apple-macosx \
-          LLVM_STATIC_PLATFORM=x86_64-apple-macosx \
-          LIB_GC=/tmp/arm64/lib/libgc.a \
-          LIB_EVENT=/tmp/arm64/lib/libevent.a  \
-          LIB_PCRE=/tmp/arm64/lib/libpcre.a"
+          TARGET_PLATFORM=x86_64-apple-macosx \
+          LLVM_STATIC_PLATFORM=arm64-apple-macosx \
+          LIB_GC=/tmp/x86_64/lib/libgc.a \
+          LIB_EVENT=/tmp/x86_64/lib/libevent.a \
+          LIB_PCRE=/tmp/x86_64/lib/libpcre.a"
         # Set up the SDKROOT path specific to the present XCode version.
-        SDKROOT: /Applications/Xcode-12.5.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+        SDKROOT: /Applications/Xcode-14.2.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1" # optimizes brew install
       macos_instance:
-        image: big-sur-xcode-12.5
+        image: ghcr.io/cirruslabs/macos-ventura-xcode:14.2
       # Caching some homebrew directories helps save some of the otherwise huge
       # amount of time that it takes to update brew from the CI base image.
       brew_cache:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
             os: ubuntu-20.04
             deps: sudo apt-get install -y libgc-dev
           - crystal: "1.5.0"
-            os: macos-13
+            os: macos-12 # upgrade to macos-13 when available
             deps: echo no system deps to download
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
             os: ubuntu-20.04
             deps: sudo apt-get install -y libgc-dev
           - crystal: "1.5.0"
-            os: macos-11
+            os: macos-13
             deps: echo no system deps to download
     runs-on: ${{matrix.os}}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ CLANG_TARGET_PLATFORM?=$(TARGET_PLATFORM)
 
 # Specify where to download our pre-built LLVM/clang static libraries from.
 # This needs to get bumped explicitly here when we do a new LLVM build.
-LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/v14.0.3-20220506
+LLVM_STATIC_RELEASE_URL?=https://github.com/savi-lang/llvm-static/releases/download/v15.0.6-20230104
 $(eval $(call MAKE_VAR_CACHE_FOR,LLVM_STATIC_RELEASE_URL))
 
 # Specify where to download our pre-built runtime bitcode from.

--- a/platform.sh
+++ b/platform.sh
@@ -42,20 +42,20 @@ elif uname | grep -iq 'DragonFly'; then
     fail "On DragonFly, the only arch currently supported is: x86_64"
   fi
 elif uname | grep -iq 'Darwin'; then
-  if uname -m | grep -iq 'x86_64'; then
-    echo 'x86_64-apple-macosx'
-  elif uname -m | grep -iq 'arm64'; then
+  if uname -m | grep -iq 'arm64'; then
+    echo 'arm64-apple-macosx'
+  elif uname -m | grep -iq 'x86_64'; then
     # LLVM static pre-built libraries are dual-arch, but we upload them
-    # under the name of the x86_64 arch - so we fake that arch here only
+    # under the name of the arm64 arch - so we fake that arch here only
     # for the case of determining paltform for downloading llvm-static libs.
     # For all other purposes we return the true platform triple.
     if [ "$purpose" = 'llvm-static' ]; then
-      echo 'x86_64-apple-macosx'
-    else
       echo 'arm64-apple-macosx'
+    else
+      echo 'x86_64-apple-macosx'
     fi
   else
-    fail "On Darwin, the only arches currently supported are: x86_64, arm64"
+    fail "On Darwin, the only arches currently supported are: arm64, x86_64"
   fi
 else
   fail "The only supported operating systems are: Linux, FreeBSD, Darwin"

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -108,9 +108,6 @@ class Savi::Compiler::CodeGen
     @target_info = Target.new(@target_machine.triple)
     @llvm = LLVM::Context.new
 
-    # TODO: Enable opaque pointers before they are mandatory in LLVM 16.
-    LibLLVM.context_set_opaque_pointers(@llvm, false)
-
     @mod = @llvm.new_module("main")
     @builder = @llvm.new_builder
 
@@ -142,7 +139,7 @@ class Savi::Compiler::CodeGen
       [] of LLVM::Type, @i32).as(LLVM::Function)
 
     @bitwidth = @isize.int_width.to_u.as(UInt32)
-    @memcpy = mod.functions.add("llvm.memcpy.p0i8.p0i8.i#{@bitwidth}",
+    @memcpy = mod.functions.add("llvm.memcpy.p0.p0.i#{@bitwidth}",
       [@ptr, @ptr, @isize, @i1], @void).as(LLVM::Function)
 
     @frames = [] of Frame
@@ -296,14 +293,12 @@ class Savi::Compiler::CodeGen
     when :i64 then @i64
     when :f32 then @f32
     when :f64 then @f64
-    when :ptr then llvm_type_of(ref.single_def!(ctx).cpointer_type_arg(ctx)).pointer
     when :isize then @isize
+    when :ptr then @ptr
+    when :struct_ptr then @ptr
+    when :struct_ptr_opaque then @ptr
     when :struct_value then
       @gtypes[ctx.reach[ref.single!].llvm_name].fields_struct_type
-    when :struct_ptr then
-      @gtypes[ctx.reach[ref.single!].llvm_name].struct_ptr
-    when :struct_ptr_opaque then
-      @obj_ptr
     else raise NotImplementedError.new(ref.llvm_use_type(ctx))
     end
   end
@@ -317,14 +312,12 @@ class Savi::Compiler::CodeGen
     when :i64 then @i64
     when :f32 then @f32
     when :f64 then @f64
-    when :ptr then llvm_type_of(ref.single_def!(ctx).cpointer_type_arg(ctx)).pointer
     when :isize then @isize
+    when :ptr then @ptr
+    when :struct_ptr then @ptr
+    when :struct_ptr_opaque then @ptr
     when :struct_value then
       @gtypes[ctx.reach[ref.single!].llvm_name].fields_struct_type
-    when :struct_ptr then
-      @gtypes[ctx.reach[ref.single!].llvm_name].struct_ptr
-    when :struct_ptr_opaque then
-      @obj_ptr
     else raise NotImplementedError.new(ref.llvm_mem_type(ctx))
     end
   end
@@ -430,17 +423,17 @@ class Savi::Compiler::CodeGen
     # Construct the following arguments to pass to the main function:
     # i32 argc = 0, i8** argv = ["savijit", NULL], i8** envp = [NULL]
     argc = @i32.const_int(1)
-    argv = @builder.alloca(@i8.pointer.array(2), "argv")
-    envp = @builder.alloca(@i8.pointer.array(1), "envp")
-    argv_0 = @builder.inbounds_gep(argv, @i32_0, @i32_0, "argv_0")
-    argv_1 = @builder.inbounds_gep(argv, @i32_0, @i32.const_int(1), "argv_1")
-    envp_0 = @builder.inbounds_gep(envp, @i32_0, @i32_0, "envp_0")
+    argv = @builder.alloca(@ptr.array(2), "argv")
+    envp = @builder.alloca(@ptr.array(1), "envp")
+    argv_0 = @builder.inbounds_gep(@ptr.array(2), argv, @i32_0, @i32_0, "argv_0")
+    argv_1 = @builder.inbounds_gep(@ptr.array(2), argv, @i32_0, @i32.const_int(1), "argv_1")
+    envp_0 = @builder.inbounds_gep(@ptr.array(1), envp, @i32_0, @i32_0, "envp_0")
     @builder.store(gen_cstring("savijit"), argv_0)
     @builder.store(@ptr.null, argv_1)
     @builder.store(@ptr.null, envp_0)
 
     # Call the main function with the constructed arguments.
-    res = @builder.call(@mod.functions["main"], [argc, argv_0, envp_0], "res")
+    res = gen_call_named("main", [argc, argv_0, envp_0], "res")
     @builder.ret(res)
   end
 
@@ -549,6 +542,24 @@ class Savi::Compiler::CodeGen
     frame.llvm_func.basic_blocks.append(name)
   end
 
+  def gen_call_named(
+    func_name : String,
+    args : Array(LLVM::Value),
+    value_name : String = ""
+  ) : LLVM::Value
+    func = @mod.functions[func_name]
+    @builder.call(func.function_type, func, args, value_name)
+  end
+
+  def gen_call_gfunc(
+    gfunc : GenFunc,
+    args : Array(LLVM::Value),
+    value_name : String = ""
+  ) : LLVM::Value
+    func = gfunc.llvm_func
+    @builder.call(func.function_type, func, args, value_name)
+  end
+
   def gen_llvm_func(name, param_types, ret_type)
     @mod.functions.add(name, param_types, ret_type) { |f|
       # Give the function private linkage unless the flag to keep all functions
@@ -591,7 +602,7 @@ class Savi::Compiler::CodeGen
     if gfunc.needs_receiver?
       receiver_type =
         if gfunc.boxed_fields_receiver?(ctx)
-          gtype.struct_ptr
+          @ptr
         else
           llvm_type_of(gtype)
         end
@@ -625,7 +636,7 @@ class Savi::Compiler::CodeGen
         # includes a receiver parameter, but throws it away without using it.
         vtable_name = "#{gfunc.llvm_name}.VIRTUAL"
         vparam_types = param_types.dup
-        vparam_types.unshift(gtype.struct_ptr)
+        vparam_types.unshift(@ptr)
 
         gen_llvm_func vtable_name, vparam_types, ret_type do |fn|
           next if gtype.type_def.is_abstract?(ctx) && (!gfunc.func.body || gfunc.func.cap.value != "non")
@@ -635,7 +646,7 @@ class Savi::Compiler::CodeGen
           forward_args =
             (vparam_types.size - 1).times.map { |i| fn.params[i + 1] }.to_a
 
-          result = @builder.call(gfunc.llvm_func, forward_args)
+          result = gen_call_gfunc(gfunc, forward_args)
           if ret_type == @void
             @builder.ret
           else
@@ -651,7 +662,7 @@ class Savi::Compiler::CodeGen
         vtable_name = "#{gfunc.llvm_name}.VIRTUAL"
         vparam_types = param_types.dup
         vparam_types.shift
-        vparam_types.unshift(gtype.struct_ptr)
+        vparam_types.unshift(@ptr)
 
         gen_llvm_func vtable_name, vparam_types, ret_type do |fn|
           next if gtype.type_def.is_abstract?(ctx) && (!gfunc.func.body || gfunc.func.cap.value != "non")
@@ -662,7 +673,7 @@ class Savi::Compiler::CodeGen
             (vparam_types.size - 1).times.map { |i| fn.params[i + 1] }.to_a
           forward_args.unshift(gen_unboxed_fields(fn.params[0], gtype))
 
-          result = @builder.call(gfunc.llvm_func, forward_args)
+          result = gen_call_gfunc(gfunc, forward_args)
           if ret_type == @void
             @builder.ret
           else
@@ -671,9 +682,9 @@ class Savi::Compiler::CodeGen
 
           gen_func_end
         end
-      elsif param_types.first != gtype.struct_ptr
-        # If the receiver parameter type doesn't match the struct pointer,
-        # we assume it is a boxed machine value, so we need a wrapper function
+      elsif param_types.first != @ptr
+        # If the receiver parameter type isn't a pointer, we assume
+        # the pointer is a boxed machine value, so we need a wrapper function
         # that will unwrap the raw machine value to use as the receiver.
         elem_types = gtype.fields_struct_type.struct_element_types
         raise "expected the receiver type to be a raw machine value" \
@@ -682,7 +693,7 @@ class Savi::Compiler::CodeGen
         vtable_name = "#{gfunc.llvm_name}.VIRTUAL"
         vparam_types = param_types.dup
         vparam_types.shift
-        vparam_types.unshift(gtype.struct_ptr)
+        vparam_types.unshift(@ptr)
 
         gen_llvm_func vtable_name, vparam_types, ret_type do |fn|
           next if gtype.type_def.is_abstract?(ctx) && (!gfunc.func.body || gfunc.func.cap.value != "non")
@@ -693,7 +704,7 @@ class Savi::Compiler::CodeGen
             (vparam_types.size - 1).times.map { |i| fn.params[i + 1] }.to_a
           forward_args.unshift(gen_unboxed_value(fn.params[0], gtype))
 
-          result = @builder.call(gfunc.llvm_func, forward_args)
+          result = gen_call_gfunc(gfunc, forward_args)
           if ret_type == @void
             @builder.ret
           else
@@ -716,9 +727,12 @@ class Savi::Compiler::CodeGen
       send_name = "#{gfunc.llvm_name}.SEND"
       msg_name = "#{gfunc.llvm_name}.SEND.MSG"
 
+      # The return type is None, which is a pointer.
+      none_ptr = @ptr
+
       # We'll fill in the implementation of this later, in gen_send_impl.
       gfunc.virtual_llvm_func = gfunc.send_llvm_func =
-        gen_llvm_func(send_name, param_types, @gtypes["None"].struct_ptr) {}
+        gen_llvm_func(send_name, param_types, none_ptr) {}
 
       # We also need to create a message type to use in the send operation.
       gfunc.send_msg_llvm_type =
@@ -758,7 +772,11 @@ class Savi::Compiler::CodeGen
             forward_args =
               (virtual_continue_param_types.size - 1).times.map { |i| fn.params[i + 1] }.to_a
 
-            result = @builder.call(gfunc.continue_llvm_func.not_nil!, forward_args)
+            result = @builder.call(
+              gfunc.continue_llvm_func.not_nil!.function_type,
+              gfunc.continue_llvm_func.not_nil!,
+              forward_args,
+            )
             if ret_type == @void
               @builder.ret
             else
@@ -812,7 +830,7 @@ class Savi::Compiler::CodeGen
         next if init_func.nil?
 
         call_args = [func_frame.receiver_value]
-        init_value = @builder.call(init_func.llvm_func, call_args)
+        init_value = gen_call_gfunc(init_func, call_args)
         gen_field_store(name, init_value)
       end
     end
@@ -872,33 +890,20 @@ class Savi::Compiler::CodeGen
   def gen_ffi_call(gfunc, args)
     llvm_ffi_func = gen_ffi_decl(gfunc)
 
-    # Sometimes different user libraries may bind to the same
-    # FFI function with different (but ABI-compatible) signatures.
-    # In such a case, the first binding "wins" and the other one
-    # ends up with possible different (but ABI-compatible) LLVM types,
-    # so we must cast the arguments to the appropriate types here.
-    param_types = llvm_ffi_func.type.element_type.params_types
-    cast_args = [] of LLVM::Value
-    args.each_with_index { |arg, index|
-      param_type = param_types[index]?
-      cast_args <<
-        if param_type && arg.type != param_type
-          @builder.bit_cast(arg, param_type, "#{arg.name}.FFICAST")
-        else
-          arg
-        end
-    }
-
     # Now call the FFI function, according to its convention.
     case gfunc.calling_convention
     when GenFunc::Simple
-      value = @builder.call llvm_ffi_func, cast_args
+      value = @builder.call(
+        llvm_ffi_func.function_type,
+        llvm_ffi_func,
+        args,
+      )
       value = gen_none if llvm_ffi_func.return_type == @void
       value
     when GenFunc::Errorable
       then_block = gen_block("invoke_then")
       else_block = gen_block("invoke_else")
-      value = @builder.invoke llvm_ffi_func, cast_args, then_block, else_block
+      value = @builder.invoke llvm_ffi_func, args, then_block, else_block
       value = gen_none if llvm_ffi_func.return_type == @void
 
       # In the else block, make a landing pad to catch the Pony-style error,
@@ -921,9 +926,6 @@ class Savi::Compiler::CodeGen
     # And possibly cast the return type, for the same reasons
     # that we possibly cast the argument types earlier above.
     ret_type = llvm_type_of(gfunc.func.ret.not_nil!, gfunc)
-    if value.type != ret_type
-      value = @builder.bit_cast(value, ret_type, "#{value.name}.FFICAST")
-    end
 
     value
   end
@@ -953,51 +955,36 @@ class Savi::Compiler::CodeGen
       when "_unsafe", "_unsafe_val"
         params[0]
       when "_offset", "offset"
-        @builder.bit_cast(
-          @builder.inbounds_gep(
-            @builder.bit_cast(params[0], elem_llvm_type.pointer),
-            params[1]
-          ),
-          params[0].type
-        )
+        @builder.inbounds_gep(elem_llvm_type, params[0], params[1])
       when "_get_at"
-        gep = @builder.inbounds_gep(params[0], params[1])
-        @builder.load(gep)
+        gep = @builder.inbounds_gep(elem_llvm_type, params[0], params[1])
+        @builder.load(elem_llvm_type, gep)
       when "_get_at_no_alias"
-        gep = @builder.inbounds_gep(params[0], params[1])
-        @builder.load(gep)
+        gep = @builder.inbounds_gep(elem_llvm_type, params[0], params[1])
+        @builder.load(elem_llvm_type, gep)
       when "_assign_at"
-        gep = @builder.inbounds_gep(params[0], params[1])
+        gep = @builder.inbounds_gep(elem_llvm_type, params[0], params[1])
         new_value = params[2]
         @builder.store(new_value, gep)
         new_value
       when "_displace_at"
-        gep = @builder.inbounds_gep(params[0], params[1])
+        gep = @builder.inbounds_gep(elem_llvm_type, params[0], params[1])
         new_value = params[2]
-        old_value = @builder.load(gep)
+        old_value = @builder.load(elem_llvm_type, gep)
         @builder.store(new_value, gep)
         old_value
       when "_copy_to"
-        @builder.call(@memcpy, [
-          @builder.bit_cast(params[1], @ptr),
-          @builder.bit_cast(params[0], @ptr),
-          @builder.mul(
-            params[2],
-            @isize.const_int(elem_size_value),
-          ),
+        @builder.call(@memcpy.function_type, @memcpy, [
+          params[1],
+          params[0],
+          @builder.mul(params[2], @isize.const_int(elem_size_value)),
           @i1.const_int(0),
         ])
         gen_none
       when "_compare"
-        @builder.call(
-          @mod.functions["memcmp"],
-          [params[0], params[1], params[2]],
-        )
+        gen_call_named("memcmp", [params[0], params[1], params[2]])
       when "_hash"
-        @builder.call(
-          @mod.functions["ponyint_hash_block"],
-          [params[0], params[1]],
-        )
+        gen_call_named("ponyint_hash_block", [params[0], params[1]])
       when "is_null"
         @builder.is_null(params[0])
       when "is_not_null"
@@ -1053,12 +1040,11 @@ class Savi::Compiler::CodeGen
       case gfunc.func.ident.value
       when "[]"
         param_type = params[0].type
+        asm_fn_type = LLVM::Type.function([param_type], @void)
         asm_fn = LLVM::Function.from_value(
-          LLVM::Type.function([param_type], @void).inline_asm(
-            "", "imr,~{memory}", true, false
-          )
+          asm_fn_type.inline_asm("", "imr,~{memory}", true, false)
         )
-        call = @builder.call(asm_fn, [params[0]])
+        call = @builder.call(asm_fn_type, asm_fn, [params[0]])
         call.add_instruction_attribute(
           LLVM::AttributeIndex::FunctionIndex.to_u32,
           LLVM::Attribute::NoUnwind, @llvm)
@@ -1071,12 +1057,11 @@ class Savi::Compiler::CodeGen
             if param_type.kind == LLVM::Type::Kind::Pointer
         gen_none
       when "observe_side_effects"
+        asm_fn_type = LLVM::Type.function([] of LLVM::Type, @void)
         asm_fn = LLVM::Function.from_value(
-          LLVM::Type.function([] of LLVM::Type, @void).inline_asm(
-            "", "~{memory}", true, false
-          )
+          asm_fn_type.inline_asm("", "~{memory}", true, false)
         )
-        call = @builder.call(asm_fn)
+        call = @builder.call(asm_fn_type, asm_fn, [] of LLVM::Value)
         call.add_instruction_attribute(
           LLVM::AttributeIndex::FunctionIndex.to_u32,
           LLVM::Attribute::NoUnwind, @llvm)
@@ -1391,7 +1376,7 @@ class Savi::Compiler::CodeGen
             use_external_llvm_func("llvm.bitreverse.i64", [@i64], @i64)
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
-        @builder.call(op_func, [params[0]])
+        @builder.call(op_func.function_type, op_func, [params[0]])
       when "swap_bytes"
         raise "swap_bytes float" if gtype.type_def.is_floating_point_numeric?(ctx)
         case bit_width_of(gtype)
@@ -1400,15 +1385,15 @@ class Savi::Compiler::CodeGen
         when 16
           op_func =
             use_external_llvm_func("llvm.bswap.i16", [@i16], @i16)
-          @builder.call(op_func, [params[0]])
+          @builder.call(op_func.function_type, op_func, [params[0]])
         when 32
           op_func =
             use_external_llvm_func("llvm.bswap.i32", [@i32], @i32)
-          @builder.call(op_func, [params[0]])
+          @builder.call(op_func.function_type, op_func, [params[0]])
         when 64
           op_func =
             use_external_llvm_func("llvm.bswap.i64", [@i64], @i64)
-          @builder.call(op_func, [params[0]])
+          @builder.call(op_func.function_type, op_func, [params[0]])
         else raise NotImplementedError.new(bit_width_of(gtype))
         end
       when "leading_zero_bits"
@@ -1428,7 +1413,7 @@ class Savi::Compiler::CodeGen
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
         gen_numeric_conv gtype, @gtypes["U8"],
-          @builder.call(op_func, [params[0], @i1_false])
+          @builder.call(op_func.function_type, op_func, [params[0], @i1_false])
       when "trailing_zero_bits"
         raise "trailing_zero_bits float" if gtype.type_def.is_floating_point_numeric?(ctx)
         op_func =
@@ -1446,7 +1431,7 @@ class Savi::Compiler::CodeGen
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
         gen_numeric_conv gtype, @gtypes["U8"],
-          @builder.call(op_func, [params[0], @i1_false])
+          @builder.call(op_func.function_type, op_func, [params[0], @i1_false])
       when "total_one_bits"
         raise "total_one_bits float" if gtype.type_def.is_floating_point_numeric?(ctx)
         op_func =
@@ -1464,7 +1449,7 @@ class Savi::Compiler::CodeGen
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
         gen_numeric_conv gtype, @gtypes["U8"], \
-          @builder.call(op_func, [params[0]])
+          @builder.call(op_func.function_type, op_func, [params[0]])
       when "+!", "-!", "*!"
         raise NotImplementedError.new("overflow-checked arithmetic for float") \
           if gtype.type_def.is_floating_point_numeric?(ctx)
@@ -1498,7 +1483,7 @@ class Savi::Compiler::CodeGen
         overflow_block = gen_block("overflow")
         after_block = gen_block("after")
 
-        result = @builder.call(op_func, [params[0], params[1]])
+        result = @builder.call(op_func.function_type, op_func, [params[0], params[1]])
 
         is_overflow = @builder.extract_value(result, 1)
         @builder.cond(is_overflow, overflow_block, after_block)
@@ -1538,7 +1523,7 @@ class Savi::Compiler::CodeGen
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
 
-        @builder.call(op_func, [params[0], params[1]])
+        @builder.call(op_func.function_type, op_func, [params[0], params[1]])
       when "bits"
         raise "bits integer" unless gtype.type_def.is_floating_point_numeric?(ctx)
         case bit_width_of(gtype)
@@ -1563,7 +1548,7 @@ class Savi::Compiler::CodeGen
             use_external_llvm_func("llvm.log.f64", [@f64], @f64)
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
-        @builder.call(op_func, [params[0]])
+        @builder.call(op_func.function_type, op_func, [params[0]])
       when "log2"
         raise "log2 integer" unless gtype.type_def.is_floating_point_numeric?(ctx)
         op_func =
@@ -1574,7 +1559,7 @@ class Savi::Compiler::CodeGen
             use_external_llvm_func("llvm.log2.f64", [@f64], @f64)
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
-        @builder.call(op_func, [params[0]])
+        @builder.call(op_func.function_type, op_func, [params[0]])
       when "log10"
         raise "log10 integer" unless gtype.type_def.is_floating_point_numeric?(ctx)
         op_func =
@@ -1585,7 +1570,7 @@ class Savi::Compiler::CodeGen
             use_external_llvm_func("llvm.log10.f64", [@f64], @f64)
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
-        @builder.call(op_func, [params[0]])
+        @builder.call(op_func.function_type, op_func, [params[0]])
       when "pow"
         raise "pow integer" unless gtype.type_def.is_floating_point_numeric?(ctx)
         op_func =
@@ -1596,7 +1581,7 @@ class Savi::Compiler::CodeGen
             use_external_llvm_func("llvm.pow.f64", [@f64, @f64], @f64)
           else raise NotImplementedError.new(bit_width_of(gtype))
           end
-        @builder.call(op_func, [params[0], params[1]])
+        @builder.call(op_func.function_type, op_func, [params[0], params[1]])
       when "next_pow2"
         raise "next_pow2 float" if gtype.type_def.is_floating_point_numeric?(ctx)
 
@@ -1606,7 +1591,7 @@ class Savi::Compiler::CodeGen
           else
             @builder.zext(params[0], @isize)
           end
-        res = @builder.call(@mod.functions["ponyint_next_pow2"], [arg])
+        res = gen_call_named("ponyint_next_pow2", [arg])
 
         if bit_width_of(gtype) < bit_width_of(@isize)
           @builder.trunc(res, llvm_type_of(gtype))
@@ -1708,7 +1693,7 @@ class Savi::Compiler::CodeGen
 
     member = member_ast.value
     arg_exprs = args_ast.try(&.terms.map(&.as(AST::Node?))) || [] of AST::Node?
-    args = arg_exprs.map { |x| gen_expr(x.not_nil!).as(LLVM::Value) }
+    args = arg_exprs.map { |x| gen_expr(x.not_nil!) }
     arg_frames = arg_exprs.map { nil.as(Frame?) }
 
     lhs_type = type_of(call.receiver)
@@ -1768,7 +1753,6 @@ class Savi::Compiler::CodeGen
         gen_vtable_func_get(
           receiver,
           lhs_type,
-          gfunc.virtual_llvm_func.type,
           gfunc.vtable_index,
           member,
         )
@@ -1794,14 +1778,7 @@ class Savi::Compiler::CodeGen
     if gfunc.needs_continuation?
       cont = gen_yielding_call_cont_gep(call, "#{gfunc.llvm_name}.CONT")
 
-      # We need to cast the cont argument if this is a virtual call.
-      if needs_virtual_call
-        cont_param_index = use_receiver ? 1 : 0
-        cont_param_type = llvm_func.type.element_type.params_types[cont_param_index]
-        cont_cast = @builder.bit_cast(cont, cont_param_type, "#{cont.name}.CAST")
-      end
-
-      args.unshift((cont_cast || cont).not_nil!)
+      args.unshift(cont.not_nil!)
       arg_exprs.unshift(nil)
       arg_frames.unshift(nil)
     end
@@ -1827,11 +1804,13 @@ class Savi::Compiler::CodeGen
     @di.set_loc(call.ident)
     result = gen_call(
       gfunc.reach_func.signature,
+      gfunc,
       llvm_func,
       args,
       arg_exprs,
       arg_frames,
       gfunc.func.has_tag?(:ffi) ? gfunc : nil,
+      needs_virtual_call,
       use_receiver,
       !cont.nil?,
     )
@@ -1918,7 +1897,6 @@ class Savi::Compiler::CodeGen
             gen_local_alloca(yield_param_ref, llvm_type_of(yield_param_ast))
 
           yield_out = @builder.extract_value(yield_out_all, index, yield_param_ref.name)
-          yield_out = @builder.bit_cast(yield_out, llvm_type_of(yield_param_ast))
           @builder.store(yield_out, yield_param_alloca)
         end
       end
@@ -1944,9 +1922,7 @@ class Savi::Compiler::CodeGen
       # If None is the yield in value type expected, just generate None,
       # allowing us to ignore the actual result value of the yield block.
       yield_in_value = gen_expr(yield_block_ast.not_nil!)
-      if llvm_type_of(yield_in_type) == @gtypes["None"].struct_type.pointer
-        yield_in_value = gen_none
-      end
+      yield_in_value = gen_none if yield_in_type.is_none?
       yield_in_block = @builder.insert_block.not_nil!
       @builder.br(continue_block)
 
@@ -1963,27 +1939,40 @@ class Savi::Compiler::CodeGen
 
       # We're now ready to call the continue function for this function.
       # We pass the continuation data and yield_in_value back as the arguments.
+      continue_llvm_func_type : LLVM::Type =
+        if needs_virtual_call
+          gfunc.virtual_continue_llvm_func.function_type
+        else
+          gfunc.continue_llvm_func.not_nil!.function_type
+        end
       continue_llvm_func =
         if needs_virtual_call
           gen_vtable_func_get(
             receiver,
             lhs_type,
-            gfunc.virtual_continue_llvm_func.type,
             gfunc.vtable_index_continue,
             "#{member}.CONTINUE",
           )
         else
           gfunc.continue_llvm_func.not_nil!
         end
-      again_args = [(cont_cast || cont).not_nil!, yield_in_value]
+      again_args = [cont.not_nil!, yield_in_value]
       again_arg_frames = arg_exprs.map { nil.as(Frame?) }
       if use_receiver
-        again_receiver = @builder.load(receiver_gep.not_nil!, "#{gfunc.llvm_name}.@")
+        again_receiver = @builder.load(
+          llvm_type_of(call.receiver),
+          receiver_gep.not_nil!,
+          "#{gfunc.llvm_name}.@",
+        )
         again_args.unshift(again_receiver)
         again_arg_frames.unshift(nil)
       end
       @di.set_loc(call.ident)
-      @builder.call(LLVM::Function.from_value(continue_llvm_func), again_args)
+      @builder.call(
+        continue_llvm_func_type,
+        LLVM::Function.from_value(continue_llvm_func),
+        again_args,
+      )
 
       # Return to the "maybe block", to determine if we need to iterate again.
       @builder.br(maybe_block)
@@ -2019,7 +2008,6 @@ class Savi::Compiler::CodeGen
   def gen_vtable_func_get(
     receiver : LLVM::Value,
     type_ref : Reach::Ref,
-    llvm_func_type : LLVM::Type,
     vtable_index : Int32,
     name : String,
   )
@@ -2032,23 +2020,38 @@ class Savi::Compiler::CodeGen
     desc = gen_get_desc(receiver)
     vtable_gep = @runtime.gen_vtable_gep_get(self, desc, "#{rname}.DESC.VTABLE")
     vtable_idx = @i32.const_int(vtable_index)
-    gep = @builder.inbounds_gep(vtable_gep, @i32_0, vtable_idx, "#{fname}.GEP")
-    load = @builder.load(gep, "#{fname}.LOAD")
-    func = @builder.bit_cast(load, llvm_func_type, fname)
+    gep = @builder.inbounds_gep(
+      @ptr,
+      @builder.inbounds_gep(@ptr, vtable_gep, @i32_0, "#{fname}.VTABLE.ARRAY"),
+      vtable_idx,
+      "#{fname}.GEP"
+    )
+    func = @builder.load(@ptr, gep, "#{fname}.LOAD")
 
     func
   end
 
   def gen_call(
     signature : Reach::Signature,
+    signature_gfunc : GenFunc,
     func : (LLVM::Function | LLVM::Value),
     args : Array(LLVM::Value),
     arg_exprs : Array(AST::Node?),
     arg_frames : Array(Frame?),
     is_ffi_gfunc : GenFunc?,
+    is_virtual_call : Bool,
     use_receiver : Bool,
     use_cont : Bool,
   )
+    llvm_func_type =
+      if func.is_a?(LLVM::Function)
+        func.function_type
+      elsif is_virtual_call
+        signature_gfunc.virtual_llvm_func.function_type
+      else
+        signature_gfunc.llvm_func.function_type
+      end
+
     # Get the list of parameter types, prepending the receiver type
     # and/or the continuation type if either or both is in use.
     param_types = signature.params.map(&.as(Reach::Ref?))
@@ -2067,7 +2070,7 @@ class Savi::Compiler::CodeGen
       end
 
       # Don't cast if the LLVM type already matches.
-      llvm_param_type = func.type.element_type.params_types[index]
+      llvm_param_type = llvm_func_type.params_types[index]
       if arg.type == llvm_param_type
         cast_args << arg
         next
@@ -2076,13 +2079,6 @@ class Savi::Compiler::CodeGen
       arg_expr = arg_exprs[index].not_nil!
       arg_frame = arg_frames[index]
       cast_args << gen_assign_cast(arg, param_type, llvm_param_type, arg_expr, arg_frame)
-    end
-
-    # Sometimes we need one last cast at the LLVM level.
-    cast_args.each_with_index do |arg, index|
-      llvm_param_type = func.type.element_type.params_types[index]
-      next if arg.type == llvm_param_type
-      cast_args[index] = @builder.bit_cast(arg, llvm_param_type, "#{arg.name}.CAST")
     end
 
     # Handle the special case of calling an FFI function. We need to call it
@@ -2100,12 +2096,12 @@ class Savi::Compiler::CodeGen
       return gen_ffi_call(is_ffi_gfunc, cast_args)
     end
 
-    @builder.call(LLVM::Function.from_value(func), cast_args)
+    @builder.call(llvm_func_type, func, cast_args)
   end
 
   def gen_eq(relate)
     ref = func_frame.refer[relate.lhs]
-    value = gen_expr(relate.rhs).as(LLVM::Value)
+    value = gen_expr(relate.rhs)
     name = value.name
     lhs_type =
       if ref.is_a?(Refer::Local)
@@ -2132,7 +2128,7 @@ class Savi::Compiler::CodeGen
 
   def gen_displacing_eq(relate)
     ref = func_frame.refer[relate.lhs]
-    value = gen_expr(relate.rhs).as(LLVM::Value)
+    value = gen_expr(relate.rhs)
     name = value.name
     lhs_type =
       if ref.is_a?(Refer::Local)
@@ -2153,7 +2149,7 @@ class Savi::Compiler::CodeGen
     @di.set_loc(relate.op)
 
     displaced_value = gen_assign_cast(
-      @builder.load(alloca, local_ref.as(Refer::Local).name),
+      @builder.load(lhs_llvm_type, alloca, local_ref.as(Refer::Local).name),
       type_of(relate),
       nil,
       func_frame.any_defn_for_local(local_ref),
@@ -2165,7 +2161,7 @@ class Savi::Compiler::CodeGen
   end
 
   def gen_field_eq(node : AST::FieldWrite)
-    value = gen_expr(node.rhs).as(LLVM::Value)
+    value = gen_expr(node.rhs)
     name = value.name
 
     value = gen_assign_cast(value, type_of(node), nil, node.rhs)
@@ -2179,7 +2175,7 @@ class Savi::Compiler::CodeGen
   def gen_field_displace(node : AST::FieldDisplace)
     old_value = gen_field_load(node.value)
 
-    value = gen_expr(node.rhs).as(LLVM::Value)
+    value = gen_expr(node.rhs)
     name = value.name
 
     value = gen_assign_cast(value, type_of(node), nil, node.rhs)
@@ -2300,12 +2296,7 @@ class Savi::Compiler::CodeGen
     && rhs.type.kind == LLVM::Type::Kind::Pointer
       # Objects (not boxed machine words) of the same type are compared by
       # integer comparison of the pointer to the object.
-      @builder.icmp(
-        pred,
-        @builder.bit_cast(lhs, @obj_ptr, "#{lhs.name}.CAST"),
-        @builder.bit_cast(rhs, @obj_ptr, "#{rhs.name}.CAST"),
-        "#{lhs.name}.is.#{rhs.name}",
-      )
+      @builder.icmp(pred, lhs, rhs, "#{lhs.name}.is.#{rhs.name}")
     else
       raise NotImplementedError.new("this comparison:\n#{pos.show}")
     end
@@ -2441,8 +2432,8 @@ class Savi::Compiler::CodeGen
     if rhs_type.is_concrete?(ctx)
       rhs_gtype = @gtypes[ctx.reach[rhs_type.single!].llvm_name]
 
-      lhs_desc = gen_get_desc_opaque(lhs)
-      rhs_desc = gen_get_desc_opaque(rhs_gtype)
+      lhs_desc = gen_get_desc(lhs)
+      rhs_desc = rhs_gtype.desc
 
       # For a positive check, we check if the type descriptors are equal.
       # For a negative check, we succeed if they are NOT equal.
@@ -2465,10 +2456,9 @@ class Savi::Compiler::CodeGen
 
       # Load the trait bitmap of the concrete type descriptor of the lhs.
       desc = gen_get_desc(lhs)
-      traits_gep = @runtime.gen_traits_gep_get(self, desc, "#{lhs.name}.DESC.TRAITS.GEP")
-      traits = @builder.load(traits_gep, "#{lhs.name}.DESC.TRAITS")
-      bits_gep = @builder.inbounds_gep(traits, @i32_0, shift, "#{lhs.name}.DESC.TRAITS.GEP.#{rhs_name}")
-      bits = @builder.load(bits_gep, "#{lhs.name}.DESC.TRAITS.#{rhs_name}")
+      traits = @runtime.gen_traits_get(self, desc, "#{lhs.name}.DESC.TRAITS")
+      bits_gep = @builder.inbounds_gep(@isize.array(0), traits, @i32_0, shift, "#{lhs.name}.DESC.TRAITS.GEP.#{rhs_name}")
+      bits = @builder.load(@isize, bits_gep, "#{lhs.name}.DESC.TRAITS.#{rhs_name}")
 
       # For a positive check, we check if the trait bit intersection is nonzero.
       # For a negative check, we succeed if it DOES equal zero.
@@ -2503,11 +2493,10 @@ class Savi::Compiler::CodeGen
     # Sometimes we may need to implicitly cast struct pointer to struct value.
     # We do that here by dereferencing the pointer.
     if value.type != from_llvm_type \
-    && value.type.kind == LLVM::Type::Kind::Pointer \
-    && value.type.element_type.kind == LLVM::Type::Kind::Struct \
-    && value.type.element_type.struct_element_types[-1] == from_llvm_type
+    && value.type.kind == LLVM::Type::Kind::Pointer
       value = gen_unboxed_fields(value, gtype_of(from_type))
     end
+    from_llvm_type = value.type
 
     # We assert that the origin llvm type derived from type analysis is the
     # same as the actual type of the llvm value we are being asked to cast.
@@ -2524,11 +2513,6 @@ class Savi::Compiler::CodeGen
         value, from_kind, to_kind, from_type, to_type, from_expr)
     end
 
-    # Finally, if the LLVM type doesn't yet match, proceed with a bit cast.
-    if value.type != to_llvm_type
-      value = @builder.bit_cast(value, to_llvm_type, "#{value.name}.CAST")
-    end
-
     value
   end
 
@@ -2541,7 +2525,9 @@ class Savi::Compiler::CodeGen
     @builder.store(
       value,
       @builder.struct_gep(
+        gtype.fields_struct_type,
         @builder.struct_gep(
+          gtype.struct_type,
           boxed,
           gtype.fields_struct_index,
           "#{value.name}.BOXED.FIELDS.GEP"
@@ -2558,13 +2544,12 @@ class Savi::Compiler::CodeGen
   def gen_unboxed_value(boxed, gtype)
     # Load the value itself from the value field of the boxed struct pointer.
     @builder.load(
+      gtype.fields_struct_type.struct_element_types[0],
       @builder.struct_gep(
+        gtype.fields_struct_type,
         @builder.struct_gep(
-          @builder.bit_cast(
-            boxed,
-            gtype.struct_ptr,
-            "#{boxed.name}.BOXED"
-          ),
+          gtype.struct_type,
+          boxed,
           gtype.fields_struct_index,
           "#{boxed.name}.FIELDS.GEP"
         ),
@@ -2584,6 +2569,7 @@ class Savi::Compiler::CodeGen
     @builder.store(
       fields_value,
       @builder.struct_gep(
+        gtype.struct_type,
         boxed,
         gtype.fields_struct_index,
         "#{fields_value.name}.BOXED.FIELDS.GEP"
@@ -2597,12 +2583,10 @@ class Savi::Compiler::CodeGen
   def gen_unboxed_fields(boxed, gtype)
     # Load the fields value from the fields struct of the boxed struct pointer.
     @builder.load(
+      gtype.fields_struct_type,
       @builder.struct_gep(
-        @builder.bit_cast(
-          boxed,
-          gtype.struct_ptr,
-          "#{boxed.name}.BOXED"
-        ),
+        gtype.struct_type,
+        boxed,
         gtype.fields_struct_index,
         "#{boxed.name}.FIELDS.GEP"
       ),
@@ -2623,7 +2607,7 @@ class Savi::Compiler::CodeGen
 
         alloca = func_frame.current_locals[local_ref]
         gen_assign_cast(
-          @builder.load(alloca, local_ref.name),
+          @builder.load(alloca.allocated_type, alloca, local_ref.name),
           type_of(expr),
           nil,
           func_frame.any_defn_for_local(ref),
@@ -2771,10 +2755,6 @@ class Savi::Compiler::CodeGen
     @gtypes["None"].singleton
   end
 
-  def gen_none_type
-    @gtypes["None"].struct_type.pointer
-  end
-
   def gen_bool(bool)
     @i1.const_int(bool ? 1 : 0)
   end
@@ -2815,18 +2795,7 @@ class Savi::Compiler::CodeGen
       # meaning that we need to unbox it as such here. This will fail
       # in a silent and ugly way if the type system doesn't properly
       # ensure that the value we hold here is truly a Bool.
-      @builder.load(
-        @builder.struct_gep(
-          @builder.bit_cast(
-            value,
-            @gtypes["Bool"].struct_ptr,
-            "#{value.name}.BOXED",
-          ),
-          1,
-          "#{value.name}.VALUE",
-        ),
-        "#{value.name}.VALUE.LOAD",
-      )
+      gen_unboxed_value(value, @gtypes["Bool"])
     else
       raise NotImplementedError.new(value.type)
     end
@@ -3216,6 +3185,7 @@ class Savi::Compiler::CodeGen
 
   def gen_cstring(value : String) : LLVM::Value
     @llvm.const_inbounds_gep(
+      @ptr,
       @cstring_globals.fetch value do
         global = gen_global_for_const(@llvm.const_string(value))
 
@@ -3257,7 +3227,7 @@ class Savi::Compiler::CodeGen
       gen_global_const(array_gtype, {
         "_size"  => @isize.const_int(values.size),
         "_space" => @isize.const_int(values.size),
-        "_ptr"   => @llvm.const_inbounds_gep(values_global, [@i32_0, @i32_0])
+        "_ptr"   => @llvm.const_inbounds_gep(@ptr, values_global, [@i32_0, @i32_0])
       })
     else
       gen_global_const(array_gtype, {
@@ -3295,18 +3265,14 @@ class Savi::Compiler::CodeGen
     alloca
   end
 
-  def gen_static_address_of_function(expr : AST::Relate)
+  def gen_static_address_of_function(expr : AST::Relate) : LLVM::Value
     receiver = gen_expr(expr.lhs)
 
     gtype, gfunc = resolve_call(
       AST::Call.new(expr.lhs, expr.rhs.as(AST::Identifier)).from(expr)
     )
 
-    @builder.bit_cast(
-      gfunc.llvm_func.to_value,
-      gen_none_type.pointer,
-      "#{gfunc.llvm_name}.PTR"
-    )
+    gfunc.llvm_func.to_value
   end
 
   def gen_reflection_of_type(expr, term_expr)
@@ -3350,7 +3316,7 @@ class Savi::Compiler::CodeGen
               mutator =
                 if gfunc.func.cap.value == "ref" \
                 && (gfunc.func.params.try(&.terms.size) || 0) == 0 \
-                && gfunc.llvm_func.return_type == @gtypes["None"].struct_type.pointer
+                && gfunc.reach_func.signature.ret.is_none?
                   gen_reflection_mutator_of_type(mutator_gtype, gtype, gfunc)
                 else
                   gen_none
@@ -3403,7 +3369,11 @@ class Savi::Compiler::CodeGen
         mutator_call_gfunc.virtual_llvm_func.function_type.return_type,
       ) do |fn|
         gen_func_start(fn)
-        @builder.ret @builder.call(gfunc.llvm_func, [fn.params[1]])
+        @builder.ret @builder.call(
+          gfunc.llvm_func.function_type,
+          gfunc.llvm_func,
+          [fn.params[1]]
+        )
         gen_func_end
       end
 
@@ -3412,13 +3382,11 @@ class Savi::Compiler::CodeGen
 
     # Create a vtable that places our via function in the proper index.
     vtable = mutator_gtype.gen_vtable(self)
-    vtable[mutator_call_gfunc.vtable_index] =
-      @llvm.const_bit_cast(via_llvm_func.to_value, @ptr)
+    vtable[mutator_call_gfunc.vtable_index] = via_llvm_func.to_value
 
     # Save the name of the mutator gtype's type_def as a proper String,
     # casting it to an opaque pointer to avoid circular dependency on descs.
-    type_name_string_opaque =
-      @builder.bit_cast(gen_string(mutator_gtype.type_def.llvm_name), @ptr)
+    type_name_string = gen_string(mutator_gtype.type_def.llvm_name)
 
     # Generate a type descriptor, so this can masquerade as a real module.
     raise NotImplementedError.new("gen_reflection_mutator_of_type in Verona") \
@@ -3439,7 +3407,7 @@ class Savi::Compiler::CodeGen
       @final_fn_ptr.null,                  # 12: final fn
       @i32.const_int(-1),                  # 13: event notify
       traits_bitmap_global,                # 14: traits bitmap
-      type_name_string_opaque,             # 15: type name (REPLACES unused field descriptors from Pony)
+      type_name_string,                    # 15: type name (REPLACES unused field descriptors from Pony)
       @ptr.const_array(vtable),            # 16: vtable
     ])
 
@@ -3452,8 +3420,7 @@ class Savi::Compiler::CodeGen
     value_type = value.type
 
     desc =
-      if value_type.kind == LLVM::Type::Kind::Pointer \
-        && value_type.element_type.kind == LLVM::Type::Kind::Struct
+      if value_type.kind == LLVM::Type::Kind::Pointer
         # This has an object header, so we can get the descriptor at runtime.
         gen_get_desc(value)
       else
@@ -3481,7 +3448,7 @@ class Savi::Compiler::CodeGen
     # TODO: Pop the scope frame?
   end
 
-  def gen_dynamic_array(expr : AST::Group)
+  def gen_dynamic_array(expr : AST::Group) : LLVM::Value
     gtype = gtype_of(expr)
 
     # If this array expression is inside of a constant, we know that it has
@@ -3489,20 +3456,26 @@ class Savi::Compiler::CodeGen
     # TODO: Is it possible to determine that other array expressions in other
     # code snippets are safe to be lifted to constant expressions?
     if func_frame.gfunc.try(&.func.has_tag?(:constant))
-      return gen_array(gtype, expr.terms.map { |term|
-        gen_expr(term).as(LLVM::Value)
-      })
+      return gen_array(gtype, expr.terms.map { |term| gen_expr(term) })
     end
 
     receiver = gen_alloc(gtype, expr, "#{gtype.type_def.llvm_name}.new")
     size_arg = @i64.const_int(expr.terms.size)
-    @builder.call(gtype.default_constructor.llvm_func, [receiver, size_arg])
+    @builder.call(
+      gtype.default_constructor.llvm_func.function_type,
+      gtype.default_constructor.llvm_func,
+      [receiver, size_arg],
+    )
 
     arg_type = gtype.gfuncs["<<"].reach_func.signature.params.first
 
     expr.terms.each do |term|
       value = gen_assign_cast(gen_expr(term), arg_type, nil, term)
-      @builder.call(gtype.gfuncs["<<"].llvm_func, [receiver, value])
+      @builder.call(
+        gtype.gfuncs["<<"].llvm_func.function_type,
+        gtype.gfuncs["<<"].llvm_func,
+        [receiver, value]
+      )
     end
 
     receiver
@@ -3879,7 +3852,7 @@ class Savi::Compiler::CodeGen
     end
 
     # Generate code for the values of the yield, and capture the values.
-    yield_values = expr.terms.map { |term| gen_expr(term).as(LLVM::Value) }
+    yield_values = expr.terms.map { |term| gen_expr(term) }
 
     # Capture the current value of each local variable, because we store every
     # local not only in the continuation but also in its own dedicated alloca.
@@ -3895,12 +3868,15 @@ class Savi::Compiler::CodeGen
     # but this can't always happen (e.g. for recursive yielding calls).
     ctx.inventory[gfunc.link].each_local.each_with_index do |ref, ref_index|
       cont = func_frame.continuation_value
-      cont_local = @builder.bit_cast(
-        gfunc.continuation_info.struct_gep_for_local(cont, ref),
-        llvm_type_of(func_frame.any_defn_for_local(ref)).pointer
-      )
+      cont_local =
+        gfunc.continuation_info.struct_gep_for_local(cont, ref)
       local = frame.current_locals[ref]
-      @builder.store(builder.load(local, "#{ref.name}.CURRENT"), cont_local)
+      local_llvm_type = llvm_type_of(func_frame.any_defn_for_local(ref))
+
+      @builder.store(
+        builder.load(local_llvm_type, local, "#{ref.name}.CURRENT"),
+        cont_local,
+      )
     end
 
     # Generate the return statement, which terminates this basic block and
@@ -3945,14 +3921,7 @@ class Savi::Compiler::CodeGen
     # with an alloca in between the two as a pointer that we can cast.
     alloca = gen_alloca(value.type, "#{value.name}.PTR")
     @builder.store(value, alloca)
-    @builder.load(
-      @builder.bit_cast(
-        alloca,
-        to_type.pointer,
-        "#{value.name}.CAST.PTR",
-      ),
-      "#{value.name}.CAST",
-    )
+    @builder.load(to_type, alloca, "#{value.name}.CAST")
   end
 
   # Create an alloca at the entry block then return us back to whence we came.
@@ -4061,31 +4030,19 @@ class Savi::Compiler::CodeGen
     @runtime.gen_alloc_struct(self, llvm_type, name)
   end
 
-  # Get the global constant value for the type descriptor of the given type.
-  def gen_get_desc_opaque(gtype : GenType)
-    @llvm.const_bit_cast(gtype.desc, @desc_ptr)
-  end
-
-  # Get the global constant value for the type descriptor of the given type.
-  def gen_get_desc_opaque(value : LLVM::Value)
-    desc = gen_get_desc(value)
-    @builder.bit_cast(desc, @desc_ptr, "#{value.name}.OPAQUE")
-  end
-
   # Dereference the type descriptor header of the given LLVM value,
   # loading the type descriptor of the object at runtime.
   # Prefer the above function instead when the type is statically known.
   def gen_get_desc(value : LLVM::Value)
     value_type = value.type
     raise "not a struct pointer: #{value}" \
-      unless value_type.kind == LLVM::Type::Kind::Pointer \
-        && value_type.element_type.kind == LLVM::Type::Kind::Struct
+      unless value_type.kind == LLVM::Type::Kind::Pointer
 
     @runtime.gen_get_desc(self, value)
   end
 
   def gen_put_desc(value, gtype, name = "")
-    desc_p = @builder.struct_gep(value, 0, "#{name}.DESC.GEP")
+    desc_p = @builder.struct_gep(@obj, value, 0, "#{name}.DESC.GEP")
     @builder.store(gtype.desc, desc_p)
     # TODO: tbaa? (from set_descriptor in libponyc/codegen/gencall.c)
   end
@@ -4128,12 +4085,14 @@ class Savi::Compiler::CodeGen
     raise "inconsistent frames" if @frames.size > 1
     object = func_frame.receiver_value
 
-    if object.type != gtype.struct_ptr
-      raise "current receiver is not a pointer to the expected gtype pointer: #{object.inspect}"
+    if object.type != @ptr
+      raise "current receiver is not a pointer: #{object.inspect}"
     end
 
     @builder.struct_gep(
+      gtype.struct_type.struct_element_types[gtype.fields_struct_index],
       @builder.struct_gep(
+        gtype.struct_type,
         object,
         gtype.fields_struct_index,
         "@.FIELDS.GEP"
@@ -4150,7 +4109,7 @@ class Savi::Compiler::CodeGen
     if object.type == gtype.fields_struct_type
       @builder.extract_value(object, gtype.field_index(name), "@.#{name}")
     else
-      @builder.load(gen_field_gep(name, gtype), "@.#{name}")
+      @builder.load(gtype.field_llvm_type(name), gen_field_gep(name, gtype), "@.#{name}")
     end
   end
 

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -107,6 +107,10 @@ class Savi::Compiler::CodeGen
     @target_machine = @target.create_target_machine(@target_triple).as(LLVM::TargetMachine)
     @target_info = Target.new(@target_machine.triple)
     @llvm = LLVM::Context.new
+
+    # TODO: Enable opaque pointers before they are mandatory in LLVM 16.
+    LibLLVM.context_set_opaque_pointers(@llvm, false)
+
     @mod = @llvm.new_module("main")
     @builder = @llvm.new_builder
 

--- a/src/savi/compiler/code_gen/gen_type.cr
+++ b/src/savi/compiler/code_gen/gen_type.cr
@@ -133,16 +133,16 @@ class Savi::Compiler::CodeGen
       @fields.find(&.first.==(name)).try(&.last)
     end
 
-    def struct_ptr
-      struct_type.pointer
-    end
-
     def fields_struct_index
       struct_type.struct_element_types.size - 1
     end
 
     def field_index(name)
       @fields.index { |n, _| n == name }.not_nil!
+    end
+
+    def field_llvm_type(name)
+      fields_struct_type.struct_element_types[field_index(name)]
     end
 
     def each_gfunc

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -238,7 +238,7 @@ class Savi::Compiler::CodeGen::PonyRT
       ]},
       {"ponyint_hash_block", [@ptr, @isize], @isize, [
         LLVM::Attribute::NoRecurse, LLVM::Attribute::NoUnwind,
-        LLVM::Attribute::ReadOnly, LLVM::Attribute::UWTable,
+        LLVM::Attribute::ReadOnly,
         {1, LLVM::Attribute::ReadOnly},
       ]},
 

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -255,7 +255,7 @@ class Savi::Compiler::CodeGen::PonyRT
   end
 
   def gen_alloc_ctx_get(g : CodeGen)
-    g.builder.call(g.mod.functions["pony_ctx"], "ALLOC_CTX")
+    g.gen_call_named("pony_ctx", [] of LLVM::Value, "ALLOC_CTX")
   end
 
   def cast_kind_of(
@@ -504,17 +504,35 @@ class Savi::Compiler::CodeGen::PonyRT
   end
 
   def gen_vtable_gep_get(g, desc, name)
-    g.builder.struct_gep(desc, DESC_VTABLE, name)
+    g.builder.struct_gep(@desc, desc, DESC_VTABLE, name)
+  end
+
+  def gen_vtable_get(g, desc, name)
+    g.builder.load(
+      @desc.struct_element_types[DESC_VTABLE],
+      gen_vtable_gep_get(g, desc, name),
+      "#{name}.DESC.TRAITS",
+    )
   end
 
   def gen_traits_gep_get(g, desc, name)
-    g.builder.struct_gep(desc, DESC_TRAITS, name)
+    g.builder.struct_gep(@desc, desc, DESC_TRAITS, name)
+  end
+
+  def gen_traits_get(g, desc, name)
+    g.builder.load(
+      @desc.struct_element_types[DESC_TRAITS],
+      gen_traits_gep_get(g, desc, name),
+      "#{name}.DESC.TRAITS",
+    )
   end
 
   def gen_type_name_get(g, desc, name)
-    gep = g.builder.struct_gep(desc, DESC_TYPE_NAME, "#{name}.GEP")
-    opaque = g.builder.load(gep, "#{name}.OPAQUE")
-    opaque = g.builder.bit_cast(opaque, g.gtypes["String"].struct_ptr, name)
+    g.builder.load(
+      @ptr,
+      g.builder.struct_gep(@desc, desc, DESC_TYPE_NAME, "#{name}.GEP"),
+      name,
+    )
   end
 
   def gen_struct_type(g : CodeGen, gtype : GenType)
@@ -537,8 +555,8 @@ class Savi::Compiler::CodeGen::PonyRT
   end
 
   def gen_get_desc(g : CodeGen, value : LLVM::Value)
-    desc_gep = g.builder.struct_gep(value, 0, "#{value.name}.DESC.GEP")
-    g.builder.load(desc_gep, "#{value.name}.DESC")
+    desc_gep = g.builder.struct_gep(@obj, value, 0, "#{value.name}.DESC.GEP")
+    g.builder.load(@ptr, desc_gep, "#{value.name}.DESC")
   end
 
   def gen_main(g : CodeGen)
@@ -557,7 +575,7 @@ class Savi::Compiler::CodeGen::PonyRT
 
     # Call pony_init, letting it optionally consume some of the CLI args,
     # giving us a new value for argc and a mutated argv array.
-    argc = g.builder.call(g.mod.functions["pony_init"], [argc, argv], "argc")
+    argc = g.gen_call_named("pony_init", [argc, argv], "argc")
 
     # Get the current alloc_ctx and hold on to it.
     alloc_ctx = gen_alloc_ctx_get(g)
@@ -567,19 +585,26 @@ class Savi::Compiler::CodeGen::PonyRT
     main_actor = gen_alloc_actor(g, g.gtype_main, nil, "main", become_now: true)
 
     env = gen_alloc(g, g.gtypes["Env"], nil, "env")
-    g.builder.call(g.gtypes["Env"]["_create"].llvm_func, [env, argc, argv, envp])
+    g.gen_call_gfunc(g.gtypes["Env"]["_create"], [env, argc, argv, envp])
 
     # TODO: Run module initialisers using the main actor's heap.
 
     # Send the env in a message to the main actor's constructor
-    g.builder.call(g.gtype_main.default_constructor.send_llvm_func, [main_actor, env])
+    g.builder.call(
+      g.gtype_main.default_constructor.send_llvm_func.function_type,
+      g.gtype_main.default_constructor.send_llvm_func,
+      [main_actor, env],
+    )
 
     # Start the runtime.
-    start_success = g.builder.call(g.mod.functions["pony_start"], [
-      @i1.const_int(0),
-      @i32_ptr.null,
-      @ptr.null, # TODO: pony_language_features_init_t*
-    ], "start_success")
+    start_success = g.gen_call_named("pony_start",
+      [
+        @i1.const_int(0),
+        @i32_ptr.null,
+        @ptr.null, # TODO: pony_language_features_init_t*
+      ],
+      "start_success"
+    )
 
     # Branch based on the value of `start_success`.
     start_fail_block = g.gen_block("start_fail")
@@ -588,9 +613,9 @@ class Savi::Compiler::CodeGen::PonyRT
 
     # On failure, just write a failure message then continue to the post_block.
     g.finish_block_and_move_to(start_fail_block)
-    g.builder.call(g.mod.functions["puts"], [
-      g.gen_cstring("Error: couldn't start the runtime!")
-    ])
+    g.gen_call_named("puts",
+      [g.gen_cstring("Error: couldn't start the runtime!")]
+    )
     g.builder.br(post_block)
 
     # On success (or after running the failure block), do the following:
@@ -599,14 +624,11 @@ class Savi::Compiler::CodeGen::PonyRT
     # TODO: Run module finalizers.
 
     # Become nothing (stop being the main actor).
-    g.builder.call(g.mod.functions["ponyint_become"], [
-      g.func_frame.alloc_ctx,
-      @obj_ptr.null,
-    ])
+    g.gen_call_named("ponyint_become", [g.func_frame.alloc_ctx, @obj_ptr.null])
 
     # Get the program's chosen exit code (or 0 by default), but override
     # it with -1 if we failed to start the runtime.
-    exitcode = g.builder.call(g.mod.functions["pony_get_exitcode"], "exitcode")
+    exitcode = g.gen_call_named("pony_get_exitcode", [] of LLVM::Value, "exitcode")
     ret = g.builder.select(start_success, exitcode, @i32.const_int(-1), "ret")
     g.builder.ret(ret)
 
@@ -659,11 +681,11 @@ class Savi::Compiler::CodeGen::PonyRT
         index = PonyRT.heap_index(size).to_i32
         args << @i32.const_int(index)
         # TODO: handle case where final_fn is present (pony_alloc_small_final)
-        g.builder.call(g.mod.functions["pony_alloc_small"], args, "#{name}.MEM")
+        g.gen_call_named("pony_alloc_small", args, "#{name}.MEM")
       else
         args << @isize.const_int(size)
         # TODO: handle case where final_fn is present (pony_alloc_large_final)
-        g.builder.call(g.mod.functions["pony_alloc_large"], args, "#{name}.MEM")
+        g.gen_call_named("pony_alloc_large", args, "#{name}.MEM")
       end
 
     g.builder.bit_cast(allocated, llvm_type.pointer, name)
@@ -678,25 +700,24 @@ class Savi::Compiler::CodeGen::PonyRT
     # optimizations related to the actor reference count and the cycle detector.
     no_inc_rc = from_expr && g.func_frame.classify.value_not_needed?(from_expr)
 
-    allocated = g.builder.call(g.mod.functions["pony_create"], [
+    allocated = g.gen_call_named("pony_create", [
       g.alloc_ctx,
-      g.gen_get_desc_opaque(gtype),
+      gtype.desc,
       @i1.const_int(no_inc_rc ? 1 : 0)
     ], "#{name}.OPAQUE")
 
     if become_now
-      g.builder.call(
-        g.mod.functions["ponyint_become"],
+      g.gen_call_named("ponyint_become",
         [g.gen_frame.alloc_ctx, allocated],
       )
     end
 
-    g.builder.bit_cast(allocated, gtype.struct_ptr, name)
+    allocated
   end
 
   def gen_intrinsic_cpointer_alloc(g : CodeGen, params, llvm_type, elem_size_value)
     g.builder.bit_cast(
-      g.builder.call(g.mod.functions["pony_alloc"], [
+      g.gen_call_named("pony_alloc", [
         g.alloc_ctx,
         g.builder.mul(params[0], @isize.const_int(elem_size_value)),
       ]),
@@ -706,7 +727,7 @@ class Savi::Compiler::CodeGen::PonyRT
 
   def gen_intrinsic_cpointer_realloc(g : CodeGen, params, llvm_type, elem_size_value)
     g.builder.bit_cast(
-      g.builder.call(g.mod.functions["pony_realloc"], [
+      g.gen_call_named("pony_realloc", [
         g.alloc_ctx,
         g.builder.bit_cast(params[0], @ptr),
         g.builder.mul(params[1], @isize.const_int(elem_size_value)),
@@ -726,7 +747,7 @@ class Savi::Compiler::CodeGen::PonyRT
     # Allocate a message object of the specific size/type used by this function.
     msg_size = g.abi_size_of(msg_type)
     pool_index = PonyRT.pool_index(msg_size)
-    msg_opaque = g.builder.call(g.mod.functions["pony_alloc_msg"],
+    msg_opaque = g.gen_call_named("pony_alloc_msg",
       [@i32.const_int(pool_index), @i32.const_int(vtable_index)], "msg.OPAQUE")
     msg = g.builder.bit_cast(msg_opaque, msg_type.pointer, "msg")
 
@@ -749,7 +770,7 @@ class Savi::Compiler::CodeGen::PonyRT
       needs_trace ||= src_types.last.trace_needed?(g.ctx, dst_types.last)
 
       # Store the parameter as an argument in the message.
-      arg_gep = g.builder.struct_gep(msg, i, "msg.#{i - 2}.GEP")
+      arg_gep = g.builder.struct_gep(msg_type, msg, i, "msg.#{i - 2}.GEP")
       g.builder.store(param, arg_gep)
 
       # TODO: Remove/refactor this distinction? Is this really correct?
@@ -758,13 +779,13 @@ class Savi::Compiler::CodeGen::PonyRT
     end
 
     if needs_trace
-      g.builder.call(g.mod.functions["pony_gc_send"], [g.alloc_ctx])
+      g.gen_call_named("pony_gc_send", [g.alloc_ctx])
 
       src_values.each_with_index do |src_value, i|
         gen_trace(g, src_value, dst_values[i], src_types[i], dst_types[i])
       end
 
-      g.builder.call(g.mod.functions["pony_send_done"], [g.alloc_ctx])
+      g.gen_call_named("pony_send_done", [g.alloc_ctx])
     end
 
     # If this is a constructor, we know that we are the only message producer
@@ -774,7 +795,7 @@ class Savi::Compiler::CodeGen::PonyRT
       gfunc.func.has_tag?(:constructor) ? "pony_sendv_single" : "pony_sendv"
 
     # Send the message.
-    g.builder.call(g.mod.functions[sendv_name], [
+    g.gen_call_named(sendv_name, [
       g.alloc_ctx,
       g.builder.bit_cast(fn.params[0], @obj_ptr, "@.OPAQUE"),
       msg_opaque,
@@ -808,10 +829,9 @@ class Savi::Compiler::CodeGen::PonyRT
     g.gen_func_start(fn)
 
     fn.params[0].name = "PONY_CTX"
-    fn.params[1].name = "@.OPAQUE"
+    fn.params[1].name = "@"
     g.func_frame.alloc_ctx = fn.params[0]
-    g.func_frame.receiver_value =
-      g.builder.bit_cast(fn.params[1], gtype.struct_ptr, "@")
+    g.func_frame.receiver_value = fn.params[1]
 
     if gtype.type_def.is_array?(g.ctx)
       # We have a special-case implementation for Array (unfortunately).
@@ -832,12 +852,13 @@ class Savi::Compiler::CodeGen::PonyRT
   end
 
   def gen_trace_impl_for_array(g : CodeGen, gtype : GenType, fn)
-    elem_type_ref = gtype.type_def.array_type_arg(g.ctx)
-    array_size    = g.gen_field_load("_size", gtype)
-    array_ptr     = g.gen_field_load("_ptr", gtype)
+    elem_type_ref  = gtype.type_def.array_type_arg(g.ctx)
+    elem_llvm_type = g.llvm_type_of(elem_type_ref)
+    array_size     = g.gen_field_load("_size", gtype)
+    array_ptr      = g.gen_field_load("_ptr", gtype)
 
     # First, trace the base pointer itself.
-    g.builder.call(g.mod.functions["pony_trace"], [
+    g.gen_call_named("pony_trace", [
       g.alloc_ctx,
       g.builder.bit_cast(array_ptr, @ptr),
     ])
@@ -861,7 +882,7 @@ class Savi::Compiler::CodeGen::PonyRT
     # In the cond block, compare the index variable to the array size,
     # jumping to the body block if still within bounds; else, the post block.
     g.finish_block_and_move_to(cond_block)
-    index = g.builder.load(index_alloca, "ARRAY.TRACE.LOOP.INDEX")
+    index = g.builder.load(@isize, index_alloca, "ARRAY.TRACE.LOOP.INDEX")
     continue = g.builder.icmp(LLVM::IntPredicate::ULT, index, array_size)
     g.builder.cond(continue, body_block, post_block)
 
@@ -869,9 +890,11 @@ class Savi::Compiler::CodeGen::PonyRT
     g.finish_block_and_move_to(body_block)
     elem =
       g.builder.load(
+        elem_llvm_type,
         g.builder.inbounds_gep(
+          elem_llvm_type,
           array_ptr,
-          g.builder.load(index_alloca, "ARRAY.TRACE.LOOP.INDEX"),
+          g.builder.load(@isize, index_alloca, "ARRAY.TRACE.LOOP.INDEX"),
           "ARRAY.TRACE.LOOP.ELEM.GEP",
         ),
         "ARRAY.TRACE.LOOP.ELEM",
@@ -902,18 +925,16 @@ class Savi::Compiler::CodeGen::PonyRT
     g.gen_func_start(fn)
 
     fn.params[0].name = "PONY_CTX"
-    fn.params[1].name = "@.OPAQUE"
+    fn.params[1].name = "@"
     fn.params[2].name = "msg"
 
     g.func_frame.alloc_ctx = fn.params[0]
-    receiver_opaque = fn.params[1]
-    g.func_frame.receiver_value = receiver =
-      g.builder.bit_cast(receiver_opaque, gtype.struct_ptr, "@")
+    g.func_frame.receiver_value = receiver = fn.params[1]
 
     # Get the message id from the first field of the message object
     # (which was the third parameter to this function).
-    msg_id_gep = g.builder.struct_gep(fn.params[2], 1, "msg.id.GEP")
-    msg_id = g.builder.load(msg_id_gep, "msg.id")
+    msg_id_gep = g.builder.struct_gep(@msg, fn.params[2], 1, "msg.id.GEP")
+    msg_id = g.builder.load(@msg.struct_element_types[1], msg_id_gep, "msg.id")
 
     # Capture the current insert block so we can come back to it later,
     # after we jump around into each case block that we need to generate.
@@ -932,7 +953,7 @@ class Savi::Compiler::CodeGen::PonyRT
 
       # Create the block to execute when the message id matches.
       cases[id] = block = g.gen_block("DISPATCH.#{func_name}")
-      g.@builder.position_at_end(block)
+      g.builder.position_at_end(block)
 
       src_types = [] of Reach::Ref
       dst_types = [] of Reach::Ref
@@ -951,8 +972,8 @@ class Savi::Compiler::CodeGen::PonyRT
         src_types << dst_types.last # TODO: are these ever different?
         needs_trace ||= src_types.last.trace_needed?(g.ctx, dst_types.last)
 
-        arg_gep = g.builder.struct_gep(msg, i, "msg.#{func_name}.#{i - 2}.GEP")
-        src_value = g.builder.load(arg_gep, "msg.#{func_name}.#{i - 2}")
+        arg_gep = g.builder.struct_gep(msg_type, msg, i, "msg.#{func_name}.#{i - 2}.GEP")
+        src_value = g.builder.load(msg_type.struct_element_types[i], arg_gep, "msg.#{func_name}.#{i - 2}")
         src_values << src_value
 
         dst_value = src_value
@@ -963,17 +984,17 @@ class Savi::Compiler::CodeGen::PonyRT
       args = [receiver] + dst_values
 
       if needs_trace
-        g.builder.call(g.mod.functions["pony_gc_recv"], [g.alloc_ctx])
+        g.gen_call_named("pony_gc_recv", [g.alloc_ctx])
 
         src_values.each_with_index do |src_value, i|
           gen_trace(g, src_value, dst_values[i], src_types[i], dst_types[i])
         end
 
-        g.builder.call(g.mod.functions["pony_recv_done"], [g.alloc_ctx])
+        g.gen_call_named("pony_recv_done", [g.alloc_ctx])
       end
 
       # Call the underlying function and return void.
-      g.builder.call(gfunc.llvm_func, args)
+      g.gen_call_gfunc(gfunc, args)
       g.builder.ret
     end
 
@@ -992,7 +1013,7 @@ class Savi::Compiler::CodeGen::PonyRT
   end
 
   def gen_trace_unknown(g : CodeGen, dst, ponyrt_trace_kind)
-    g.builder.call(g.mod.functions["pony_traceunknown"], [
+    g.gen_call_named("pony_traceunknown", [
       g.alloc_ctx,
       g.builder.bit_cast(dst, @obj_ptr, "#{dst.name}.OPAQUE"),
       @i32.const_int(ponyrt_trace_kind),
@@ -1002,7 +1023,7 @@ class Savi::Compiler::CodeGen::PonyRT
   def gen_trace_known(g : CodeGen, dst, src_type, ponyrt_trace_kind)
     src_gtype = g.gtype_of(src_type)
 
-    g.builder.call(g.mod.functions["pony_traceknown"], [
+    g.gen_call_named("pony_traceknown", [
       g.alloc_ctx,
       g.builder.bit_cast(dst, @obj_ptr, "#{dst.name}.OPAQUE"),
       g.builder.bit_cast(src_gtype.desc, @desc_ptr, "#{dst.name}.DESC"),

--- a/src/savi/compiler/reach.cr
+++ b/src/savi/compiler/reach.cr
@@ -80,6 +80,11 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
       0 # TODO
     end
 
+    def is_none?
+      # TODO: better reach the one true None instead of a namespaced impostor?
+      singular? && single!.link.name == "None"
+    end
+
     def is_none!
       # TODO: better reach the one true None instead of a namespaced impostor?
       raise "#{self} is not None" unless single!.link.name == "None"

--- a/src/savi/ext/llvm/builder.cr
+++ b/src/savi/ext/llvm/builder.cr
@@ -12,12 +12,6 @@ class LLVM::Builder
     LibLLVM.position_builder_before(self, instruction)
   end
 
-  def struct_gep(value, index, name = "")
-    # check_value(value)
-
-    Value.new LibLLVM.build_struct_gep(self, value, index.to_u32, name)
-  end
-
   def frem(lhs, rhs, name = "")
     # check_value(lhs)
     # check_value(rhs)
@@ -52,5 +46,32 @@ class LLVM::Builder
 
   def is_not_null(value, name = "")
     Value.new LibLLVM.build_is_not_null(self, value, name)
+  end
+
+  ##
+  # Overrides related to opaque pointers (LLVM 15)
+
+  def load(type : LLVM::Type, value : LLVM::Value, name = "")
+    Value.new LibLLVM.build_load_2(self, type, value, name)
+  end
+
+  def struct_gep(type : LLVM::Type, value : LLVM::Value, index, name = "")
+    Value.new LibLLVM.build_struct_gep_2(self, type, value, index.to_u32, name)
+  end
+
+  def inbounds_gep(type : LLVM::Type, value : LLVM::Value, index : LLVM::Value, name = "")
+    indices = pointerof(index).as(LibLLVM::ValueRef*)
+    Value.new LibLLVM.build_inbounds_gep_2(self, type, value, indices, 1, name)
+  end
+
+  def inbounds_gep(type : LLVM::Type, value : LLVM::Value, index1 : LLVM::Value, index2 : LLVM::Value, name = "")
+    indices = uninitialized LLVM::Value[2]
+    indices[0] = index1
+    indices[1] = index2
+    Value.new LibLLVM.build_inbounds_gep_2(self, type, value, indices.to_unsafe.as(LibLLVM::ValueRef*), 2, name)
+  end
+
+  def call(func_type : LLVM::Type, func, args : Array(LLVM::Value), name : String = "", bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null)
+    Value.new LibLLVMExt.build_call2(self, func_type, func, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, bundle, name)
   end
 end

--- a/src/savi/ext/llvm/context.cr
+++ b/src/savi/ext/llvm/context.cr
@@ -7,8 +7,8 @@ class LLVM::Context
     Type.new LibLLVM.struct_create_named(self, name)
   end
 
-  def const_inbounds_gep(value : Value, indices : Array(Value))
-    Value.new LibLLVM.const_inbounds_gep(value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size)
+  def const_inbounds_gep(type : Type, value : Value, indices : Array(Value))
+    Value.new LibLLVM.const_inbounds_gep_2(type, value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size)
   end
 
   def const_bit_cast(value : Value, to_type : Type)

--- a/src/savi/ext/llvm/function.cr
+++ b/src/savi/ext/llvm/function.cr
@@ -1,4 +1,10 @@
 struct LLVM::Function
+  # Override the Crystal implementation of this method because the old one
+  # doesn't work with opaque pointers (beginning in LLVM 15).
+  def function_type
+    Type.new LibLLVM.global_get_value_type self
+  end
+
   def entry_block
     BasicBlock.new LibLLVM.get_entry_basic_block self
   end

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -1,4 +1,5 @@
 lib LibLLVM
+  fun context_set_opaque_pointers = LLVMContextSetOpaquePointers(context : ContextRef, value : Bool)
   fun clear_insertion_position = LLVMClearInsertionPosition(builder : BuilderRef)
   fun get_entry_basic_block = LLVMGetEntryBasicBlock(function : ValueRef) : BasicBlockRef
   fun get_basic_block_terminator = LLVMGetBasicBlockTerminator(basic_block : BasicBlockRef) : ValueRef

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -1,11 +1,9 @@
 lib LibLLVM
-  fun context_set_opaque_pointers = LLVMContextSetOpaquePointers(context : ContextRef, value : Bool)
   fun clear_insertion_position = LLVMClearInsertionPosition(builder : BuilderRef)
   fun get_entry_basic_block = LLVMGetEntryBasicBlock(function : ValueRef) : BasicBlockRef
   fun get_basic_block_terminator = LLVMGetBasicBlockTerminator(basic_block : BasicBlockRef) : ValueRef
   fun position_builder_before = LLVMPositionBuilderBefore(builder : BuilderRef, instruction : ValueRef)
   fun intptr_type_in_context = LLVMIntPtrTypeInContext(ContextRef, TargetDataRef) : TypeRef
-  fun build_struct_gep = LLVMBuildStructGEP(builder : BuilderRef, pointer : ValueRef, index : UInt32, name : UInt8*) : ValueRef
   fun build_frem = LLVMBuildFRem(builder : BuilderRef, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
   fun build_extract_value = LLVMBuildExtractValue(builder : BuilderRef, aggregate : ValueRef, index : UInt32, name : UInt8*) : ValueRef
   fun build_insert_value = LLVMBuildInsertValue(builder : BuilderRef, aggregate : ValueRef, element : ValueRef, index : UInt32, name : UInt8*) : ValueRef
@@ -25,6 +23,14 @@ lib LibLLVM
   fun get_dll_storage_class = LLVMGetDLLStorageClass(global : ValueRef) : LLVM::DLLStorageClass
   fun set_dll_storage_class = LLVMSetDLLStorageClass(global : ValueRef, cls : LLVM::DLLStorageClass)
   fun remove_enum_attribute_at_index = LLVMRemoveEnumAttributeAtIndex(f : ValueRef, idx : AttributeIndex, kind : UInt32)
+
+  # Changes related to opaque pointers (LLVM 15).
+  fun global_get_value_type = LLVMGlobalGetValueType(value : ValueRef) : TypeRef
+  fun get_allocated_value_type = LLVMGetAllocatedType(value : ValueRef) : TypeRef
+  fun build_load_2 = LLVMBuildLoad2(builder : BuilderRef, type : TypeRef, pointer : ValueRef, name : UInt8*) : ValueRef
+  fun build_struct_gep_2 = LLVMBuildStructGEP2(builder : BuilderRef, type : TypeRef, pointer : ValueRef, index : UInt32, name : UInt8*) : ValueRef
+  fun build_inbounds_gep_2 = LLVMBuildInBoundsGEP2(builder : BuilderRef, type : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
+  fun const_inbounds_gep_2 = LLVMConstInBoundsGEP2(type : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32) : ValueRef
 
   enum ByteOrdering
     BigEndian

--- a/src/savi/ext/llvm/value_methods.cr
+++ b/src/savi/ext/llvm/value_methods.cr
@@ -16,6 +16,10 @@ module LLVM::ValueMethods
     cls
   end
 
+  def allocated_type
+    Type.new LibLLVM.get_allocated_value_type(self)
+  end
+
   def to_value
     Value.new to_unsafe
   end


### PR DESCRIPTION
Also switches Cirrus CI MacOS x86_64 with arm64 cross-compiling.
Cirrus CI now runs MacOS on arm64, and no longer runs it on x86_64.
So now we direct-compile the former and cross-compile the latter.

Note that LLVM 15 includes [a breaking change with all pointers now being opaque](https://releases.llvm.org/15.0.0/docs/OpaquePointers.html), so a lot of refactoring to the `CodeGen` pass was required.