### PR TITLE
Add `String.take_buffer` and `Bytes.take_buffer`.

### DIFF
--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -47,6 +47,14 @@
   :fun val as_array: Array(U8).val_from_cpointer(@_ptr._unsafe, @_size, @_space)
   :fun val as_string: String.from_bytes(@)
 
+  :: Take the underlying buffer and return a new isolated `Bytes`,
+  :: leaving this original `Bytes` instance empty.
+  :fun ref take_buffer Bytes'iso
+    new = @iso_from_cpointer(@_ptr, @_size, @_space)
+    @_size = 0
+    @_ptr_set_null
+    --new
+
   :fun "=="(other Bytes'box)
     (@_size == other._size) && (@_ptr._compare(other._ptr, @_size) == 0)
 

--- a/core/String.savi
+++ b/core/String.savi
@@ -48,6 +48,14 @@
   :fun val as_array: Array(U8).val_from_cpointer(@_ptr._unsafe, @_size, @_space)
   :fun val as_bytes: Bytes.from_string(@)
 
+  :: Take the underlying buffer and return a new isolated `String`,
+  :: leaving this original `String` instance empty.
+  :fun ref take_buffer String'iso
+    new = @iso_from_cpointer(@_ptr, @_size, @_space)
+    @_size = 0
+    @_ptr_set_null
+    --new
+
   :fun into_string_space: @space
 
   :fun into_string(out String'iso) String'iso

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -101,6 +101,17 @@
     assert: b"string".as_string == "string"
     assert: Bytes.from_string("string") == b"string"
 
+  :it "has its underlying buffer taken and lifted to iso, leaving it empty"
+    giver ref = b"example".clone
+    cpointer = giver.cpointer
+    taker iso = giver.take_buffer
+
+    assert: giver.cpointer.is_null
+    assert: taker.cpointer.is_not_null
+    assert: taker.cpointer.address == cpointer.address
+    assert: giver.size == 0, assert: giver.space == 0
+    assert: taker.size == 7, assert: taker.space >= 7
+
   :it "compares bytewise equality with another bytes string"
     assert: (b"string" == b"string")
     assert: (b"string" == b"other").is_false

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -75,6 +75,17 @@
     assert: "string".as_bytes == b"string"
     assert: String.from_bytes(b"string") == "string"
 
+  :it "has its underlying buffer taken and lifted to iso, leaving it empty"
+    giver ref = "example".clone
+    cpointer = giver.cpointer
+    taker iso = giver.take_buffer
+
+    assert: giver.cpointer.is_null
+    assert: taker.cpointer.is_not_null
+    assert: taker.cpointer.address == cpointer.address
+    assert: giver.size == 0, assert: giver.space == 0
+    assert: taker.size == 7, assert: taker.space >= 7
+
   :it "compares bytewise equality with another string"
     assert: ("string" == "string")
     assert: ("string" == "other").is_false


### PR DESCRIPTION
This removes the buffer from the original instance and gives it to a new instance, which can be lifted to `iso` because it's known that no other non-`tag` reference to that pointer exists.