### PR TITLE
DEPRECATED: `_until` methods using boolean-driven loop interruption.

### DIFF
--- a/core/Indexable.savi
+++ b/core/Indexable.savi
@@ -19,6 +19,7 @@
       yield value
     )
 
+  :: DEPRECATED: Use `break` to exit early from `each` if needed.
   :fun each_until(
     from USize = 0
     to = USize.max_value
@@ -30,6 +31,7 @@
     )
     False
 
+  :: DEPRECATED: Use `break` to exit early from `each_with_index` if needed.
   :fun each_with_index_until(
     from USize = 0
     to = USize.max_value

--- a/core/String.savi
+++ b/core/String.savi
@@ -230,7 +230,7 @@
       yield value
     )
 
-  // TODO: Move to be on a new `Indexable.Bytes` trait?
+  :: DEPRECATED: Use `break` to exit early from `each_byte` if needed.
   :fun each_byte_until(from USize = 0, to = USize.max_value, stride USize = 1)
     :yields for Bool
     @each_byte(from, to, stride) -> (byte |
@@ -238,6 +238,7 @@
     )
     False
 
+  // TODO: Move to be on a new `Indexable.Bytes` trait?
   :fun each_byte_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
     index = from
     while index < to.at_most(@_size) (
@@ -246,6 +247,7 @@
     )
     None
 
+  // TODO: Move to be on a new `Indexable.Bytes` trait?
   :fun reverse_each_byte_with_index(
     from = USize.max_value
     to USize = 0

--- a/docs/intro-vs-pony.md
+++ b/docs/intro-vs-pony.md
@@ -372,10 +372,10 @@ Note that the block is not a value that can be carried around - yielding cannot 
   :fun blab_until
     :yields (String, USize) for Bool
       index USize = 0
-      @sentences.each_until -> (sentence |
+      @sentences.each -> (sentence |
         stopped_listening = yield (sentence, index)
+        break if stopped_listening
         index += 1
-        stopped_listening // stop iterating when caller stops listening
       )
 
 :actor Main


### PR DESCRIPTION
Using a boolean yield block result to determine whether an "each"-like loop should continue is an old pattern I added to Savi early on.

Now this pattern is superceded by the fact that the `break` macro now works with yield blocks just as well as it works with inline loop macros.

So the old pattern of defining a separate `_until` method is now kind of an anti-pattern, and shouldn't be used anymore, going forward.

This commit marks those standard-library methods as being `DEPRECATED`. They'll be removed in the future.