### PR TITLE
Add `/usr/local/lib` to known link paths on Linux and FreeBSD.

### DIFF
--- a/src/savi/compiler/binary.cr
+++ b/src/savi/compiler/binary.cr
@@ -317,6 +317,7 @@ class Savi::Compiler::Binary
     yield "/usr/lib64", nil
     yield "/lib", nil
     yield "/usr/lib", nil
+    yield "/usr/local/lib", nil
 
     if target.dragonfly?
       yield "/usr/lib/gcc80", nil


### PR DESCRIPTION
This is apparently a common link path on FreeBSD.