### PR TITLE
Call `pony_os_stdout_setup` at the start of a Savi program.

### DIFF
--- a/core/Env.savi
+++ b/core/Env.savi
@@ -17,6 +17,10 @@
     argv CPointer(CPointer(U8)'ref)'ref
     envp CPointer(CPointer(U8)'ref)'ref
   )
+    // This sets up proper buffering for stdout and stderr.
+    // Without this, program output piped to files may behave poorly.
+    _FFI.pony_os_stdout_setup
+
     @args = []
     i = USize[0]
     while argc > 0 (

--- a/core/_FFI.savi
+++ b/core/_FFI.savi
@@ -5,6 +5,7 @@
   :ffi variadic snprintf(buffer CPointer(U8), buffer_size I32, fmt CPointer(U8)) I32
 
   :ffi pony_exitcode(code I32) None
+  :ffi pony_os_stdout_setup() None
   :ffi pony_os_stdout() CPointer(None)'ref
   :ffi pony_os_stderr() CPointer(None)'ref
   :ffi pony_os_std_print(


### PR DESCRIPTION
This sets up proper buffering for stdout and stderr. Without this, program output piped to files may behave poorly.