### PR TITLE
Add support for raising an `error!` with a value.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -473,6 +473,13 @@
   :term out TypeOrTypeList
 
 // TODO: Document this.
+:declarator errors
+  :intrinsic
+  :context function
+
+  :term out Type
+
+// TODO: Document this.
 :declarator const
   :intrinsic
   :context type

--- a/spec/compiler/flow.savi.spec.md
+++ b/spec/compiler/flow.savi.spec.md
@@ -238,9 +238,41 @@ It analyzes control flow for errors and partial calls in a `try`.
     )
     @after_if ::flow.block=> 5(8U | 12)
   |
-    @catch ::flow.block=> 4(7 | 10 | 11)
+    @else ::flow.block=> 4(7 | 10 | 11)
   )
   @after ::flow.block=> 2(5 | 4)
+  @ ::flow.exit_block=> 1(2)
+```
+
+---
+
+It analyzes control flow for errors and partial calls in a `try` that
+includes an error value catch expression.
+
+```savi
+  @before ::flow.block=> 0(entry)
+  try (
+    @before_if ::flow.block=> 3(0)
+    if (
+      @cond ::flow.block=> 7(3)
+    ) (
+      @before_error ::flow.block=> 8(7T)
+      error!        ::flow.block=> 8(7T)
+      @after_error  ::flow.block=> 9U(8)
+    |
+      @before_partial_call_1 ::flow.block=> 11(10T)
+      @partial_call_1!       ::flow.block=> 11(10T)
+      @before_partial_call_2 ::flow.block=> 12(11)
+      @partial_call_2!       ::flow.block=> 12(11)
+      @after_partial_calls   ::flow.block=> 13(12)
+    )
+    @after_if ::flow.block=> 6(9U | 13)
+  |
+    err ::flow.block=> 4(8 | 11 | 12)
+  |
+    @else ::flow.block=> 5(4)
+  )
+  @after ::flow.block=> 2(6 | 5)
   @ ::flow.exit_block=> 1(2)
 ```
 

--- a/spec/compiler/local.savi.spec.md
+++ b/spec/compiler/local.savi.spec.md
@@ -61,6 +61,20 @@ It marks the use sites of yield parameters.
 
 ---
 
+It marks the use sites of a try catch expression variable.
+
+```savi
+  try (
+    error! "value"
+  |
+    err          ::local.use_site=> err:W:(4, 4)
+  |
+    string = err ::local.use_site=> err:R:(5, 7)
+  )
+```
+
+---
+
 It complains when trying to read a local variable prior to its first assignment.
 
 ```savi

--- a/spec/compiler/macros/try_spec.cr
+++ b/spec/compiler/macros/try_spec.cr
@@ -35,7 +35,10 @@ describe Savi::Compiler::Macros do
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
       - this term is the body to be attempted, followed by an optional
-        else clause to execute if the body errors (partitioned by `|`):
+        else clause (partitioned by `|`) to execute if there is an error;
+        if there are three clauses, then the middle one is treated as a
+        an expression that captures the error value in a local variable,
+        possibly constraining the type of error values that are allowed:
         from (example):3:
           try (error! | True) what now
               ^~~~~~~~~~~~~~~
@@ -73,12 +76,12 @@ describe Savi::Compiler::Macros do
           try (error! | True | what | now)
                ^~~~~~
 
-      - this section is the body to be executed if the previous errored (the "else" case):
+      - this section is an optional local variable expression to bind a caught error value:
         from (example):3:
           try (error! | True | what | now)
                         ^~~~
 
-      - this is an excessive section:
+      - this section is the body to be executed if the previous errored (the "else" case):
         from (example):3:
           try (error! | True | what | now)
                                ^~~~

--- a/spec/compiler/t_type_check.errors.savi.spec.md
+++ b/spec/compiler/t_type_check.errors.savi.spec.md
@@ -1,0 +1,225 @@
+---
+pass: t_type_check
+---
+
+The following functions are used in some but not all of the examples below:
+```savi
+:module Errors
+  :fun none!: error! None
+    :errors None
+
+  :fun string!: error! "Whoops"
+    :errors String
+
+  :fun u8!: error! U8.zero
+    :errors U8
+
+  :fun f32!: error! F32.zero
+    :errors F32
+```
+
+---
+
+It collects error value types in the type of catch expr:
+
+```savi
+  :fun example(flag1 Bool, flag2 Bool)
+    try (
+      case (
+      | flag1 | error! "Whoops"
+      | flag2 | error! U64.zero
+      |         error!
+      )
+      Errors.string!
+      Errors.none!
+      Errors.u8!
+    | e |
+      e ::t_type=> (String | U64 | None | U8)
+    )
+```
+
+---
+
+It applies the type constraint of an error catch expression to an error value:
+
+```savi
+    try (
+      error! 52 ::t_type=> U8
+    | e U8 |
+      e ::t_type=> U8
+    )
+```
+
+---
+
+It complains when the catch type constraint doesn't match the error value.
+
+```savi
+  :fun example(flag1 Bool, flag2 Bool)
+    try (
+      case (
+      | flag1 | error! "Whoops"
+      | flag2 | error! 9 ::t_type=> U8
+      |         error!
+      )
+      Errors.string!
+      Errors.none!
+      Errors.u8!
+    | e U8 |
+      e
+    )
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      | flag1 | error! "Whoops"
+                ^~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the expression was String:
+      | flag1 | error! "Whoops"
+                       ^~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      |         error!
+                ^~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the singleton value for this type was None:
+      |         error!
+                ^~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      Errors.string!
+      ^~~~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the error value raised by this function was String:
+      Errors.string!
+      ^~~~~~~~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      Errors.none!
+      ^~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the error value raised by this function was None:
+      Errors.none!
+      ^~~~~~~~~~~~
+```
+
+---
+
+It collects uncaught error value types in the errors type of the function:
+
+```savi
+  :fun example(flag1 Bool, flag2 Bool)
+    try (
+      @example!(flag1, flag2)
+    | e |
+      e ::t_type=> (String | U64 | None | U8)
+    )
+  :fun example!(flag1 Bool, flag2 Bool)
+    case (
+    | flag1 | error! "Whoops"
+    | flag2 | error! U64.zero
+    |         error!
+    )
+    Errors.string!
+    Errors.none!
+    Errors.u8!
+    try Errors.f32! // caught by the try, so won't be raised out
+```
+
+---
+
+It applies the type constraint of the `:errors` declaration to an error value:
+
+```savi
+  :fun example!
+    :errors U8
+    error! 52 ::t_type=> U8
+```
+
+---
+
+It complains when the `:errors` type constraint doesn't match the error value.
+
+```savi
+  :fun example!(flag1 Bool, flag2 Bool)
+    :errors U8
+    case (
+    | flag1 | error! "Whoops"
+    | flag2 | error! 9 ::t_type=> U8
+    |         error!
+    )
+    Errors.string!
+    Errors.none!
+    Errors.u8!
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    | flag1 | error! "Whoops"
+              ^~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the expression was String:
+    | flag1 | error! "Whoops"
+                     ^~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    |         error!
+              ^~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the singleton value for this type was None:
+    |         error!
+              ^~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    Errors.string!
+    ^~~~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the error value raised by this function was String:
+    Errors.string!
+    ^~~~~~~~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    Errors.none!
+    ^~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the error value raised by this function was None:
+    Errors.none!
+    ^~~~~~~~~~~~
+```

--- a/spec/compiler/type_check.errors.savi.spec.md
+++ b/spec/compiler/type_check.errors.savi.spec.md
@@ -1,0 +1,225 @@
+---
+pass: type_check
+---
+
+The following functions are used in some but not all of the examples below:
+```savi
+:module Errors
+  :fun none!: error! None
+    :errors None
+
+  :fun string!: error! "Whoops"
+    :errors String
+
+  :fun u8!: error! U8.zero
+    :errors U8
+
+  :fun f32!: error! F32.zero
+    :errors F32
+```
+
+---
+
+It collects error value types in the type of catch expr:
+
+```savi
+  :fun example(flag1 Bool, flag2 Bool)
+    try (
+      case (
+      | flag1 | error! "Whoops"
+      | flag2 | error! U64.zero
+      |         error!
+      )
+      Errors.string!
+      Errors.none!
+      Errors.u8!
+    | e |
+      e ::type=> (String | U64 | U8 | None)
+    )
+```
+
+---
+
+It applies the type constraint of an error catch expression to an error value:
+
+```savi
+    try (
+      error! 52 ::type=> U8
+    | e U8 |
+      e ::type=> U8
+    )
+```
+
+---
+
+It complains when the catch type constraint doesn't match the error value.
+
+```savi
+  :fun example(flag1 Bool, flag2 Bool)
+    try (
+      case (
+      | flag1 | error! "Whoops"
+      | flag2 | error! 9 ::type=> U8
+      |         error!
+      )
+      Errors.string!
+      Errors.none!
+      Errors.u8!
+    | e U8 |
+      e
+    )
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      | flag1 | error! "Whoops"
+                ^~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the expression was String:
+      | flag1 | error! "Whoops"
+                       ^~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      |         error!
+                ^~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the singleton value for this type was None:
+      |         error!
+                ^~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      Errors.string!
+      ^~~~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the error value raised by this function was String:
+      Errors.string!
+      ^~~~~~~~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+      Errors.none!
+      ^~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    | e U8 |
+        ^~
+
+- but the type of the error value raised by this function was None:
+      Errors.none!
+      ^~~~~~~~~~~~
+```
+
+---
+
+It collects uncaught error value types in the errors type of the function:
+
+```savi
+  :fun example(flag1 Bool, flag2 Bool)
+    try (
+      @example!(flag1, flag2)
+    | e |
+      e ::type=> (String | U64 | U8 | None)
+    )
+  :fun example!(flag1 Bool, flag2 Bool)
+    case (
+    | flag1 | error! "Whoops"
+    | flag2 | error! U64.zero
+    |         error!
+    )
+    Errors.string!
+    Errors.none!
+    Errors.u8!
+    try Errors.f32! // caught by the try, so won't be raised out
+```
+
+---
+
+It applies the type constraint of the `:errors` declaration to an error value:
+
+```savi
+  :fun example!
+    :errors U8
+    error! 52 ::type=> U8
+```
+
+---
+
+It complains when the `:errors` type constraint doesn't match the error value.
+
+```savi
+  :fun example!(flag1 Bool, flag2 Bool)
+    :errors U8
+    case (
+    | flag1 | error! "Whoops"
+    | flag2 | error! 9 ::type=> U8
+    |         error!
+    )
+    Errors.string!
+    Errors.none!
+    Errors.u8!
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    | flag1 | error! "Whoops"
+              ^~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the expression was String:
+    | flag1 | error! "Whoops"
+                     ^~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    |         error!
+              ^~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the singleton value for this type was None:
+    |         error!
+              ^~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    Errors.string!
+    ^~~~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the error value raised by this function was String:
+    Errors.string!
+    ^~~~~~~~~~~~~~
+```
+```error
+The type of this expression doesn't meet the constraints imposed on it:
+    Errors.none!
+    ^~~~~~~~~~~~
+
+- it is required here to be a subtype of U8:
+    :errors U8
+            ^~
+
+- but the type of the error value raised by this function was None:
+    Errors.none!
+    ^~~~~~~~~~~~
+```

--- a/spec/language/semantics/try_spec.savi
+++ b/spec/language/semantics/try_spec.savi
@@ -2,6 +2,22 @@
   :fun non not_really!: None
   :fun non now!: @inner!
   :fun non inner!: error!
+  :fun non now_with_value_u64!: error! 99
+    :errors U64
+  :fun non now_with_value_string!: error! "whoops!"
+  :fun non now_with_value_struct!: @inner_with_value_struct!
+  :fun non inner_with_value_struct!: error! _MyError.new(99, "whoops!")
+  :fun non maybe_with_value_struct_or_none!(should_struct Bool)
+    if should_struct (error! _MyError.new(100, "whoa") | error!)
+
+:struct _MyError
+  :let code U64
+  :let message String
+  :new (@code, @message)
+  :fun inspect_into(output String'ref) None
+    Inspect.into(output, @code)
+    output << ": "
+    output << @message
 
 :module TrySpec
   :fun run(test MicroTest)
@@ -100,10 +116,102 @@
       )
     )
 
-    test["try call error; with error"].pass = U64[33] == (
+    test["try call; with error"].pass = U64[33] == (
       try (_Err.now!, 11 | 33)
     )
 
-    test["try call error; without error"].pass = U64[33] == (
+    test["try call; without error"].pass = U64[33] == (
       try (_Err.not_really!, 33 | 11)
+    )
+
+    test["try; with error value (numeric)"].pass = "98" == (
+      try (
+        error! 98
+        "success"
+      | err U64 |
+        Inspect[err]
+      )
+    )
+
+    test["try; with error value (class)"].pass = "whoopsie" == (
+      try (
+        error! "whoopsie"
+        "success"
+      | err |
+        err
+      )
+    )
+
+    test["try; with error value (struct)"].pass = "98: whoopsie" == (
+      try (
+        error! _MyError.new(98, "whoopsie")
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try; with error value (struct or none)"].pass = "98: whoopsie" == (
+      try (
+        if False error!
+        error! _MyError.new(98, "whoopsie")
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try; with error value (none or struct)"].pass = "None" == (
+      try (
+        if True error!
+        error! _MyError.new(98, "whoopsie")
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try call; with error value (numeric)"].pass = "99" == (
+      try (
+        _Err.now_with_value_u64!
+        "success"
+      | err U64 |
+        Inspect[err]
+      )
+    )
+
+    test["try call; with error value (class)"].pass = "whoops!" == (
+      try (
+        _Err.now_with_value_string!
+        "success"
+      | err |
+        err
+      )
+    )
+
+    test["try call; with error value (struct)"].pass = "99: whoops!" == (
+      try (
+        _Err.now_with_value_struct!
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try call; with error value (none or struct)"].pass = "None" == (
+      try (
+        _Err.maybe_with_value_struct_or_none!(False)
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try call; with error value (struct or none)"].pass = "100: whoa" == (
+      try (
+        _Err.maybe_with_value_struct_or_none!(True)
+        "success"
+      | err |
+        Inspect[err]
+      )
     )

--- a/src/savi/compiler/classify.cr
+++ b/src/savi/compiler/classify.cr
@@ -213,6 +213,7 @@ module Savi::Compiler::Classify
         f.ret.try(&.accept(ctx, visitor))
         visitor.type_expr_visit(ctx, f.ret)
         f.body.try(&.accept(ctx, visitor))
+        visitor.type_expr_visit(ctx, f.error_out)
         visitor.type_expr_visit(ctx, f.yield_out)
         visitor.type_expr_visit(ctx, f.yield_in)
 

--- a/src/savi/compiler/infer.cr
+++ b/src/savi/compiler/infer.cr
@@ -160,6 +160,9 @@ module Savi::Compiler::Infer
     getter! yield_out_spans : Array(Span)
     protected setter yield_out_spans
 
+    getter! error_out_span : Span?
+    protected setter error_out_span
+
     protected getter captured_function_pointers
     def each_captured_function_pointer; @captured_function_pointers.each; end
 
@@ -939,6 +942,18 @@ module Savi::Compiler::Infer
         other_rt.args, call_cap, other_f.has_tag?(:constructor))
     end
 
+    def depends_on_call_error_out_span(ctx, other_rt, other_f, other_f_link, call_cap : Cap)
+      # TODO: Track dependencies and invalidate cache based on those.
+      other_pre = ctx.pre_infer[other_f_link]
+      error_out_info = other_pre.error_out_info
+      return unless error_out_info
+      other_analysis = ctx.infer_edge.run_for_func(ctx, other_f, other_f_link)
+      raw_span = other_analysis.direct_span(error_out_info)
+
+      other_analysis.deciding_reify_of(raw_span,
+        other_rt.args, call_cap, other_f.has_tag?(:constructor))
+    end
+
     def run_edge(ctx : Context)
       @analysis.param_spans =
         func.params.try { |params|
@@ -952,6 +967,9 @@ module Savi::Compiler::Infer
 
       @analysis.yield_out_spans =
         @pre_infer.yield_out_infos.map { |info| resolve(ctx, info) }
+
+      @analysis.error_out_span =
+        @pre_infer.error_out_info.try { |info| resolve(ctx, info) }
     end
 
     def run(ctx : Context)

--- a/src/savi/compiler/infer/reified.cr
+++ b/src/savi/compiler/infer/reified.cr
@@ -289,6 +289,13 @@ module Savi::Compiler::Infer
     ) : MetaType?
       meta_type_of(ctx, infer.yield_in_span, infer)
     end
+
+    def meta_type_of_error_out(
+      ctx : Context,
+      infer : FuncAnalysis = ctx.infer[@link]
+    ) : MetaType?
+      meta_type_of(ctx, infer.error_out_span, infer)
+    end
   end
 
   struct TypeParam

--- a/src/savi/compiler/local.cr
+++ b/src/savi/compiler/local.cr
@@ -298,6 +298,11 @@ module Savi::Compiler::Local
         if old_use_site.try(&.is_first_lexical_appearance)
     end
 
+    # Observing a try entails observing the catch expression if it has one.
+    def observe(ctx, node : AST::Try)
+      node.catch_expr.try { |e| observe_param(ctx, e) }
+    end
+
     # Observing a call site entails observing any yield parameters.
     def observe(ctx, node : AST::Call)
       node.yield_params.try(&.terms.each { |param| observe_param(ctx, param) })

--- a/src/savi/compiler/reach.cr
+++ b/src/savi/compiler/reach.cr
@@ -583,9 +583,10 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
     getter receiver : Ref # TODO: add to subtype_of? logic
     getter params : Array(Ref)
     getter ret : Ref
+    getter error_out : Ref? # TODO: add to subtype_of? logic
     getter yield_out : Array(Ref) # TODO: add to subtype_of? logic
     # TODO: Add yield_in as well
-    def initialize(@name, @receiver, @params, @ret, @yield_out)
+    def initialize(@name, @receiver, @params, @ret, @error_out, @yield_out)
     end
 
     def subtype_of?(ctx, other : Signature)
@@ -772,11 +773,15 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
     }
     ret = ctx.reach.handle_type_ref(ctx, rf.meta_type_of_ret(ctx, infer) || bogus_mt)
 
+    error_out = infer.error_out_span.try { |span|
+      ctx.reach.handle_type_ref(ctx, rf.meta_type_of(ctx, span, infer) || bogus_mt)
+    }
+
     yield_out = infer.yield_out_spans.map { |span|
       ctx.reach.handle_type_ref(ctx, rf.meta_type_of(ctx, span, infer) || bogus_mt)
     }
 
-    Signature.new(rf.name, receiver, params, ret, yield_out)
+    Signature.new(rf.name, receiver, params, ret, error_out, yield_out)
   end
 
   def handle_field(ctx, rt : Infer::ReifiedType, f_link, ident) : {String, Ref}?

--- a/src/savi/compiler/t_infer/info.cr
+++ b/src/savi/compiler/t_infer/info.cr
@@ -608,6 +608,15 @@ module Savi::Compiler::TInfer
 
   class Local < NamedInfo
     def describe_kind : String; "local variable" end
+
+    def initialize(pos, layer_index)
+      super(pos, layer_index)
+
+      @infer_from_all_upstreams = false
+    end
+
+    def set_infer_from_all_upstreams; @infer_from_all_upstreams = true end
+    def infer_from_all_upstreams? : Bool; @infer_from_all_upstreams end
   end
 
   class Param < NamedInfo
@@ -620,6 +629,12 @@ module Savi::Compiler::TInfer
 
   class YieldOut < NamedInfo
     def describe_kind : String; "yielded result" end
+  end
+
+  class ErrorOut < NamedInfo
+    def describe_kind : String; "raised error value" end
+
+    def infer_from_all_upstreams? : Bool; true end
   end
 
   class Field < DynamicInfo
@@ -1227,6 +1242,52 @@ module Savi::Compiler::TInfer
 
             infer
               .depends_on_call_ret_span(ctx, call_defn, call_func, call_link)
+          }
+          Span.reduce_combine_mts(intersection_term_spans) { |accum, mt| accum.intersect(mt) }.not_nil!
+        }
+        Span.reduce_combine_mts(union_member_spans) { |accum, mt| accum.unite(mt) }.not_nil!
+      }
+    end
+  end
+
+  class FromCallErrorOut < DynamicInfo
+    getter call : FromCall
+
+    def describe_kind : String; "error value raised by this function" end
+
+    def initialize(@pos, @layer_index, @call)
+    end
+
+    def tether_terminal?
+      true
+    end
+
+    def tether_resolve_span(ctx : Context, infer : Visitor)
+      infer.resolve(ctx, self)
+    end
+
+    def resolve_span!(ctx : Context, infer : Visitor) : Span
+      @call.resolve_receiver_span(ctx, infer).transform_mt_to_span { |call_receiver_mt|
+        union_member_spans = call_receiver_mt.map_each_union_member { |union_member_mt|
+          intersection_term_spans = union_member_mt.map_each_intersection_term { |term_mt|
+            call_defn = term_mt.single!
+            call_func = call_defn.defn(ctx).find_func!(@call.member)
+            call_link = call_func.make_link(call_defn.link)
+
+            raw_err_span = infer.depends_on_call_error_out_span(
+              ctx, call_defn, call_func, call_link
+            )
+
+            unless raw_err_span
+              call_name = "#{call_defn.defn(ctx).ident.value}.#{@call.member}"
+              next Span.error(pos,
+                "This error value will never be received", [
+                  {call_func.ident.pos, "'#{call_name}' cannot raise an error"}
+                ]
+              )
+            end
+
+            raw_err_span.not_nil!
           }
           Span.reduce_combine_mts(intersection_term_spans) { |accum, mt| accum.intersect(mt) }.not_nil!
         }

--- a/src/savi/compiler/t_infer/reified.cr
+++ b/src/savi/compiler/t_infer/reified.cr
@@ -276,6 +276,13 @@ module Savi::Compiler::TInfer
     ) : MetaType?
       meta_type_of(ctx, infer.yield_in_span, infer)
     end
+
+    def meta_type_of_error_out(
+      ctx : Context,
+      infer : FuncAnalysis = ctx.t_infer[@link]
+    ) : MetaType?
+      meta_type_of(ctx, infer.error_out_span, infer)
+    end
   end
 
   struct TypeParam

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -24,6 +24,15 @@ lib LibLLVM
   fun set_dll_storage_class = LLVMSetDLLStorageClass(global : ValueRef, cls : LLVM::DLLStorageClass)
   fun remove_enum_attribute_at_index = LLVMRemoveEnumAttributeAtIndex(f : ValueRef, idx : AttributeIndex, kind : UInt32)
   fun add_named_metadata_operand = LLVMAddNamedMetadataOperand(mod : ModuleRef, name : UInt8*, val : ValueRef)
+  fun set_thread_local_mode = LLVMSetThreadLocalMode(global_var : ValueRef, mode : ThreadLocalMode)
+
+  enum ThreadLocalMode
+    NotThreadLocal = 0
+    GeneralDynamicTLSModel
+    LocalDynamicTLSModel
+    InitialExecTLSModel
+    LocalExecTLSModel
+  end
 
   # Changes related to opaque pointers (LLVM 15).
   fun global_get_value_type = LLVMGlobalGetValueType(value : ValueRef) : TypeRef

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -373,6 +373,8 @@ class Savi::Program
     def ret=(x); ast.ret = x end
     def body; ast.body end
     def body=(x); ast.body = x end
+    def error_out; ast.error_out end
+    def error_out=(x); ast.error_out = x end
     def yield_out; ast.yield_out end
     def yield_out=(x); ast.yield_out = x end
     def yield_in; ast.yield_in end

--- a/src/savi/program/declarator/intrinsic.cr
+++ b/src/savi/program/declarator/intrinsic.cr
@@ -595,6 +595,8 @@ module Savi::Program::Intrinsic
       case declarator.name.value
       when "inline"
         scope.current_function.add_tag(:inline)
+      when "errors"
+        scope.current_function.error_out = terms["out"]?.as(AST::Term?)
       when "yields"
         scope.current_function.yield_out = terms["out"]?.as(AST::Term?)
         scope.current_function.yield_in  = terms["in"]?.as(AST::Term?)


### PR DESCRIPTION
- it is now possible to write `error! some_value` to raise an error with a value
  - `error!` with no value will have a value of `None`.

- An `:errors SomeType` declaration constrains what types of value can be raised from a function
  - If this declaration is not present, the type will be inferred from all errors within

- if a `try` group has three sections (as opposed to the typical one or two sections):
  - the first section is the body of potentially-error-raising expressions to execute
  - the second section is an local variable identifier with optional type (like a parameter) to declare the local variable which will catch the raised error value.
  - the third section is the body of code to handle the error case, with the above "catch" local variable being within scope and available to use.

This is a backwards-compatible change.