### PR TITLE
Add `:ffi global cpointer` declarator to give the address of a C global.

### DIFF
--- a/core/declarators/declarators.savi
+++ b/core/declarators/declarators.savi
@@ -453,6 +453,10 @@
 :: Use `var` if the global variable is expected to change (either on the Savi
 :: side or on the C side), or `let` if it's expected to be set just once.
 ::
+:: Alternatively, `cpointer` can be specified instead of `var` or `let`,
+:: causing the declaration to generate a getter that returns the address of the
+:: global variable as a `CPointer(T)`, where `T` is the specified `type`.
+::
 :: WARNING: Savi programs involve actors and are implicitly multi-threaded,
 :: so global variables whose values are expected to change during the life
 :: of the program are very likely to cause memory safety issues.
@@ -464,7 +468,7 @@
   :begins ffi
 
   :keyword global
-  :term var_or_let enum (var, let)
+  :term var_or_let enum (var, let, cpointer)
   :term name Name
   :term type Type
 

--- a/spec/integration/run-ffi-globals/manifest.savi
+++ b/spec/integration/run-ffi-globals/manifest.savi
@@ -1,0 +1,2 @@
+:manifest "example"
+  :sources "src/*.savi"

--- a/spec/integration/run-ffi-globals/savi.run.output.txt
+++ b/spec/integration/run-ffi-globals/savi.run.output.txt
@@ -1,0 +1,17 @@
+initially...
+foo == 1 == 1
+bar == 2
+foo cpointer and foo_2 cpointer have the same address? True
+foo cpointer and bar cpointer have the same address? False
+---
+foo = 42 returns 42
+foo == 42 == 42
+bar == 2
+---
+bar = 99 returns 99
+foo == 42 == 42
+bar == 99
+---
+setting foo via cpointer to 32
+foo == 32 == 32
+bar == 99

--- a/spec/integration/run-ffi-globals/savi.run.test.sh
+++ b/spec/integration/run-ffi-globals/savi.run.test.sh
@@ -1,0 +1,2 @@
+$SAVI
+bin/example

--- a/spec/integration/run-ffi-globals/src/Main.savi
+++ b/spec/integration/run-ffi-globals/src/Main.savi
@@ -1,0 +1,57 @@
+
+:ffi_link_c_files (
+  "../vendor/mylib_globals.c"
+)
+
+:module _FFI.Cast(A, B)
+  :ffi pointer(input A) B
+    :foreign_name savi_cast_pointer
+
+:module _FFI.Globals
+  :ffi global var foo U64
+  :ffi global var bar U64
+
+  :ffi global let foo_2 U64
+    :foreign_name foo
+
+  :ffi global cpointer foo_cpointer U64
+    :foreign_name foo
+  :ffi global cpointer bar_cpointer U64
+    :foreign_name bar
+  :ffi global cpointer foo_cpointer_2 U64
+    :foreign_name foo
+
+  :fun "foo_via_cpointer="(value U64)
+    cpointer = _FFI.Globals.foo_cpointer
+    array = Array(U64).from_cpointer(
+      _FFI.Cast(CPointer(U64), CPointer(U64)'ref).pointer(cpointer)
+      1
+      1
+    )
+    try (array[0]! = value)
+    value
+
+:actor Main
+  :new (env)
+    env.out.print("initially...")
+    env.out.print("foo == \(_FFI.Globals.foo) == \(_FFI.Globals.foo_2)")
+    env.out.print("bar == \(_FFI.Globals.bar)")
+    env.out.print("foo cpointer and foo_2 cpointer have the same address? \(
+      _FFI.Globals.foo_cpointer.address == _FFI.Globals.foo_cpointer_2.address
+    )")
+    env.out.print("foo cpointer and bar cpointer have the same address? \(
+      _FFI.Globals.foo_cpointer.address == _FFI.Globals.bar_cpointer.address
+    )")
+    env.out.print("---")
+    env.out.print("foo = 42 returns \(_FFI.Globals.foo = 42)")
+    env.out.print("foo == \(_FFI.Globals.foo) == \(_FFI.Globals.foo_2)")
+    env.out.print("bar == \(_FFI.Globals.bar)")
+    env.out.print("---")
+    env.out.print("bar = 99 returns \(_FFI.Globals.bar = 99)")
+    env.out.print("foo == \(_FFI.Globals.foo) == \(_FFI.Globals.foo_2)")
+    env.out.print("bar == \(_FFI.Globals.bar)")
+    env.out.print("---")
+    env.out.print("setting foo via cpointer to \(_FFI.Globals.foo_via_cpointer = 32)")
+    env.out.print("foo == \(_FFI.Globals.foo) == \(_FFI.Globals.foo_2)")
+    env.out.print("bar == \(_FFI.Globals.bar)")
+

--- a/spec/integration/run-ffi-globals/vendor/mylib_globals.c
+++ b/spec/integration/run-ffi-globals/vendor/mylib_globals.c
@@ -1,0 +1,4 @@
+#include <stdint.h>
+
+uint64_t foo = 1;
+uint64_t bar = 2;

--- a/spec/integration/run-ffi-link-c-files/savi.run.output.txt
+++ b/spec/integration/run-ffi-link-c-files/savi.run.output.txt
@@ -1,4 +1,2 @@
 2 + 2 == 4!
 4 - 2 == 2!
-the magic number is 3
-the other magic number is 4.2

--- a/spec/integration/run-ffi-link-c-files/src/Main.savi
+++ b/spec/integration/run-ffi-link-c-files/src/Main.savi
@@ -2,19 +2,13 @@
 :ffi_link_c_files (
   "../vendor/mylib_add.c"
   "../vendor/mylib_sub.c"
-  "../vendor/mylib_magic_number.c"
 )
 
 :module _FFI
   :ffi mylib_add(a I32, b I32) I32
   :ffi mylib_sub(a I32, b I32) I32
-  :ffi global let mylib_magic_number I32
-  :ffi global let mylib_other_magic_number F64
-    :foreign_name mylib_magic_number_2
 
 :actor Main
   :new (env)
     env.out.print("2 + 2 == \(_FFI.mylib_add(2, 2))!")
     env.out.print("4 - 2 == \(_FFI.mylib_sub(4, 2))!")
-    env.out.print("the magic number is \(_FFI.mylib_magic_number)")
-    env.out.print("the other magic number is \(_FFI.mylib_other_magic_number)")

--- a/spec/integration/run-ffi-link-c-files/vendor/mylib_magic_number.c
+++ b/spec/integration/run-ffi-link-c-files/vendor/mylib_magic_number.c
@@ -1,2 +1,0 @@
-int mylib_magic_number = 3;
-double mylib_magic_number_2 = 4.2;

--- a/src/savi/program.cr
+++ b/src/savi/program.cr
@@ -391,6 +391,7 @@ class Savi::Program
       :ffi,
       :ffi_call,
       :ffi_global_constant,
+      :ffi_global_cpointer_getter,
       :ffi_global_getter,
       :ffi_global_setter,
       :field,


### PR DESCRIPTION
This is useful for C APIs where a value is declared as a global and it is expected to be used in the C API with the `&` (address of) operator.