### PR TITLE
Add `Env.OutStream.flush` behavior.

### DIFF
--- a/core/Env.savi
+++ b/core/Env.savi
@@ -90,3 +90,7 @@
     chunks.each -> (data |
       _FFI.pony_os_std_write(@_stream, data.cpointer, data.size)
     )
+
+  :: Ensure that all buffered data is flushed to the output stream.
+  :be flush
+    _FFI.pony_os_std_flush(@_stream)

--- a/core/_FFI.savi
+++ b/core/_FFI.savi
@@ -13,6 +13,7 @@
   :ffi pony_os_std_write(
     fp CPointer(None)'ref, buffer CPointer(U8), length USize
   ) None
+  :ffi pony_os_std_flush(fp CPointer(None)'ref) None
 
 :module _FFI.Cast(A, B)
   :: An FFI-only utility function for bit-casting type A to B.


### PR DESCRIPTION
This can be used to ensure that all buffered data
is flushed to the output stream.