### PR TITLE
Add error-raising variants of `Bytes.truncate*` and `.chop*` methods.

### DIFF
--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -505,14 +505,46 @@
     )
 
   :: Discard all bytes after the given offset.
+  ::
+  :: If there isn't enough filled data in the buffer, the truncate offset will
+  :: be silently reduced to match the size of the buffer, making the remaining
+  :: data still in the buffer shorter than expected. If you'd prefer to
+  :: raise an error for this case instead, use the `truncate!` method.
   :fun ref truncate(offset USize)
     offset = offset.at_most(@_size)
     @_size = offset
     @
 
+  :: Discard all bytes after the given offset.
+  ::
+  :: Raises an error if the offset is beyond the filled data of the buffer.
+  :: If you'd prefer in this case that the truncate offset be silently reduced
+  :: to match the size of the buffer, use the `truncate` method instead.
+  :fun ref truncate!(offset USize)
+    error! if offset > @_size
+    @_size = offset
+    @
+
   :: Discard all bytes to the left of the given offset.
+  ::
+  :: If there isn't enough filled data in the buffer, the truncate offset will
+  :: be silently reduced to match the size of the buffer, making the remaining
+  :: data still in the buffer shorter than expected. If you'd prefer to
+  :: raise an error for this case instead, use the `truncate_left!` method.
   :fun ref truncate_left(offset USize)
     offset = offset.at_most(@_size)
+    @_ptr = @_ptr._offset(offset)
+    @_size -= offset
+    @_space -= offset
+    @
+
+  :: Discard all bytes to the left of the given offset.
+  ::
+  :: Raises an error if the offset is beyond the filled data of the buffer.
+  :: If you'd prefer in this case that the truncate offset be silently reduced
+  :: to match the size of the buffer, use the `truncate_left` method instead.
+  :fun ref truncate_left!(offset USize)
+    error! if offset > @_size
     @_ptr = @_ptr._offset(offset)
     @_size -= offset
     @_space -= offset
@@ -528,8 +560,35 @@
   ::
   :: If the left side later expands its size, it will then reallocate and copy,
   :: because the right side has retained claim over the right-adjacent memory.
+  ::
+  :: If there isn't enough filled data in the buffer, the chop offset will
+  :: be silently reduced to match the size of the buffer, making the left side
+  :: shorter than expected (and the right side empty). If you'd prefer to
+  :: raise an error for this case instead, use the `chop_left!` method.
   :fun ref chop_left(offset USize) Bytes'iso
     offset = offset.at_most(@_size)
+    chopped = Bytes.iso_from_cpointer(@_ptr, offset, offset)
+    @_size -= offset
+    @_space -= offset
+    @_ptr = if @_space > 0 (@_ptr._offset(offset) | @_ptr._null)
+    --chopped
+
+  :: Split this byte buffer at the given offset, leaving the right side here
+  :: but chopping the left side off to return it as an isolated buffer.
+  ::
+  :: This method does not copy, and the existing allocation will be shared,
+  :: with the two buffers occupying adjacent memory in the same allocation.
+  ::
+  :: Both buffers remain mutable because they cannot access each other's bytes.
+  ::
+  :: If the left side later expands its size, it will then reallocate and copy,
+  :: because the right side has retained claim over the right-adjacent memory.
+  ::
+  :: Raises an error if the offset is beyond the filled data of the buffer.
+  :: If you'd prefer in this case that the chop offset be silently reduced
+  :: to match the size of the buffer, use the `chop_left` method instead.
+  :fun ref chop_left!(offset USize) Bytes'iso
+    error! if offset > @_size
     chopped = Bytes.iso_from_cpointer(@_ptr, offset, offset)
     @_size -= offset
     @_space -= offset
@@ -546,8 +605,38 @@
   ::
   :: If the left side later expands its size, it will then reallocate and copy,
   :: because the right side has retained claim over the right-adjacent memory.
+  ::
+  :: If there isn't enough filled data in the buffer, the chop offset will
+  :: be silently reduced to match the size of the buffer, making the left side
+  :: shorter than expected (and the right side empty). If you'd prefer to
+  :: raise an error for this case instead, use the `chop_right!` method.
   :fun ref chop_right(offset USize) Bytes'iso
     offset = offset.at_most(@_size)
+    chopped = Bytes.iso_from_cpointer(
+      if @_space > offset (@_ptr._offset(offset) | @_ptr._null)
+      @_size - offset
+      @_space - offset
+    )
+    @_size = offset
+    @_space = offset
+    --chopped
+
+  :: Split this byte buffer at the given offset, leaving the left side here
+  :: but chopping the right side off to return it as an isolated buffer.
+  ::
+  :: This method does not copy, and the existing allocation will be shared,
+  :: with the two buffers occupying adjacent memory in the same allocation.
+  ::
+  :: Both buffers remain mutable because they cannot access each other's bytes.
+  ::
+  :: If the left side later expands its size, it will then reallocate and copy,
+  :: because the right side has retained claim over the right-adjacent memory.
+  ::
+  :: Raises an error if the offset is beyond the filled data of the buffer.
+  :: If you'd prefer in this case that the chop offset be silently reduced
+  :: to match the size of the buffer, use the `chop_right` method instead.
+  :fun ref chop_right!(offset USize) Bytes'iso
+    error! if offset > @_size
     chopped = Bytes.iso_from_cpointer(
       if @_space > offset (@_ptr._offset(offset) | @_ptr._null)
       @_size - offset

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -237,14 +237,22 @@
     assert: b"example".clone.trim_in_place(5, 4) == b""
 
   :it "truncates from the left or right"
-    assert: b"example".clone.truncate(5)        == b"examp"
-    assert: b"example".clone.truncate_left(2)   == b"ample"
-    assert: b"example".clone.truncate(0)        == b""
-    assert: b"example".clone.truncate_left(0)   == b"example"
-    assert: b"example".clone.truncate(7)        == b"example"
-    assert: b"example".clone.truncate_left(7)   == b""
-    assert: b"example".clone.truncate(100)      == b"example"
-    assert: b"example".clone.truncate_left(100) == b""
+    assert: b"example".clone.truncate(5)         == b"examp"
+    assert: b"example".clone.truncate!(5)        == b"examp"
+    assert: b"example".clone.truncate_left(2)    == b"ample"
+    assert: b"example".clone.truncate_left!(2)   == b"ample"
+    assert: b"example".clone.truncate(0)         == b""
+    assert: b"example".clone.truncate!(0)        == b""
+    assert: b"example".clone.truncate_left(0)    == b"example"
+    assert: b"example".clone.truncate_left!(0)   == b"example"
+    assert: b"example".clone.truncate(7)         == b"example"
+    assert: b"example".clone.truncate!(7)        == b"example"
+    assert: b"example".clone.truncate_left(7)    == b""
+    assert: b"example".clone.truncate_left!(7)   == b""
+    assert: b"example".clone.truncate(100)       == b"example"
+    assert error: b"example".clone.truncate!(100)
+    assert: b"example".clone.truncate_left(100)  == b""
+    assert error: b"example".clone.truncate_left!(100)
 
   :it "chops off the left or right"
     center Bytes'ref = b"example".clone
@@ -292,6 +300,50 @@
     right_right ref = right.chop_right(100)
     assert: right_right == b"", assert: right == b"lel"
 
+  :it "chops off the left or right (error-raising variant)"
+    center Bytes'ref = b"example".clone
+    original_padding = center.space - center.size
+    left ref = try (center.chop_left!(2) | Bytes.new)
+    right ref = try (center.chop_right!(3) | Bytes.new)
+
+    assert: left == b"ex"
+    assert: center == b"amp"
+    assert: right == b"le"
+
+    // The three buffers are adjacent in memory.
+    assert: left.cpointer(2).address == center.cpointer.address
+    assert: center.cpointer(3).address == right.cpointer.address
+
+    // The first two buffers have a space exactly the same as their size,
+    // and the right buffer retains whatever space padding was in the original.
+    assert: left.space == left.size
+    assert: center.space == center.size
+    assert: right.space == right.size + original_padding
+
+    // Any of the three can have a byte appended without bleeding into the
+    // adjacent memory of the other buffers, since under the hood, this
+    // extension of either the left or center buffer forces reallocation of it.
+    left.push('t'), center.push('s'), right.push('l')
+    assert: left == b"ext"
+    assert: center == b"amps"
+    assert: right == b"lel"
+
+    // After the pushes above, The buffers are no longer adjacent in memory,
+    // checking with a pointer offset of both the original size and new size.
+    assert: left.cpointer(2).address != center.cpointer.address
+    assert: left.cpointer(3).address != center.cpointer.address
+    assert: center.cpointer(3).address != right.cpointer.address
+    assert: center.cpointer(4).address != right.cpointer.address
+
+    // Also now the first two buffers have some padding in their space,
+    // since they reserved more space when they were forced to reallocate.
+    assert: left.space > left.size
+    assert: center.space > center.size
+
+    // Chopping with an out-of-bounds offset raises an error.
+    assert error: left.chop_left!(100)
+    assert error: right.chop_right!(100)
+
   :it "chops into a null pointer on the right side when it runs out of space"
     // Chopping at the right edge of the buffer correctly leaves the right
     // Bytes with a null cpointer, rather than pointing out of bounds.
@@ -305,7 +357,21 @@
     assert: buffer_a_left.cpointer.is_not_null
     assert: buffer_a.cpointer.is_null
 
-    buffer_b_right = buffer_a.chop_right(buffer_b.size)
+    buffer_b_right = buffer_b.chop_right(buffer_b.size)
+    assert: buffer_b.cpointer.is_not_null
+    assert: buffer_b_right.cpointer.is_null
+
+  :it "chops into a null pointer on the right side (error-raising variant)"
+    // Same test as above, but with the error-raising variants of chop methods.
+    buffer_a = Bytes.new_iso(8), buffer_b = Bytes.new_iso(8)
+    while buffer_a.space > buffer_a.size buffer_a.push('.')
+    while buffer_b.space > buffer_b.size buffer_b.push('.')
+
+    buffer_a_left = try (buffer_a.chop_left!(buffer_a.size) | b"".clone)
+    assert: buffer_a_left.cpointer.is_not_null
+    assert: buffer_a.cpointer.is_null
+
+    buffer_b_right = try (buffer_b.chop_right!(buffer_b.size) | b"...".clone)
     assert: buffer_b.cpointer.is_not_null
     assert: buffer_b_right.cpointer.is_null
 


### PR DESCRIPTION
These variants can be used when the caller prefers to avoid silently reducing the truncate/chop offset in the case where the filled size of the buffer is too small.

These variants raise an error instead.