### PR TITLE
Fix memory safety bugs involving dynamic tracing of a "boxed" struct.

### DIFF
--- a/spec/language/micro_test/micro_test.savi
+++ b/spec/language/micro_test/micro_test.savi
@@ -2,9 +2,9 @@
   :ffi variadic libc_printf(format CPointer(U8)) I32
     :foreign_name printf // (we use this just to test `:foreign_name` here)
 
-:class MicroTest
+:class val MicroTest
   :var env Env
-  :new (@env)
+  :new val (@env)
   :fun non _printf(f String, t String): _FFI.libc_printf(f.cstring, t.cstring)
   :fun non print_line_break: @_printf("%s", "\n")
   :fun "[]"(text String) MicroTestInstance

--- a/spec/language/semantics/regression_spec.savi
+++ b/spec/language/semantics/regression_spec.savi
@@ -1,4 +1,6 @@
 :module RegressionSpec
+  :fun maybe_int_format!: 33.format.decimal
+
   :fun run(test MicroTest)
     // In a past version of the compiler, this would generate invalid LLVM IR,
     // failing to deal properly with the fact that we were calling `into_string`
@@ -7,4 +9,45 @@
       try (@maybe_int_format! | "???")
     )" == "example: 33"
 
-  :fun maybe_int_format!: 33.format.decimal
+    RegressionSpec.TraceArrayOfUnionOfNoneAndPairWithNestedClass.new(test)
+
+:class val _ValWrap(T val)
+  :let value T
+  :new val (@value)
+
+// In a past version of the compiler, this would generate a wrong kind of
+// trace for the garbage collection, causing some objects to be collected
+// (and their memory reused) while they are still in the array, causing
+// data corruption due to future objects reusing the same memory.
+:actor RegressionSpec.TraceArrayOfUnionOfNoneAndPairWithNestedClass
+  :let test MicroTest
+  :let array Array(
+    (Pair(I32, _ValWrap(_ValWrap(USize))) | None)
+  ): []
+  :const max_index USize: 1000
+  :new (@test): @next(0)
+
+  :be next(index USize)
+    if index >= @max_index (
+      @finish
+      return
+    )
+    @array << Pair(I32, _ValWrap(_ValWrap(USize))).new(
+      0
+      _ValWrap(_ValWrap(USize)).new(
+        _ValWrap(USize).new(index)
+      )
+    )
+    @next(index + 1)
+
+  :fun check_array
+    @array.each_with_index -> (element, index |
+      return False unless (
+        try (element.not!(None).value.value.value == index | False)
+      )
+    )
+    True
+
+  :be finish
+    @test["trace array of union of none and pair with nested class"].pass =
+      @check_array

--- a/spec/language/semantics/try_spec.savi
+++ b/spec/language/semantics/try_spec.savi
@@ -124,94 +124,112 @@
       try (_Err.not_really!, 33 | 11)
     )
 
-    // test["try; with error value (numeric)"].pass = "98" == (
-    //   try (
-    //     error! 98
-    //     "success"
-    //   | err U64 |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try; with error value (numeric)"].pass = "98" == (
+      try (
+        error! 98
+        "success"
+      | err U64 |
+        Inspect[err]
+      )
+    )
 
-    // test["try; with error value (class)"].pass = "whoopsie" == (
-    //   try (
-    //     error! "whoopsie"
-    //     "success"
-    //   | err |
-    //     err
-    //   )
-    // )
+    test["try; with error value (class)"].pass = "whoopsie" == (
+      try (
+        error! "whoopsie"
+        "success"
+      | err |
+        err
+      )
+    )
 
-    // test["try; with error value (struct)"].pass = "98: whoopsie" == (
-    //   try (
-    //     error! _MyError.new(98, "whoopsie")
-    //     "success"
-    //   | err |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try; with error value (struct)"].pass = "98: whoopsie" == (
+      try (
+        error! _MyError.new(98, "whoopsie")
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
 
-    // test["try; with error value (struct or none)"].pass = "98: whoopsie" == (
-    //   try (
-    //     if False error!
-    //     error! _MyError.new(98, "whoopsie")
-    //     "success"
-    //   | err |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try; with error value (none)"].pass = "None" == (
+      try (
+        error!
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
 
-    // test["try; with error value (none or struct)"].pass = "None" == (
-    //   try (
-    //     if True error!
-    //     error! _MyError.new(98, "whoopsie")
-    //     "success"
-    //   | err |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try; with error value (struct or none)"].pass = "98: whoopsie" == (
+      try (
+        if False error!
+        error! _MyError.new(98, "whoopsie")
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
 
-    // test["try call; with error value (numeric)"].pass = "99" == (
-    //   try (
-    //     _Err.now_with_value_u64!
-    //     "success"
-    //   | err U64 |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try; with error value (none or struct)"].pass = "None" == (
+      try (
+        if True error!
+        error! _MyError.new(98, "whoopsie")
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
 
-    // test["try call; with error value (class)"].pass = "whoops!" == (
-    //   try (
-    //     _Err.now_with_value_string!
-    //     "success"
-    //   | err |
-    //     err
-    //   )
-    // )
+    test["try call; with error value (numeric)"].pass = "99" == (
+      try (
+        _Err.now_with_value_u64!
+        "success"
+      | err U64 |
+        Inspect[err]
+      )
+    )
 
-    // test["try call; with error value (struct)"].pass = "99: whoops!" == (
-    //   try (
-    //     _Err.now_with_value_struct!
-    //     "success"
-    //   | err |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try call; with error value (class)"].pass = "whoops!" == (
+      try (
+        _Err.now_with_value_string!
+        "success"
+      | err |
+        err
+      )
+    )
 
-    // test["try call; with error value (none or struct)"].pass = "None" == (
-    //   try (
-    //     _Err.maybe_with_value_struct_or_none!(False)
-    //     "success"
-    //   | err |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try call; with error value (struct)"].pass = "99: whoops!" == (
+      try (
+        _Err.now_with_value_struct!
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
 
-    // test["try call; with error value (struct or none)"].pass = "100: whoa" == (
-    //   try (
-    //     _Err.maybe_with_value_struct_or_none!(True)
-    //     "success"
-    //   | err |
-    //     Inspect[err]
-    //   )
-    // )
+    test["try call; with error value (none)"].pass = "None" == (
+      try (
+        _Err.now!
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try call; with error value (none or struct)"].pass = "None" == (
+      try (
+        _Err.maybe_with_value_struct_or_none!(False)
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )
+
+    test["try call; with error value (struct or none)"].pass = "100: whoa" == (
+      try (
+        _Err.maybe_with_value_struct_or_none!(True)
+        "success"
+      | err |
+        Inspect[err]
+      )
+    )

--- a/spec/language/semantics/try_spec.savi
+++ b/spec/language/semantics/try_spec.savi
@@ -124,94 +124,94 @@
       try (_Err.not_really!, 33 | 11)
     )
 
-    test["try; with error value (numeric)"].pass = "98" == (
-      try (
-        error! 98
-        "success"
-      | err U64 |
-        Inspect[err]
-      )
-    )
+    // test["try; with error value (numeric)"].pass = "98" == (
+    //   try (
+    //     error! 98
+    //     "success"
+    //   | err U64 |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try; with error value (class)"].pass = "whoopsie" == (
-      try (
-        error! "whoopsie"
-        "success"
-      | err |
-        err
-      )
-    )
+    // test["try; with error value (class)"].pass = "whoopsie" == (
+    //   try (
+    //     error! "whoopsie"
+    //     "success"
+    //   | err |
+    //     err
+    //   )
+    // )
 
-    test["try; with error value (struct)"].pass = "98: whoopsie" == (
-      try (
-        error! _MyError.new(98, "whoopsie")
-        "success"
-      | err |
-        Inspect[err]
-      )
-    )
+    // test["try; with error value (struct)"].pass = "98: whoopsie" == (
+    //   try (
+    //     error! _MyError.new(98, "whoopsie")
+    //     "success"
+    //   | err |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try; with error value (struct or none)"].pass = "98: whoopsie" == (
-      try (
-        if False error!
-        error! _MyError.new(98, "whoopsie")
-        "success"
-      | err |
-        Inspect[err]
-      )
-    )
+    // test["try; with error value (struct or none)"].pass = "98: whoopsie" == (
+    //   try (
+    //     if False error!
+    //     error! _MyError.new(98, "whoopsie")
+    //     "success"
+    //   | err |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try; with error value (none or struct)"].pass = "None" == (
-      try (
-        if True error!
-        error! _MyError.new(98, "whoopsie")
-        "success"
-      | err |
-        Inspect[err]
-      )
-    )
+    // test["try; with error value (none or struct)"].pass = "None" == (
+    //   try (
+    //     if True error!
+    //     error! _MyError.new(98, "whoopsie")
+    //     "success"
+    //   | err |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try call; with error value (numeric)"].pass = "99" == (
-      try (
-        _Err.now_with_value_u64!
-        "success"
-      | err U64 |
-        Inspect[err]
-      )
-    )
+    // test["try call; with error value (numeric)"].pass = "99" == (
+    //   try (
+    //     _Err.now_with_value_u64!
+    //     "success"
+    //   | err U64 |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try call; with error value (class)"].pass = "whoops!" == (
-      try (
-        _Err.now_with_value_string!
-        "success"
-      | err |
-        err
-      )
-    )
+    // test["try call; with error value (class)"].pass = "whoops!" == (
+    //   try (
+    //     _Err.now_with_value_string!
+    //     "success"
+    //   | err |
+    //     err
+    //   )
+    // )
 
-    test["try call; with error value (struct)"].pass = "99: whoops!" == (
-      try (
-        _Err.now_with_value_struct!
-        "success"
-      | err |
-        Inspect[err]
-      )
-    )
+    // test["try call; with error value (struct)"].pass = "99: whoops!" == (
+    //   try (
+    //     _Err.now_with_value_struct!
+    //     "success"
+    //   | err |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try call; with error value (none or struct)"].pass = "None" == (
-      try (
-        _Err.maybe_with_value_struct_or_none!(False)
-        "success"
-      | err |
-        Inspect[err]
-      )
-    )
+    // test["try call; with error value (none or struct)"].pass = "None" == (
+    //   try (
+    //     _Err.maybe_with_value_struct_or_none!(False)
+    //     "success"
+    //   | err |
+    //     Inspect[err]
+    //   )
+    // )
 
-    test["try call; with error value (struct or none)"].pass = "100: whoa" == (
-      try (
-        _Err.maybe_with_value_struct_or_none!(True)
-        "success"
-      | err |
-        Inspect[err]
-      )
-    )
+    // test["try call; with error value (struct or none)"].pass = "100: whoa" == (
+    //   try (
+    //     _Err.maybe_with_value_struct_or_none!(True)
+    //     "success"
+    //   | err |
+    //     Inspect[err]
+    //   )
+    // )

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -3869,16 +3869,18 @@ class Savi::Compiler::CodeGen
       )
       catch_type = else_stack_tuple[3]
       error_value = gen_none
-      catch_type.try { |catch_type|
-        error_value = gen_assign_cast(
-          error_value_from_call,
-          catch_type,
-          llvm_type_of(catch_type),
-          from_call,
-          nil, # from_frame
-          error_type, # from_type
-        )
-      }
+      if error_type != @gtypes["None"].type_def.as_ref
+        catch_type.try { |catch_type|
+          error_value = gen_assign_cast(
+            error_value_from_call,
+            catch_type,
+            llvm_type_of(catch_type),
+            from_call,
+            nil, # from_frame
+            error_type, # from_type
+          )
+        }
+      end
       else_stack_tuple[2] << error_value
 
       # Jump to the try else block.

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -474,7 +474,11 @@ class Savi::Compiler::CodeGen
     @frames << Frame.new(self, llvm_func, gtype, gfunc)
 
     # Add debug info for this function
-    @di.func_start(gfunc, llvm_func) if gfunc
+    if gfunc
+      @di.func_start(gfunc, llvm_func)
+    elsif gtype
+      @di.func_start_raw(gtype.type_def.reified.defn(ctx).ident.pos, llvm_func)
+    end
 
     # Start building from the entry block.
     finish_block_and_move_to(func_frame.entry_block)

--- a/src/savi/compiler/code_gen/gen_func.cr
+++ b/src/savi/compiler/code_gen/gen_func.cr
@@ -162,10 +162,14 @@ class Savi::Compiler::CodeGen
       end
 
       def gen_error_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value?, value_expr : AST::Node?, continue_current_value : Bool)
+        value_type = gfunc.reach_func.signature.error_out.not_nil!
+        if value && value_expr
+          value = g.gen_assign_cast(value, value_type, nil, value_expr)
+        end
         tuple = llvm_func_ret_type(g, gfunc).undef
         tuple = g.builder.insert_value(tuple, g.llvm.int1.const_int(1), 1)
         g.builder.store(value, g.current_error_thread_local.not_nil!) \
-          if !continue_current_value && value != g.gen_none
+          if !continue_current_value && value_type != g.gtypes["None"].type_def.as_ref
         g.builder.ret(tuple)
       end
     end
@@ -238,10 +242,14 @@ class Savi::Compiler::CodeGen
       end
 
       def gen_error_return(g : CodeGen, gfunc : GenFunc, value : LLVM::Value?, value_expr : AST::Node?, continue_current_value : Bool)
+        value_type = gfunc.reach_func.signature.error_out.not_nil!
+        if value && value_expr
+          value = g.gen_assign_cast(value, value_type, nil, value_expr)
+        end
         cont = g.func_frame.continuation_value
         gfunc.continuation_info.set_as_error(cont)
         g.builder.store(value, g.current_error_thread_local.not_nil!) \
-          if !continue_current_value && value != g.gen_none
+          if !continue_current_value && value_type != g.gtypes["None"].type_def.as_ref
         g.builder.ret
       end
 

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -738,7 +738,7 @@ class Savi::Compiler::CodeGen::PonyRT
 
   def gen_send_impl(g : CodeGen, gtype : GenType, gfunc : GenFunc)
     fn = gfunc.send_llvm_func
-    g.gen_func_start(fn)
+    g.gen_func_start(fn, gtype)
 
     # Get the message type and virtual table index to use.
     msg_type = gfunc.send_msg_llvm_type
@@ -826,7 +826,7 @@ class Savi::Compiler::CodeGen::PonyRT
     fn.call_convention = LLVM::CallConvention::C
     fn.linkage = LLVM::Linkage::External
 
-    g.gen_func_start(fn)
+    g.gen_func_start(fn, gtype)
 
     fn.params[0].name = "PONY_CTX"
     fn.params[1].name = "@"
@@ -922,7 +922,7 @@ class Savi::Compiler::CodeGen::PonyRT
     fn.call_convention = LLVM::CallConvention::C
     fn.linkage = LLVM::Linkage::External
 
-    g.gen_func_start(fn)
+    g.gen_func_start(fn, gtype)
 
     fn.params[0].name = "PONY_CTX"
     fn.params[1].name = "@"

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -1034,6 +1034,11 @@ class Savi::Compiler::CodeGen::PonyRT
   def gen_trace_tuple(g : CodeGen, dst, src_type)
     src_gtype = g.gtype_of(src_type)
 
+    # Sometimes we may be dealing with a "boxed" tuple, so we need to unbox it.
+    if dst.type.kind == LLVM::Type::Kind::Pointer
+      dst = g.gen_unboxed_fields(dst, src_gtype)
+    end
+
     src_gtype.fields.each_with_index { |(name, field_type), index|
       field = g.builder.extract_value(dst, index)
       gen_trace(g, field, field, field_type, field_type)
@@ -1042,16 +1047,25 @@ class Savi::Compiler::CodeGen::PonyRT
 
   def gen_trace_dynamic(g : CodeGen, dst, src_type, dst_type, after_block)
     if src_type.is_union?
+      after_union_block = g.gen_block("after_dynamic_union_trace")
+
+      # We need to trace each possible type, guarded by a runtime type check.
+      # That's what gen_trace_dynamic will do for a singular type.
       src_type.union_children.each do |child_type|
-        gen_trace_dynamic(g, dst, child_type, dst_type, after_block)
+        gen_trace_dynamic(g, dst, child_type, dst_type, after_union_block)
       end
+      g.builder.br(after_union_block)
+      g.finish_block_and_move_to(after_union_block)
+
+      # We also need to trace the pointer itself as an opaque value,
+      # because it may be a "boxed" pointer to a simple/non-allocated value,
+      # and we can't let that "boxed" pointer get garbage-collected.
       gen_trace_unknown(g, dst, PonyRT::TRACE_OPAQUE)
     elsif src_type.singular?
       src_type_def = src_type.single_def!(g.ctx)
 
-      # We can't trace it if it's a simple value (with no type descriptor),
-      # and we shouldn't trace it if it isn't runtime-allocated.
-      return if src_type_def.is_simple_value?(g.ctx) || !src_type_def.has_allocation?(g.ctx)
+      # We'll only trace a constructed value (because it may have fields)
+      return unless src_type_def.is_constructed?(g.ctx)
 
       # Generate code to check if this value is a subtype of this at runtime.
       is_subtype = g.gen_check_subtype_at_runtime(dst, src_type, true)

--- a/src/savi/compiler/reach.cr
+++ b/src/savi/compiler/reach.cr
@@ -458,6 +458,10 @@ class Savi::Compiler::Reach < Savi::AST::Visitor
       @reified.defn(ctx).has_tag?(:simple_value)
     end
 
+    def is_constructed?(ctx)
+      @reified.defn(ctx).has_tag?(:constructed)
+    end
+
     def has_allocation?(ctx)
       @reified.defn(ctx).has_tag?(:allocated)
     end

--- a/src/savi/compiler/run.cr
+++ b/src/savi/compiler/run.cr
@@ -19,6 +19,12 @@ class Savi::Compiler::Run
     bin_path += ".exe" if target.windows?
 
     res = Process.run("/usr/bin/env", [bin_path], output: STDOUT, error: STDERR)
-    @exitcode = res.exit_code
+
+    if res.exit_reason == Process::ExitReason::Normal
+      @exitcode = res.exit_code
+    else
+      STDERR.puts "Process exited with reason: #{res.exit_reason}"
+      @exitcode = 1
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit, we had some bugs in the compiler-generated
tracing code for dynamic tracing, leading to situations where
the memory for the boxed struct (and for objects nested at
various levels within) may not be traced during garbage collection,
causing those memory regions to be reclaimed and potentially
reused, corrupting the data previously stored in that memory.

This commit fixes those bugs and adds a relevant test.