### PR TITLE
Add `String.format.literal` and update `Inspect` to use it.

### DIFF
--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -21,10 +21,7 @@
     case input <: (
     | _InspectCustom | input.inspect_into(output)
     | Bytes'box | input.format.literal.into_string(output)
-    | String'box |
-      output.push_byte('"')
-      output << input.clone // TODO: show some characters as escaped.
-      output.push_byte('"')
+    | String'box | input.format.literal.into_string(output)
     | _InspectEach |
       output.push_byte('[')
       index USize = 0

--- a/core/String.Format.savi
+++ b/core/String.Format.savi
@@ -1,0 +1,38 @@
+:: Format the given `String` value using one of the available format types.
+:: Call one of the methods of this struct to choose which format type to use.
+:struct box String.Format
+  :let _value String'box
+  :new box _new(@_value)
+
+  :fun literal: String.Format.Literal._new(@_value)
+
+  :fun lit: @literal
+
+:: Format the given `String` as it could appear in Savi source code. That is,
+:: as a string literal with non-printable or non-ASCII bytes escaped.
+:struct box String.Format.Literal
+  :is IntoString
+
+  :let _value String'box
+  :new box _new(@_value)
+
+  :fun into_string(out String'ref) None
+    out.push_byte('"')
+    @_value.each_byte -> (byte |
+      case (
+      | byte >= 0x7f | byte.format.hex.with_prefix("\\x").into_string(out)
+      | byte == '"'  | out.push_byte('\\').push_byte('"')
+      | byte >= 0x20 | out.push_byte(byte)
+      | byte == '\n' | out.push_byte('\\').push_byte('n')
+      | byte == '\r' | out.push_byte('\\').push_byte('r')
+      | byte == '\t' | out.push_byte('\\').push_byte('t')
+      |                byte.format.hex.with_prefix("\\x").into_string(out)
+      )
+    )
+    out.push_byte('"')
+
+  :fun into_string_space USize
+    // Use a conservative estimate, assuming all bytes will be escaped hex.
+    // Each escaped hex byte takes 4 bytes to display, and there are 2 bytes
+    // of overhead involved in displaying the leading `"` and final `"`.
+    @_value.size * 4 + 2

--- a/core/String.savi
+++ b/core/String.savi
@@ -101,6 +101,8 @@
   :fun is_empty:     @size == 0
   :fun is_not_empty: @size != 0
 
+  :fun format: String.Format._new(@)
+
   :fun clone @'iso
     copy = @new_iso(@size)
     _ptr_tag CPointer(U8)'tag = @_ptr // TODO: this indirection shouldn't be needed

--- a/spec/core/Inspect.Spec.savi
+++ b/spec/core/Inspect.Spec.savi
@@ -51,6 +51,9 @@
   :it "inspects strings"
     assert: Inspect["example"] == "\"example\""
     assert: Inspect[String.new] == "\"\""
+    assert: Inspect["\x00\x08\x1a ABC123\"\n\r\t\x7f\x80\xff"] == <<<
+      "\x00\x08\x1a ABC123\"\n\r\t\x7f\x80\xff"
+    >>>
 
   :it "inspects bytes"
     assert: Inspect[b"example"] == "b\"example\""


### PR DESCRIPTION
Now inspected strings will show escape sequences for bytes that are outside ASCII range or are not easily read when printed.

Prior to this commit, inspecting a string would copy the bytes verbatim from the string into the output of the inspection.