### PR TITLE
Add `--llvm-optimize-nothing` CLI option.

### DIFF
--- a/main.cr
+++ b/main.cr
@@ -21,6 +21,7 @@ module Savi
       option "--with-runtime-asserts", desc: "Compile with runtime assertions even in release mode", type: Bool, default: false
       option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
       option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
+      option "--llvm-optimize-nothing", desc: "Don't allow LLVM to do any IR optimization at all", type: Bool, default: false
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
       option "-X", "--cross-compile=TRIPLE", desc: "Cross compile to the given target triple"
       option "-C", "--cd=DIR", desc: "Change the working directory"
@@ -34,6 +35,7 @@ module Savi
         options.runtime_asserts = opts.with_runtime_asserts || !opts.release
         options.llvm_ir = true if opts.llvm_ir
         options.llvm_keep_fns = true if opts.llvm_keep_fns
+        options.llvm_optimize_nothing = true if opts.llvm_optimize_nothing
         options.auto_fix = true if opts.fix
         options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
         options.cross_compile = opts.cross_compile.not_nil! if opts.cross_compile
@@ -108,6 +110,7 @@ module Savi
         option "--with-runtime-asserts", desc: "Compile with runtime assertions even in release mode", type: Bool, default: false
         option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
         option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
+        option "--llvm-optimize-nothing", desc: "Don't allow LLVM to do any IR optimization at all", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-X", "--cross-compile=TRIPLE", desc: "Cross compile to the given target triple"
         option "-C", "--cd=DIR", desc: "Change the working directory"
@@ -121,6 +124,7 @@ module Savi
           options.runtime_asserts = opts.with_runtime_asserts || !opts.release
           options.llvm_ir = true if opts.llvm_ir
           options.llvm_keep_fns = true if opts.llvm_keep_fns
+          options.llvm_optimize_nothing = true if opts.llvm_optimize_nothing
           options.auto_fix = true if opts.fix
           options.target_pass = Savi::Compiler.pass_symbol(opts.pass) if opts.pass
           options.cross_compile = opts.cross_compile.not_nil! if opts.cross_compile
@@ -142,6 +146,7 @@ module Savi
         option "--with-runtime-asserts", desc: "Compile with runtime assertions even in release mode", type: Bool, default: false
         option "--llvm-ir", desc: "Write generated LLVM IR to a file", type: Bool, default: false
         option "--llvm-keep-fns", desc: "Don't allow LLVM to remove functions from the output", type: Bool, default: false
+        option "--llvm-optimize-nothing", desc: "Don't allow LLVM to do any IR optimization at all", type: Bool, default: false
         option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
         option "-X", "--cross-compile=TRIPLE", desc: "Cross compile to the given target triple"
         option "-C", "--cd=DIR", desc: "Change the working directory"
@@ -154,6 +159,7 @@ module Savi
           options.runtime_asserts = opts.with_runtime_asserts || !opts.release
           options.llvm_ir = true if opts.llvm_ir
           options.llvm_keep_fns = true if opts.llvm_keep_fns
+          options.llvm_optimize_nothing = true if opts.llvm_optimize_nothing
           options.auto_fix = true if opts.fix
           options.manifest_name = args.name.not_nil! if args.name
           options.cross_compile = opts.cross_compile.not_nil! if opts.cross_compile

--- a/src/savi/compiler.cr
+++ b/src/savi/compiler.cr
@@ -11,6 +11,7 @@ class Savi::Compiler
     property runtime_asserts = true
     property llvm_ir = false
     property llvm_keep_fns = false
+    property llvm_optimize_nothing = false
     property auto_fix = false
     property cross_compile : String? = nil
     property manifest_name : String?

--- a/src/savi/compiler/binary_object.cr
+++ b/src/savi/compiler/binary_object.cr
@@ -116,7 +116,9 @@ class Savi::Compiler::BinaryObject
 
     # Now run LLVM passes, doing full optimization if in release mode.
     # Otherwise we will only run a minimal set of passes.
-    LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
+    unless ctx.options.llvm_optimize_nothing
+      LibLLVM.optimize_for_savi(mod.to_unsafe, ctx.options.release)
+    end
 
     # Now that we've optimized, only actually called functions remain,
     # so we can mark for linking those libraries that are associated to


### PR DESCRIPTION
This disables all optimization, including even the very basic forms of inlining enabled by default.

This is mainly useful for troubleshooting the compiler and potential issues with LLVM IR generation.