### PR TITLE
Add `/lib/gcc/x86_64-pc-linux-gnu/*` as a known link lib path.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -299,6 +299,7 @@ class Savi::Compiler::Binary
       else
         if target.x86_64?
           yield "/lib/gcc/x86_64-linux-gnu/*", nil
+          yield "/lib/gcc/x86_64-pc-linux-gnu/*", nil
           yield "/lib/x86_64-linux-gnu", nil
           yield "/usr/lib/gcc/x86_64-linux-gnu/*", nil
           yield "/usr/lib/gcc/x86_64-pc-linux-gnu/*", nil


### PR DESCRIPTION
This may help solve an "illegal instruction" issue that one user reported on Arch Linux.

See https://savi.zulipchat.com/#narrow/stream/294897-general/topic/illegal.20instruction.20on.20arch.20linux

My hypothesis is that this user may have some cross-toolchain link libs somewhere on the path, and the native gcc link libs are not taking precedence over those as they should.

I ran an `archlinux:latest` docker container and saw that gcc link libs on arch linux are currently found in the following path: `/usr/lib/gcc/x86_64-pc-linux-gnu/12.2.1`.

So this change adds that pattern to our own link lib path heuristics.