### PR TITLE
Fix LLVM IR issue with struct field initializer expressions.

### DIFF
--- a/spec/language/semantics/struct_spec.savi
+++ b/spec/language/semantics/struct_spec.savi
@@ -1,0 +1,8 @@
+:struct _StructWithFieldInitializer
+  :let array Array(String): []
+
+:module StructSpec
+  :fun run(test MicroTest)
+    s_w_f_i = _StructWithFieldInitializer.new
+    s_w_f_i.array << "example"
+    test["struct with field initializer"].pass = s_w_f_i.array == ["example"]

--- a/spec/language/semantics/test.savi
+++ b/spec/language/semantics/test.savi
@@ -26,5 +26,6 @@
     EnumSpec.run(test)
     StringSpec.run(test)
     NumberSpec.run(test)
+    StructSpec.run(test)
 
     test.print_line_break // TODO: move to MicroTest constructor and finalizer

--- a/src/savi/compiler/code_gen/gen_func.cr
+++ b/src/savi/compiler/code_gen/gen_func.cr
@@ -68,6 +68,7 @@ class Savi::Compiler::CodeGen
       && type_def.is_pass_by_value?(ctx) \
       && (
         func.has_tag?(:constructor) \
+        || func.has_tag?(:field) \
         || (func.has_tag?(:let) && func.ident.value.ends_with?("=")) # TODO: less hacky as a special case somehow?
       )
     end

--- a/src/savi/compiler/populate.cr
+++ b/src/savi/compiler/populate.cr
@@ -49,7 +49,7 @@ class Savi::Compiler::Populate
       end
 
       # If the type doesn't have a constructor and needs one, then add one.
-      if dest.has_tag?(:allocated) && !dest.has_tag?(:abstract) \
+      if dest.has_tag?(:constructed) \
       && !dest.functions.any? { |f| f.has_tag?(:constructor) }
         # Create the default constructor function, unless we have one cached.
         f = ctx.prev_ctx.try(&.populate.default_constructors[dest.ident.pos.hash]?) || begin

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -209,6 +209,7 @@ class Savi::Program
       :abstract,
       :actor,
       :allocated,
+      :constructed,
       :enum,
       :hygienic,
       :ignores_cap,

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -66,10 +66,13 @@ module Savi::Program::Intrinsic
         when "actor"
           type.add_tag(:actor)
           type.add_tag(:allocated)
+          type.add_tag(:constructed)
         when "class"
           type.add_tag(:allocated)
+          type.add_tag(:constructed) if type.ident.value != "CPointer" # TODO: less hacky and special-cased for this
           type.add_tag(:simple_value) if type.ident.value == "CPointer" # TODO: less hacky and special-cased for this
         when "struct"
+          type.add_tag(:constructed)
           type.add_tag(:pass_by_value)
           type.add_tag(:no_field_reassign)
         when "trait"


### PR DESCRIPTION
Resolves #435.

This also resolves another issue in which structs were not getting a implicit default constructor added when it was missing a constructor.