### PR TITLE
Fix memory safety of `each`-style iteration methods.

### DIFF
--- a/core/Array.savi
+++ b/core/Array.savi
@@ -256,9 +256,8 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.at_most(to)
     index = from
-    while (index < to) (
+    while (index < to.at_most(@_size)) (
       yield (@_ptr._get_at(index), index)
       index += stride
     )
@@ -270,10 +269,10 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.at_most(from) -! 1
+      index USize = from.at_most(@_size) -! 1
       while (index >= to) (
         yield (@_ptr._get_at(index), index)
-        index = index -! stride
+        index = index.at_most(@_size) -! stride
       )
     )
     None

--- a/core/BitArray.savi
+++ b/core/BitArray.savi
@@ -147,11 +147,7 @@
   )
     to = @_size.at_most(to)
     index = from
-    while (index < to) (
-      // TODO: it should be possible to do fewer underlying pointer loads
-      // by batching with an inner loop when the stride is less than 64
-      // However, it's unclear how much of a performance boost that would be,
-      // so it needs to be tested to see if that's worth the extra complexity.
+    while (index < to.at_most(@_size)) (
       yield (@_ptr_get_at(index), index)
       index += stride
     )
@@ -163,14 +159,10 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.at_most(from) -! 1
+      index USize = from.at_most(@_size) -! 1
       while (index >= to) (
-        // TODO: it should be possible to do fewer underlying pointer loads
-        // by batching with an inner loop when the stride is less than 64
-        // However, it's unclear how much of a performance boost that would be,
-        // so it needs to be tested to see if that's worth the extra complexity.
         yield (@_ptr_get_at(index), index)
-        index = index -! stride
+        index = index.at_most(@_size) -! stride
       )
     )
     None

--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -322,9 +322,8 @@
     to = USize.max_value
     stride USize = 1
   )
-    to = @_size.at_most(to)
     index = from
-    while (index < to) (
+    while (index < to.at_most(@_size)) (
       yield (@_ptr._get_at(index), index)
       index += stride
     )
@@ -336,10 +335,10 @@
     stride USize = 1
   )
     try (
-      index USize = @_size.at_most(from) -! 1
+      index USize = from.at_most(@_size) -! 1
       while (index >= to) (
         yield (@_ptr._get_at(index), index)
-        index = index -! stride
+        index = index.at_most(@_size) -! stride
       )
     )
     None

--- a/core/String.savi
+++ b/core/String.savi
@@ -13,6 +13,8 @@
   :fun size: @_size
   :fun space: @_space
 
+  :fun ref clear: @_size = 0, @
+
   :fun ref _ptr_set_null
     @_space = 0
     @_ptr = CPointer(U8)._null
@@ -216,33 +218,25 @@
     @
 
   :fun each_byte(from USize = 0, to = USize.max_value, stride USize = 1)
-    to = @_size.at_most(to)
-    index = from
-    while (index < to) (
-      yield @_ptr._get_at(index)
-      index = index + stride
+    @each_byte_with_index(from, to, stride) -> (value, index |
+      yield value
     )
-    @
 
+  // TODO: Move to be on a new `Indexable.Bytes` trait?
   :fun each_byte_until(from USize = 0, to = USize.max_value, stride USize = 1)
     :yields for Bool
-    early_stop = False
-    to = @_size.at_most(to)
-    index = from
-    while (index < to && !early_stop) (
-      early_stop = yield @_ptr._get_at(index)
-      index += stride
+    @each_byte(from, to, stride) -> (byte |
+      return True if (yield byte)
     )
-    early_stop
+    False
 
   :fun each_byte_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
-    to = @_size.at_most(to)
     index = from
-    while (index < to) (
+    while (index < to.at_most(@_size)) (
       yield (@_ptr._get_at(index), index)
-      index = index + stride
+      index += stride
     )
-    @
+    None
 
   :: Starting from the given byte index and continuing up to the given end,
   :: yield each UTF8-encoded Unicode codepoint, its starting byte index,
@@ -263,11 +257,10 @@
   :fun each_char_with_index_and_width(from USize = 0, to = USize.max_value)
     codepoint U32 = 0
     state U8 = 0
-    to = @_size.at_most(to)
     index = from
     start_index = index
 
-    while (index < to) (
+    while (index < to.at_most(@_size)) (
       byte = @_ptr._get_at(index)
       codepoint = UTF8Decoding.read_byte_into_codepoint(byte, state, codepoint)
       state = UTF8Decoding.next_state(byte, state)

--- a/spec/core/Array.Spec.savi
+++ b/spec/core/Array.Spec.savi
@@ -213,6 +213,23 @@
     assert:
       array_a == ["baz", "bar", "foo"]
 
+  :it "won't violate memory safety when the array is mutated during iteration"
+    seen Array(String) = []
+    array = ["foo", "bar", "baz"]
+    array.each_with_index -> (string, index |
+      array.clear
+      seen << string
+    )
+    assert: seen == ["foo"]
+
+    seen.clear
+    array = ["foo", "bar", "baz"]
+    array.reverse_each_with_index -> (string, index |
+      array.clear
+      seen << string
+    )
+    assert: seen == ["baz"]
+
   :it "swaps the elements in the array if both indices are in range"
     array = ["foo", "bar", "baz"]
 

--- a/spec/core/BitArray.Spec.savi
+++ b/spec/core/BitArray.Spec.savi
@@ -143,6 +143,23 @@
     assert: array_b == [2, 1, 0]
     assert: array_a == [1, 1, 0]
 
+  :it "won't violate memory safety when the buffer is mutated during iteration"
+    seen Array(Bool) = []
+    bits = BitArray.new << 0 << 1 << 1
+    bits.each_with_index -> (bit, index |
+      bits.clear
+      seen << bit
+    )
+    assert: seen == [0]
+
+    seen.clear
+    bits = BitArray.new << 0 << 1 << 1
+    bits.reverse_each_with_index -> (bit, index |
+      bits.clear
+      seen << bit
+    )
+    assert: seen == [1]
+
   :it "swaps the bits in the array if both indices are in range"
     bits = BitArray.new << 0 << 1 << 0
 

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -317,6 +317,23 @@
     assert: bytes == ['o', 'l', 'l', 'e', 'h']
     assert: indices == [4, 3, 2, 1, 0]
 
+  :it "won't violate memory safety when the buffer is mutated during iteration"
+    seen Array(U8) = []
+    bytes Bytes'ref = b"123".clone
+    bytes.each_with_index -> (byte, index |
+      bytes.clear
+      seen << byte
+    )
+    assert: seen == ['1']
+
+    seen.clear
+    bytes = b"123".clone
+    bytes.reverse_each_with_index -> (byte, index |
+      bytes.clear
+      seen << byte
+    )
+    assert: seen == ['3']
+
   :it "copies bytes from the given buffer onto the end of the byte string"
     assert: (Bytes.new << b"foo" << b"" << b"bar") == b"foobar"
 

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -174,6 +174,23 @@
     assert: string_a == ['y', 'o']
     assert: string_b == [0, 1]
 
+  :it "won't violate memory safety when the buffer is mutated during iteration"
+    seen Array(U8) = []
+    string = "123".clone
+    string.each_byte_with_index -> (byte, index |
+      string.clear
+      seen << byte
+    )
+    assert: seen == ['1']
+
+    seen.clear
+    string = "123".clone
+    string.each_char_with_index_and_width -> (char, index, width |
+      string.clear
+      seen << char.u8
+    )
+    assert: seen == ['1']
+
   :it "copies bytes from the given string onto the end of the string"
     assert: (String.new << "foo" << "" << "bar") == "foobar"
 


### PR DESCRIPTION
Prior to this commit, these yielding methods were vulnerable to memory unsafety issues if the length of the iterated collection got reduced by something the caller did inside of the yield block.

This commit fixes these issues to make sure the internal loop iterations are always bounded to the current `_size` of the collection.