### PR TITLE
Limit concurrency when running `git ...` to 1

### DIFF
--- a/src/savi/packaging/remote_service.cr
+++ b/src/savi/packaging/remote_service.cr
@@ -39,7 +39,7 @@ module Savi::Packaging::RemoteService
       fetch_specified_versions_of_each(ctx, deps, versions, into_dirname)
     end
 
-    PROCESS_CONCURRENCY            = 2
+    PROCESS_CONCURRENCY            = 1
     COMMAND_GIT_REMOTE_SORTED_TAGS =
       %w{git -c versionsort.suffix=- ls-remote --tags --sort=-v:refname}
 


### PR DESCRIPTION
* It will slow down cloning git repositories.

* This should fix issue #447 both locally or on CI.

* TODO: A better alternative would be to retry upon failure.