### PR TITLE
Add `Platform.is_arm` and `Platform.is_x86` functions.

### DIFF
--- a/core/Platform.savi
+++ b/core/Platform.savi
@@ -52,6 +52,18 @@
   :: It is mutually exclusive with `is_posix`.
   :const is_windows Bool: compiler intrinsic
 
+  :: SECTION: CPU Architecture
+
+  :: Returns `True` if the target platform uses an ARM-based CPU architecture.
+  ::
+  :: This is mutually exclusive with `is_x86`.
+  :const is_arm Bool: compiler intrinsic
+
+  :: Returns `True` if the target platform uses an x86-based CPU architecture.
+  ::
+  :: This is mutually exclusive with `is_arm`.
+  :const is_x86 Bool: compiler intrinsic
+
   :: SECTION: Data Type Sizes
 
   :: Returns `True` if the target platform uses ILP32 data type sizes.

--- a/spec/core/Platform.Spec.savi
+++ b/spec/core/Platform.Spec.savi
@@ -9,6 +9,11 @@
       (if Platform.is_macos   (1 | 0)) +
       (if Platform.is_windows (1 | 0))
 
+  :it "returns True for exactly one of {is_arm, is_x86}"
+    assert: U8[1] == U8[0] +
+      (if Platform.is_arm (1 | 0)) +
+      (if Platform.is_x86 (1 | 0))
+
   :it "returns True for is_posix on POSIX platforms"
     if Platform.is_linux   (assert: Platform.is_posix)
     if Platform.is_bsd     (assert: Platform.is_posix)

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1028,6 +1028,10 @@ class Savi::Compiler::CodeGen
         gen_bool(!target.windows?)
       when "is_windows"
         gen_bool(target.windows?)
+      when "is_arm"
+        gen_bool(target.any_arm?)
+      when "is_x86"
+        gen_bool(target.any_x86?)
       when "is_ilp32"
         gen_bool(abi_size_of(@isize) == 4)
       when "is_lp64"

--- a/src/savi/compiler/target.cr
+++ b/src/savi/compiler/target.cr
@@ -1,6 +1,14 @@
 require "compiler/crystal/codegen/target"
 
 class Savi::Compiler::Target < Crystal::Codegen::Target
+  def any_arm?
+    architecture == "arm" || architecture == "aarch64"
+  end
+
+  def any_x86?
+    architecture == "i386" || architecture == "x86_64"
+  end
+
   def arm64?
     architecture == "aarch64"
   end


### PR DESCRIPTION
These functions allow for writing cross-platform code that needs to vary across these different CPU architectures.

This should be fairly rare as a need, but some FFI struct layouts do need to vary by CPU architecture, so it is sometimes needed.