### PR TITLE
Fix erroneous "double-dot" output in `FloatingPoint.Format`.

### DIFF
--- a/core/FloatingPoint.Format.savi
+++ b/core/FloatingPoint.Format.savi
@@ -178,9 +178,6 @@
   :let _value _FormattableF64
   :new val _new(@_value)
 
-  // We will use some functions of `Integer.Format.Decimal` as a utility.
-  :fun non _util: Integer.Format.Decimal(U64)
-
   :fun into_string_space USize
     // First, deal with any special cases (zero or non-finite numbers).
     // We count these in a special (hard-coded) way and return early.
@@ -235,9 +232,6 @@
   :let _value _FormattableF64
   :new val _new(@_value)
 
-  // We will use some functions of `Integer.Format.Decimal` as a utility.
-  :fun non _util: Integer.Format.Decimal(U64)
-
   :fun into_string_space USize
     // First, deal with any special cases (zero or non-finite numbers).
     // We count these in a special (hard-coded) way and return early.
@@ -284,7 +278,7 @@
 
     // Print the digits of the significand, with decimal point if applicable.
     digit_count.times -> (digit_index |
-      if (digit_index.i16 - 1 == exponent) out.push_byte('.')
+      if (digit_index.i16 - 1 == exponent && digit_index > 0) out.push_byte('.')
       out.push_byte((significand / divisor % 10).u8 + '0')
       divisor = divisor / 10
     )

--- a/spec/core/FloatingPoint.Format.Spec.savi
+++ b/spec/core/FloatingPoint.Format.Spec.savi
@@ -4,8 +4,10 @@
 
   :it "prints the decimal digits of the floating-point value into a string"
     assert: "\(0.0)" == "0.0"
+    assert: "\(0.5)" == "0.5"
     assert: "\(1.0)" == "1.0"
     assert: "\(9.543)" == "9.543"
+    assert: "\(-0.0625)" == "-0.0625"
     assert: "\(1.2345678)" == "1.2345678"
     assert: "\(9.543e20)" == "9.543e20"
     assert: "\(9.543e80)" == "9.543e80"


### PR DESCRIPTION
Prior to this commit, a number like `0.5`
would be formatted with two dots, as: `0..5`

This commit fixes that issue by adding an additonal condition for printing the 2nd dot.

This commit also removes a no-longer-used dependency of `FloatingPoint.Format` types on `Integer.Format.Decimal`. Apparently they referenced that type earlier in their implementation, but they no longer do, so I've removed the reference.