### PR TITLE
Add `Inspect.TraceData.Printer.Deterministic`.

### DIFF
--- a/core/Inspect.savi
+++ b/core/Inspect.savi
@@ -54,9 +54,17 @@
 
   :new (@_out = String.new)
 
+  :fun non print(input TraceData) String
+    output = String.new
+    input.trace_data(@new(output))
+    output.take_buffer
+
   :fun ref take_buffer: @_out.take_buffer
 
   :is TraceData.Observer
+
+  :fun ref _show_recurse_id(recurse_id USize) None
+    recurse_id.format.hex.into_string(@_out)
 
   :fun ref object(recurse_id USize) None
     :yields None for None // TODO: add a "without interruption" enforcement to the yield signature to ensure that the yield block isn't allowed to jump away.
@@ -67,7 +75,7 @@
     if recurse_id.is_zero (
       yield None
     |
-      recurse_id.format.hex.into_string(@_out)
+      @_show_recurse_id(recurse_id)
 
       if @_recurse_stack.includes(recurse_id) (
         @_out << "..."
@@ -120,3 +128,18 @@
   :fun ref primitive_name(value String'box): value.into_string(@_out)
   :fun ref primitive_string(value String'box): value.format.literal.into_string(@_out)
   :fun ref primitive_bytes(value Bytes'box): value.format.literal.into_string(@_out)
+
+:class Inspect.TraceData.Printer.Deterministic
+  :copies Inspect.TraceData.Printer
+  :var _seen_ids Array(USize): []
+
+  :fun ref _show_recurse_id(recurse_id USize) None
+    number = try (
+      @_seen_ids.find_index! -> (id | id == recurse_id)
+      + 1
+    |
+      @_seen_ids << recurse_id
+      @_seen_ids.size
+    )
+
+    number.into_string(@_out)

--- a/spec/core/Inspect.Spec.savi
+++ b/spec/core/Inspect.Spec.savi
@@ -98,6 +98,34 @@
           2: "baz"
     >>>)"
 
+  :it "inspects deterministically an object that is traceable as data"
+    data = _InspectableTestData.new
+    assert: Inspect.TraceData.Printer.Deterministic.print(data) == <<<
+      #1:
+        example_none: None
+        example_pair: #
+          first: True
+          second: False
+        example_u64: 36
+        example_u32: 36
+        example_u16: 36
+        example_u8: 36
+        example_i64: 36
+        example_i32: 36
+        example_i16: 36
+        example_i8: 36
+        example_f64: 36.0
+        example_f32: 36.0
+        example_foo: _InspectableTestEnum.Foo
+        example_bar: _InspectableTestEnum.Bar
+        example_baz: _InspectableTestEnum.Baz
+        example_bytes: b"foo\x00bar\x00baz"
+        example_strings: #2:
+          0: "foo"
+          1: "bar"
+          2: "baz"
+    >>>
+
 :module _InspectableTestModule
 
 :enum _InspectableTestEnum


### PR DESCRIPTION
This is an alternative to `Inspect.TraceData.Printer` (the usual printer used by `Inspect[...]`, which differs only in that it avoids printing recursion ids for objects and arrays directly.

Instead, it maps recursion ids onto sequential numbers, printing the first unique object/array as `#1`, the next as `#2`, etc.

This can be used for when the printed output needs to be used in a test suite, where the pointer-derived recursion ids would otherwise cause non-determinism in the output.