### PR TITLE
Update for Crystal 1.8.0.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,7 +74,7 @@ task:
           CLANG=/usr/local/bin/clang14 \
           CLANGXX=/usr/local/bin/clang++14"
       freebsd_instance:
-        image: freebsd-13-1-release-amd64
+        image: freebsd-13-2-release-amd64
         cpu: 2
         memory: 8G
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - crystal: "1.5.0"
+          - crystal: "1.8.0"
             os: ubuntu-20.04
             deps: sudo apt-get install -y capnproto libgc-dev
-          - crystal: "1.5.0"
+          - crystal: "1.8.0"
             os: macos-12 # upgrade to macos-13 when available
             deps: brew install libgc capnp
     runs-on: ${{matrix.os}}

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ $(BUILD)/savi-release.o: main.cr $(LLVM_PATH) $(shell find src lib -name '*.cr')
 		SAVI_LLVM_VERSION=`$(LLVM_CONFIG) --version` \
 		LLVM_CONFIG=$(LLVM_CONFIG) \
 		LLVM_DEFAULT_TARGET=$(TARGET_PLATFORM) \
-		crystal build $< -o $(shell echo $@ | rev | cut -f 2- -d '.' | rev) \
+		crystal build -Duse_pcre $< -o $(shell echo $@ | rev | cut -f 2- -d '.' | rev) \
 			--release --stats --error-trace --cross-compile --target $(TARGET_PLATFORM)
 
 # Build the Savi compiler object file, based on the Crystal source code.
@@ -317,7 +317,7 @@ $(BUILD)/savi-debug.o: main.cr $(LLVM_PATH) $(shell find src lib -name '*.cr')
 		SAVI_LLVM_VERSION=`$(LLVM_CONFIG) --version` \
 		LLVM_CONFIG=$(LLVM_CONFIG) \
 		LLVM_DEFAULT_TARGET=$(TARGET_PLATFORM) \
-		crystal build $< -o $(shell echo $@ | rev | cut -f 2- -d '.' | rev) \
+		crystal build -Duse_pcre $< -o $(shell echo $@ | rev | cut -f 2- -d '.' | rev) \
 			--debug --stats --error-trace --cross-compile --target $(TARGET_PLATFORM)
 
 # Build the Savi specs object file, based on the Crystal source code.
@@ -331,7 +331,7 @@ $(BUILD)/savi-spec.o: spec/all.cr $(LLVM_PATH) $(shell find src lib spec -name '
 		SAVI_LLVM_VERSION=`$(LLVM_CONFIG) --version` \
 		LLVM_CONFIG=$(LLVM_CONFIG) \
 		LLVM_DEFAULT_TARGET=$(TARGET_PLATFORM) \
-		crystal build $< -o $(shell echo $@ | rev | cut -f 2- -d '.' | rev) \
+		crystal build -Duse_pcre $< -o $(shell echo $@ | rev | cut -f 2- -d '.' | rev) \
 			--debug --stats --error-trace --cross-compile --target $(TARGET_PLATFORM)
 
 # Build the Savi compiler executable, by linking the above targets together.

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ CRYSTAL_PATH?=$(shell env $(shell crystal env) printenv CRYSTAL_PATH | rev | cut
 lib/libsavi_runtime: $(MAKE_VAR_CACHE)/RUNTIME_BITCODE_RELEASE_URL
 	rm -rf $@-tmp
 	mkdir -p $@-tmp
-	cd $@-tmp && curl -L --fail -sS \
+	cd $@-tmp && curl -L --fail --retry 10 -sS \
 		"${RUNTIME_BITCODE_RELEASE_URL}/libsavi_runtime.tar.gz" \
 	| tar -xzvf -
 	rm -rf $@
@@ -257,7 +257,7 @@ lib/libsavi_runtime: $(MAKE_VAR_CACHE)/RUNTIME_BITCODE_RELEASE_URL
 $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 	rm -rf $@-tmp
 	mkdir -p $@-tmp
-	cd $@-tmp && curl -L --fail -sS \
+	cd $@-tmp && curl -L --fail --retry 10 -sS \
 		"${LLVM_STATIC_RELEASE_URL}/${LLVM_STATIC_PLATFORM}-llvm-static.tar.gz" \
 	| tar -xzvf -
 	rm -rf $@
@@ -268,7 +268,7 @@ $(BUILD)/llvm-static: $(MAKE_VAR_CACHE)/LLVM_STATIC_RELEASE_URL
 # See github.com/jemc-savi/CapnProto for more info.
 $(BUILD)/capnpc-savi: $(MAKE_VAR_CACHE)/CAPNPC_SAVI_DOWNLOAD_URL
 	rm -f $@-tmp
-	curl -L --fail -sS "${CAPNPC_SAVI_DOWNLOAD_URL}" | tar -C $(BUILD) -xzvf -
+	curl -L --fail --retry 10 -sS "${CAPNPC_SAVI_DOWNLOAD_URL}" | tar -C $(BUILD) -xzvf -
 	chmod a+x $@
 	touch $@
 

--- a/shard.yml
+++ b/shard.yml
@@ -19,6 +19,6 @@ dependencies:
     github: at-grandpa/clim
     version: 0.13.0
 
-crystal: 1.5.0
+crystal: 1.8.0
 
 license: MPLv2

--- a/src/savi/ast.cr
+++ b/src/savi/ast.cr
@@ -120,7 +120,7 @@ module Savi::AST
     end
 
     def name; :doc end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       list.each { |x| res << x.to_a.as(A) }
       res
@@ -156,7 +156,7 @@ module Savi::AST
     end
 
     def name; :declare end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res.concat(terms.map(&.to_a.as(A)))
       res.concat(nested.map(&.to_a.as(A)))
@@ -211,7 +211,7 @@ module Savi::AST
     end
 
     def name; :fun end
-    def to_a: Array(A); [
+    def to_a : Array(A); [
       cap.to_a,
       ident.to_a,
       params.try(&.to_a),
@@ -269,7 +269,7 @@ module Savi::AST
     def initialize(@value : String)
     end
     def name; :doc_string end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
   end
 
   # An Identifier is any "bare word" in the source code, identifying something.
@@ -283,7 +283,7 @@ module Savi::AST
     def initialize(@value : String)
     end
     def name; :ident end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
 
     # If this identifier is immediately dot-nested within the given outer
     # identifier, then return the nested portion as a new identifier.
@@ -319,7 +319,7 @@ module Savi::AST
     def initialize(@value : String, @prefix_ident : Identifier? = nil)
     end
     def name; :string end
-    def to_a: Array(A); [name, value, prefix_ident.try(&.to_a)] of A end
+    def to_a : Array(A); [name, value, prefix_ident.try(&.to_a)] of A end
   end
 
   # A LiteralCharacter is similar to a LiteralString, but it uses single-quotes
@@ -334,7 +334,7 @@ module Savi::AST
     def initialize(@value : UInt64 | Int64)
     end
     def name; :char end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
   end
 
   # A LiteralInteger is an integer-appearing number in the source code,
@@ -355,7 +355,7 @@ module Savi::AST
     def initialize(@value : UInt64 | Int64)
     end
     def name; :integer end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
   end
 
   # A LiteralFloat is a floating-point-appearing number in the source code,
@@ -370,7 +370,7 @@ module Savi::AST
     def initialize(@value : Float64)
     end
     def name; :float end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
   end
 
   # A ComposeString is surrounded by double-quotes in source code much like
@@ -390,7 +390,7 @@ module Savi::AST
     def initialize(@terms = [] of Term, @prefix_ident : Identifier? = nil)
     end
     def name; :compose_string end
-    def to_a: Array(A); [name, *terms.map(&.to_a), prefix_ident.try(&.to_a)] of A end
+    def to_a : Array(A); [name, *terms.map(&.to_a), prefix_ident.try(&.to_a)] of A end
     def children_accept(ctx : Compiler::Context, visitor : Visitor)
       @terms.each(&.accept(ctx, visitor))
     end
@@ -415,7 +415,7 @@ module Savi::AST
     def initialize(@value : String)
     end
     def name; :op end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
   end
 
   # A Prefix is an AST node containing a single Term to which a single Operator
@@ -436,7 +436,7 @@ module Savi::AST
     end
 
     def name; :prefix end
-    def to_a: Array(A); [name, op.to_a, term.to_a] of A end
+    def to_a : Array(A); [name, op.to_a, term.to_a] of A end
     def children_accept(ctx : Compiler::Context, visitor : Visitor)
       @op.accept(ctx, visitor)
       @term.accept(ctx, visitor)
@@ -470,7 +470,7 @@ module Savi::AST
     end
 
     def name; :qualify end
-    def to_a: Array(A); [name, term.to_a, group.to_a] of A end
+    def to_a : Array(A); [name, term.to_a, group.to_a] of A end
     def children_accept(ctx : Compiler::Context, visitor : Visitor)
       @term.accept(ctx, visitor)
       @group.accept(ctx, visitor)
@@ -554,7 +554,7 @@ module Savi::AST
     end
 
     def name; :group end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res << style
       terms.each { |x| res << x.to_a }
@@ -618,7 +618,7 @@ module Savi::AST
     end
 
     def name; :relate end
-    def to_a: Array(A); [name, lhs.to_a, op.to_a, rhs.to_a] of A end
+    def to_a : Array(A); [name, lhs.to_a, op.to_a, rhs.to_a] of A end
     def children_accept(ctx : Compiler::Context, visitor : Visitor)
       @lhs.accept(ctx, visitor)
       @op.accept(ctx, visitor)
@@ -646,7 +646,7 @@ module Savi::AST
     def initialize(@value : String)
     end
     def name; :field_r end
-    def to_a: Array(A); [name, value] of A end
+    def to_a : Array(A); [name, value] of A end
   end
 
   # A FieldWrite node indicates a value being written to a particular field.
@@ -660,7 +660,7 @@ module Savi::AST
     end
 
     def name; :field_w end
-    def to_a: Array(A); [name, value, rhs.to_a] of A end
+    def to_a : Array(A); [name, value, rhs.to_a] of A end
     def children_accept(ctx : Compiler::Context, visitor : Visitor)
       @rhs.accept(ctx, visitor)
     end
@@ -685,7 +685,7 @@ module Savi::AST
     end
 
     def name; :field_x end
-    def to_a: Array(A); [name, value, rhs.to_a] of A end
+    def to_a : Array(A); [name, value, rhs.to_a] of A end
     def children_accept(ctx : Compiler::Context, visitor : Visitor)
       @rhs.accept(ctx, visitor)
     end
@@ -727,7 +727,7 @@ module Savi::AST
     end
 
     def name; :call end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res << receiver.to_a
       res << ident.to_a
@@ -783,7 +783,7 @@ module Savi::AST
     end
 
     def name; :choice end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       list.each { |cond, body| res << [cond.to_a, body.to_a] of A}
       res
@@ -834,7 +834,7 @@ module Savi::AST
     end
 
     def name; :loop end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res << initial_cond.to_a
       res << body.to_a
@@ -884,7 +884,7 @@ module Savi::AST
     end
 
     def name; :try end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res << body.to_a
       res << else_body.to_a
@@ -928,7 +928,7 @@ module Savi::AST
     end
 
     def name; :yield end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res.concat(terms.map(&.to_a.as(A)))
       res
@@ -968,7 +968,7 @@ module Savi::AST
     end
 
     def name; :jump end
-    def to_a: Array(A)
+    def to_a : Array(A)
       res = [name] of A
       res << kind.to_s.downcase
       res << term.to_a

--- a/src/savi/compiler/infer.cr
+++ b/src/savi/compiler/infer.cr
@@ -775,7 +775,7 @@ module Savi::Compiler::Infer
         f_cap_string = @func.cap.value
         f_cap_string = "ref" if @func.has_tag?(:constructor)
         f_cap_string = "read" if f_cap_string == "box" # TODO: figure out if we can remove this Pony-originating semantic hack
-        next_index: Int32 = 0
+        next_index : Int32 = 0
         MetaType::Capability.new_maybe_generic(f_cap_string).each_cap.map { |f_cap|
           {
             f_cap,

--- a/src/savi/compiler/namespace.cr
+++ b/src/savi/compiler/namespace.cr
@@ -21,7 +21,7 @@ class Savi::Compiler::Namespace
   end
 
   def main_type!(ctx); main_type?(ctx).not_nil! end
-  def main_type?(ctx): Program::Type::Link?
+  def main_type?(ctx) : Program::Type::Link?
     @types_by_package[ctx.root_package_link]["Main"]?.as(Program::Type::Link?)
   end
 

--- a/src/savi/ext/llvm/builder.cr
+++ b/src/savi/ext/llvm/builder.cr
@@ -74,4 +74,8 @@ class LLVM::Builder
   def call(func_type : LLVM::Type, func, args : Array(LLVM::Value), name : String = "", bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null)
     Value.new LibLLVMExt.build_call2(self, func_type, func, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, bundle, name)
   end
+
+  def invoke(type : LLVM::Type, fn : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null, name = "")
+    Value.new LibLLVMExt.build_invoke2(self, type, fn, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, a_then, a_catch, bundle, name)
+  end
 end

--- a/src/savi/ext/llvm/context.cr
+++ b/src/savi/ext/llvm/context.cr
@@ -30,10 +30,6 @@ class LLVM::Context
     if ret != 0 && msg
       raise LLVM.string_and_dispose(msg)
     end
-    {% if LibLLVM::IS_38 %}
-      Module.new(mod, "unknown", self)
-    {% else %} # LLVM >= 3.9
-      Module.new(mod, self)
-    {% end %}
+    Module.new(mod, self)
   end
 end

--- a/src/savi/ext/llvm/function.cr
+++ b/src/savi/ext/llvm/function.cr
@@ -5,6 +5,10 @@ struct LLVM::Function
     Type.new LibLLVM.global_get_value_type self
   end
 
+  def ret_type
+    function_type.return_type
+  end
+
   def entry_block
     BasicBlock.new LibLLVM.get_entry_basic_block self
   end

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -23,6 +23,7 @@ lib LibLLVM
   fun get_dll_storage_class = LLVMGetDLLStorageClass(global : ValueRef) : LLVM::DLLStorageClass
   fun set_dll_storage_class = LLVMSetDLLStorageClass(global : ValueRef, cls : LLVM::DLLStorageClass)
   fun remove_enum_attribute_at_index = LLVMRemoveEnumAttributeAtIndex(f : ValueRef, idx : AttributeIndex, kind : UInt32)
+  fun add_named_metadata_operand = LLVMAddNamedMetadataOperand(mod : ModuleRef, name : UInt8*, val : ValueRef)
 
   # Changes related to opaque pointers (LLVM 15).
   fun global_get_value_type = LLVMGlobalGetValueType(value : ValueRef) : TypeRef

--- a/src/savi/ext/time.cr
+++ b/src/savi/ext/time.cr
@@ -5,7 +5,7 @@ struct Time
   # It works like Time.measure but it returns the result value of the block
   # and prints the timing information, including an optional label and indent.
   def self.show(label : String, indent : Int32 = 0, &block : Nil -> U) : U forall U
-    result: U? = nil
+    result : U? = nil
     time = Time.measure { result = block.call(nil) }
     puts "#{" " * indent}#{time} - #{label}"
     result.as(U)


### PR DESCRIPTION
This version has some breaking changes on the LLVM side, as well as some deprecations and warnings we want to avoid.

They also switched to a different pcre library name.