### PR TITLE
Add a nice error for the case of declared params not being valid syntax.

### DIFF
--- a/spec/compiler/declarator.interpreter.savi.spec.md
+++ b/spec/compiler/declarator.interpreter.savi.spec.md
@@ -72,7 +72,7 @@ This declaration didn't match any known declarator:
 
 ---
 
-It complains when the declaration's terms are not accepted by the declarators.
+It complains when a `TypeOrTypeList` term is not accepted by the declarator.
 
 ```savi
 :module Example
@@ -119,6 +119,52 @@ These declaration terms didn't match any known declarator:
 - an algebraic type or parenthesized group of algebraic types would be accepted:
   :term out TypeOrTypeList
   ^~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+---
+
+It complains when a `NameMaybeWithParams` term is not accepted by the declarator.
+
+```savi
+:module Example
+  :fun call(Array(U8)) U64
+```
+```error
+These declaration terms didn't match any known declarator:
+  :fun call(Array(U8)) U64
+  ^~~~~~~~~~~~~~~~~~~~~~~~
+
+- This declarator didn't match:
+:declarator fun
+            ^~~
+
+- this term was not acceptable:
+  :fun call(Array(U8)) U64
+       ^~~~~~~~~~~~~~~
+
+- any of these would be accepted: `non`:
+  :term cap enum (non)
+  ^~~~~~~~~~~~~~~~~~~~
+
+- a name with an optional parenthesized list of parameter specifiers (each parameter having at least a name and possibly a type and/or default argument) would be accepted:
+  :term name_and_params NameMaybeWithParams
+  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- This declarator didn't match:
+:declarator fun
+            ^~~
+
+- this term was not acceptable:
+  :fun call(Array(U8)) U64
+       ^~~~~~~~~~~~~~~
+
+- any of these would be accepted: `iso`, `val`, `ref`, `box`, `tag`, `non`:
+  :term cap enum (iso, val, ref, box, tag, non)
+  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- a name with an optional parenthesized list of parameter specifiers (each parameter having at least a name and possibly a type and/or default argument) would be accepted:
+  :term name_and_params NameMaybeWithParams
+  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
 ---

--- a/spec/compiler/sugar_spec.cr
+++ b/spec/compiler/sugar_spec.cr
@@ -427,11 +427,11 @@ describe Savi::Compiler::Sugar do
     # ctx.program.packages.should eq ctx2.program.packages
   end
 
-  it "transforms non-identifier parameters into assignment expressions" do
+  it "transforms field-like parameters into assignment expressions" do
     source = Savi::Source.new_example <<-SOURCE
     :class Example
-      :fun param_assigns(@x, @y.z)
-        @y.after
+      :fun param_assigns(@x)
+        @x.after
     SOURCE
 
     ctx = Savi.compiler.test_compile([source], :sugar)
@@ -441,12 +441,9 @@ describe Savi::Compiler::Sugar do
       [:declare, [:ident, "class"], [:ident, "Example"],
         [:declare, [:ident, "fun"],
           [:qualify, [:ident, "param_assigns"],
-            [:group, "(",
-              [:ident, "@x"],
-              [:relate, [:ident, "@y"], [:op, "."], [:ident, "z"]]
-            ],
+            [:group, "(", [:ident, "@x"], ],
           ],
-          [:group, ":", [:relate, [:ident, "@y"], [:op, "."], [:ident, "after"]]],
+          [:group, ":", [:relate, [:ident, "@x"], [:op, "."], [:ident, "after"]]],
         ],
       ],
     ]
@@ -461,14 +458,7 @@ describe Savi::Compiler::Sugar do
         ],
       ],
       [:call,
-        [:call, [:ident, "@"], [:ident, "y"]],
-        [:ident, "z="],
-        [:group, "(",
-          [:prefix, [:op, "--"], [:ident, "ASSIGNPARAM.2"]],
-        ],
-      ],
-      [:call,
-        [:call, [:ident, "@"], [:ident, "y"]],
+        [:call, [:ident, "@"], [:ident, "x"]],
         [:ident, "after"]
       ],
     ]


### PR DESCRIPTION
Resolves #439.

This resolves a known TODO for that kind of term acceptor.

This resolution works for all declarators that use `Params` or `NameMaybeWithParams` terms.