### PR TITLE
Change hash algorithm for `String` and `Bytes`.

### DIFF
--- a/core/Bytes.savi
+++ b/core/Bytes.savi
@@ -9,7 +9,7 @@
   :new ref from_cpointer(@_ptr, @_size, @_space)
   :new iso iso_from_cpointer(@_ptr, @_size, @_space) // TODO: remove this and use recover instead?
   :new val val_from_cpointer(@_ptr, @_size, @_space) // TODO: remove this and use recover instead?
-  :fun hash: @_ptr._hash(@_size)
+  :fun hash: _Unsafe.RapidHash._run(@_ptr, @_size)
   :fun size: @_size
   :fun space: @_space
   :fun cpointer(offset = 0) CPointer(U8)'tag: @_ptr._offset(offset)
@@ -653,32 +653,21 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U16.
   :fun read_native_u16!(offset USize) U16
     if (offset + U16.byte_width.usize) > @_size error!
-    result U16 = 0
-    result_ptr = _FFI.Cast(CPointer(U16), CPointer(U8)'ref)
-      .pointer(stack_address_of_variable result)
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    @_ptr._offset(offset)._copy_to(result_ptr, U16.byte_width.usize)
-    result
+    _Unsafe.MultiByteAccess._read_native_u16(@_ptr._offset(offset))
 
   :: Write a U16 as bytes starting at the given offset, in native byte order.
   :: Raises an error if there aren't enough bytes at that offset to fit a U16.
   :: Use push_native_u16 instead if writing past the end is needed.
   :fun ref write_native_u16!(offset USize, value U16)
     if (offset + U16.byte_width.usize) > @_size error!
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    _FFI.Cast(CPointer(U16), CPointer(U8)'box)
-      .pointer(stack_address_of_variable value)
-      ._copy_to(@_ptr._offset(offset), U16.byte_width.usize)
+    _Unsafe.MultiByteAccess._write_native_u16(@_ptr._offset(offset), value)
     @
 
   :: Add a U16 as bytes onto the end of the buffer, in native byte order.
   :: Use write_native_u16 instead if overwriting existing data is needed.
   :fun ref push_native_u16(value U16)
     @reserve(@_size + U16.byte_width.usize)
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    _FFI.Cast(CPointer(U16), CPointer(U8)'box)
-      .pointer(stack_address_of_variable value)
-      ._copy_to(@_ptr._offset(@_size), U16.byte_width.usize)
+    _Unsafe.MultiByteAccess._write_native_u16(@_ptr._offset(@_size), value)
     @_size += U16.byte_width.usize
     @
 
@@ -686,32 +675,21 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U32.
   :fun read_native_u32!(offset USize) U32
     if (offset + U32.byte_width.usize) > @_size error!
-    result U32 = 0
-    result_ptr = _FFI.Cast(CPointer(U32), CPointer(U8)'ref)
-      .pointer(stack_address_of_variable result)
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    @_ptr._offset(offset)._copy_to(result_ptr, U32.byte_width.usize)
-    result
+    _Unsafe.MultiByteAccess._read_native_u32(@_ptr._offset(offset))
 
   :: Write a U32 as bytes starting at the given offset, in native byte order.
   :: Raises an error if there aren't enough bytes at that offset to fit a U32.
   :: Use push_native_u32 instead if writing past the end is needed.
   :fun ref write_native_u32!(offset USize, value U32)
     if (offset + U32.byte_width.usize) > @_size error!
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    _FFI.Cast(CPointer(U32), CPointer(U8)'box)
-      .pointer(stack_address_of_variable value)
-      ._copy_to(@_ptr._offset(offset), U32.byte_width.usize)
+    _Unsafe.MultiByteAccess._write_native_u32(@_ptr._offset(offset), value)
     @
 
   :: Add a U32 as bytes onto the end of the buffer, in native byte order.
   :: Use write_native_u32 instead if overwriting existing data is needed.
   :fun ref push_native_u32(value U32)
     @reserve(@_size + U32.byte_width.usize)
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    _FFI.Cast(CPointer(U32), CPointer(U8)'box)
-      .pointer(stack_address_of_variable value)
-      ._copy_to(@_ptr._offset(@_size), U32.byte_width.usize)
+    _Unsafe.MultiByteAccess._write_native_u32(@_ptr._offset(@_size), value)
     @_size += U32.byte_width.usize
     @
 
@@ -719,32 +697,21 @@
   :: Raises an error if there aren't enough bytes at that offset to fill a U64.
   :fun read_native_u64!(offset USize) U64
     if (offset + U64.byte_width.usize) > @_size error!
-    result U64 = 0
-    result_ptr = _FFI.Cast(CPointer(U64), CPointer(U8)'ref)
-      .pointer(stack_address_of_variable result)
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    @_ptr._offset(offset)._copy_to(result_ptr, U64.byte_width.usize)
-    result
+    _Unsafe.MultiByteAccess._read_native_u64(@_ptr._offset(offset))
 
   :: Write a U64 as bytes starting at the given offset, in native byte order.
   :: Raises an error if there aren't enough bytes at that offset to fit a U64.
   :: Use push_native_u64 instead if writing past the end is needed.
   :fun ref write_native_u64!(offset USize, value U64)
     if (offset + U64.byte_width.usize) > @_size error!
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    _FFI.Cast(CPointer(U64), CPointer(U8)'box)
-      .pointer(stack_address_of_variable value)
-      ._copy_to(@_ptr._offset(offset), U64.byte_width.usize)
+    _Unsafe.MultiByteAccess._write_native_u64(@_ptr._offset(offset), value)
     @
 
   :: Add a U64 as bytes onto the end of the buffer, in native byte order.
   :: Use write_native_u64 instead if overwriting existing data is needed.
   :fun ref push_native_u64(value U64)
     @reserve(@_size + U64.byte_width.usize)
-    // (we use memcpy here because it gracefully handles unaligned addresses)
-    _FFI.Cast(CPointer(U64), CPointer(U8)'box)
-      .pointer(stack_address_of_variable value)
-      ._copy_to(@_ptr._offset(@_size), U64.byte_width.usize)
+    _Unsafe.MultiByteAccess._write_native_u64(@_ptr._offset(@_size), value)
     @_size += U64.byte_width.usize
     @
 

--- a/core/CPointer.savi
+++ b/core/CPointer.savi
@@ -121,19 +121,6 @@
   :: The caller is expected to only do this for in-bounds element counts.
   :fun box _compare(other @'box, count USize) I32: compiler intrinsic
 
-  :: Calculate the hash of the block of memory starting at this pointer's head,
-  :: continuing through the given number of elements in that memory.
-  ::
-  :: On the Pony runtime, this uses the `ponyint_hash_block` function.
-  ::
-  :: Only the direct memory referenced by the pointer is hashed, so similar
-  :: caveats to those documented for the `_compare` method also apply here.
-  :: As such, callers should avoid using this without statically knowing the
-  :: ramifications of what kind of representation the element has in its memory.
-  ::
-  :: The caller is expected to only do this for in-bounds element counts.
-  :fun box _hash(count USize) USize: compiler intrinsic
-
   :: Return True if this is a null pointer (i.e. a zero address).
   :fun tag is_null Bool: compiler intrinsic
 

--- a/core/String.savi
+++ b/core/String.savi
@@ -9,7 +9,7 @@
   :new iso iso_from_cpointer(@_ptr, @_size, @_space) // TODO: remove this and use recover instead?
   :new val val_from_cpointer(@_ptr, @_size, @_space) // TODO: remove this and use recover instead?
   :fun cpointer CPointer(U8): @_ptr
-  :fun hash: @_ptr._hash(@_size)
+  :fun hash: _Unsafe.RapidHash._run(@_ptr, @_size)
   :fun size: @_size
   :fun space: @_space
 

--- a/core/_Unsafe.MultiByteAccess.savi
+++ b/core/_Unsafe.MultiByteAccess.savi
@@ -1,0 +1,51 @@
+:module _Unsafe.MultiByteAccess
+  :fun _read_native_u16(ptr CPointer(U8)) U16
+    value U16 = 0
+    value_ptr = _FFI.Cast(CPointer(U16), CPointer(U8)'ref)
+      .pointer(stack_address_of_variable value)
+    // (we use memcpy here because it gracefully handles unaligned addresses)
+    _FFI.Cast(CPointer(U8), CPointer(U8)'box).pointer(ptr)
+      ._copy_to(value_ptr, U16.byte_width.usize)
+    value
+
+  :fun _read_native_u32(ptr CPointer(U8)) U32
+    value U32 = 0
+    value_ptr = _FFI.Cast(CPointer(U32), CPointer(U8)'ref)
+      .pointer(stack_address_of_variable value)
+    // (we use memcpy here because it gracefully handles unaligned addresses)
+    _FFI.Cast(CPointer(U8), CPointer(U8)'box).pointer(ptr)
+      ._copy_to(value_ptr, U32.byte_width.usize)
+    value
+
+  :fun _read_native_u64(ptr CPointer(U8)) U64
+    value U64 = 0
+    value_ptr = _FFI.Cast(CPointer(U64), CPointer(U8)'ref)
+      .pointer(stack_address_of_variable value)
+    // (we use memcpy here because it gracefully handles unaligned addresses)
+    _FFI.Cast(CPointer(U8), CPointer(U8)'box).pointer(ptr)
+      ._copy_to(value_ptr, U64.byte_width.usize)
+    value
+
+  :fun _write_native_u16(ptr CPointer(U8), value U16)
+    dest_ptr = _FFI.Cast(CPointer(U8), CPointer(U8)'ref).pointer(ptr)
+    // (we use memcpy here because it gracefully handles unaligned addresses)
+    _FFI.Cast(CPointer(U16), CPointer(U8)'box)
+      .pointer(stack_address_of_variable value)
+      ._copy_to(dest_ptr, U16.byte_width.usize)
+    value
+
+  :fun _write_native_u32(ptr CPointer(U8), value U32)
+    dest_ptr = _FFI.Cast(CPointer(U8), CPointer(U8)'ref).pointer(ptr)
+    // (we use memcpy here because it gracefully handles unaligned addresses)
+    _FFI.Cast(CPointer(U32), CPointer(U8)'box)
+      .pointer(stack_address_of_variable value)
+      ._copy_to(dest_ptr, U32.byte_width.usize)
+    value
+
+  :fun _write_native_u64(ptr CPointer(U8), value U64)
+    dest_ptr = _FFI.Cast(CPointer(U8), CPointer(U8)'ref).pointer(ptr)
+    // (we use memcpy here because it gracefully handles unaligned addresses)
+    _FFI.Cast(CPointer(U64), CPointer(U8)'box)
+      .pointer(stack_address_of_variable value)
+      ._copy_to(dest_ptr, U64.byte_width.usize)
+    value

--- a/core/_Unsafe.RapidHash.savi
+++ b/core/_Unsafe.RapidHash.savi
@@ -1,0 +1,153 @@
+:: An implementation of a leading hash function in terms of maximizing speed
+:: without sacrificing too much quality. Note that this is not a cryptographic
+:: hash function, and should not be used as such.
+::
+:: Note that rapidhash is an official successor to wyhash, which is/was a
+:: widely used hash function in many languages/platforms.
+::
+:: To follow the latest research on hash functions, see:
+:: https://github.com/rurban/smhasher
+:module _Unsafe.RapidHash
+  // Default seed.
+  :const _seed USize: U64[0xbdd89aa982704029].usize
+
+  // Default secret.
+  :const _secret_0 USize: U64[0x2d358dccaa6c78a5].usize
+  :const _secret_1 USize: U64[0x8bb84b93962eacc9].usize
+  :const _secret_2 USize: U64[0x4b33a62ed433d4a3].usize
+
+  :const _width USize: U64.byte_width.usize
+
+  :: Read a little-endian USize integer from the given byte pointer.
+  :fun _read_word(ptr CPointer(U8)) USize
+    if USize.byte_width == 8 (
+      _Unsafe.MultiByteAccess._read_native_u64(ptr).native_to_le.usize
+    |
+      _Unsafe.MultiByteAccess._read_native_u32(ptr).native_to_le.usize
+    )
+
+  :: Read a half-USize from the given byte pointer (but return as a USize)
+  :fun _read_half(ptr CPointer(U8)) USize
+    if USize.byte_width == 8 (
+      _Unsafe.MultiByteAccess._read_native_u32(ptr).native_to_le.usize
+    |
+      _Unsafe.MultiByteAccess._read_native_u16(ptr).native_to_le.usize
+    )
+
+  :: Read one, two, or three bytes (without branching) into a USize.
+  :: This is only safe if the pointer is known to point to at least one byte.
+  :: Branching is avoided by the potential of reading some bytes more than once.
+  :fun _read_small(ptr_tag CPointer(U8), count USize) USize
+    ptr = _FFI.Cast(CPointer(U8), CPointer(U8)'box).pointer(ptr_tag)
+    ptr._get_at(0).usize.bit_shl(USize.bit_width - 8)
+      .bit_or(ptr._get_at(count.bit_shr(1)).usize.bit_shl(USize.byte_width * 4))
+      .bit_or(ptr._get_at(count - 1).usize)
+
+  :fun _mix(a USize, b USize) USize
+    pair = a.wide_multiply(b)
+    pair.low.bit_xor(pair.high)
+
+  :fun _run(ptr CPointer(U8), count USize) USize
+    a USize = 0
+    b USize = 0
+    count_word = count.usize
+    twelve_width = @_width * 12
+    six_width = @_width * 6
+    two_width = @_width * 2
+    half_width = @_width / 2
+    seed = @_seed.bit_xor(
+      @_mix(
+        @_seed.bit_xor(@_secret_0)
+        @_secret_1
+      ).bit_xor(count_word)
+    )
+
+    if count <= two_width ( // TODO: "likely" annotation
+      case (
+      | count >= half_width | // TODO: "likely" annotation
+        ptr_last = ptr.offset(count - 4)
+        a = @_read_half(ptr)
+          .bit_shl(USize.bit_width / 2)
+          .bit_or(@_read_half(ptr_last))
+        delta = count.bit_and(@_width * 3)
+          .bit_shr(count.bit_shr((@_width * 3).trailing_zero_bits).u8)
+        b = @_read_half(ptr.offset(delta))
+          .bit_shl(USize.bit_width / 2)
+          .bit_or(@_read_half(ptr_last.offset(0.usize - delta)))
+      | count > 0 | // TODO: "likely" annotation
+        a = @_read_small(ptr, count)
+      )
+    |
+      i = count
+      if i > six_width  ( // TODO: "unlikely" annotation
+        see1 = seed
+        see2 = seed
+        while i >= twelve_width ( // TODO: "likely" annotation
+          seed = @_mix(
+            @_read_word(ptr).bit_xor(@_secret_0)
+            @_read_word(ptr.offset(@_width)).bit_xor(seed)
+          )
+          see1 = @_mix(
+            @_read_word(ptr.offset(@_width * 2)).bit_xor(@_secret_1)
+            @_read_word(ptr.offset(@_width * 3)).bit_xor(see1)
+          )
+          see2 = @_mix(
+            @_read_word(ptr.offset(@_width * 4)).bit_xor(@_secret_2)
+            @_read_word(ptr.offset(@_width * 5)).bit_xor(see2)
+          )
+          seed = @_mix(
+            @_read_word(ptr.offset(@_width * 6)).bit_xor(@_secret_0)
+            @_read_word(ptr.offset(@_width * 7)).bit_xor(seed)
+          )
+          see1 = @_mix(
+            @_read_word(ptr.offset(@_width * 8)).bit_xor(@_secret_1)
+            @_read_word(ptr.offset(@_width * 9)).bit_xor(see1)
+          )
+          see2 = @_mix(
+            @_read_word(ptr.offset(@_width * 10)).bit_xor(@_secret_2)
+            @_read_word(ptr.offset(@_width * 11)).bit_xor(see2)
+          )
+          ptr = ptr.offset(twelve_width), i -= twelve_width
+        )
+        if i >= six_width ( // TODO: "unlikely" annotation
+          seed = @_mix(
+            @_read_word(ptr).bit_xor(@_secret_0)
+            @_read_word(ptr.offset(@_width)).bit_xor(seed)
+          )
+          see1 = @_mix(
+            @_read_word(ptr.offset(@_width * 2)).bit_xor(@_secret_1)
+            @_read_word(ptr.offset(@_width * 3)).bit_xor(see1)
+          )
+          see2 = @_mix(
+            @_read_word(ptr.offset(@_width * 4)).bit_xor(@_secret_2)
+            @_read_word(ptr.offset(@_width * 5)).bit_xor(see2)
+          )
+          ptr = ptr.offset(six_width), i -= six_width
+        )
+        seed = seed.bit_xor(see1.bit_xor(see2))
+      )
+      if i > @_width * 2 (
+        seed = @_mix(
+          @_read_word(ptr).bit_xor(@_secret_2)
+          @_read_word(ptr.offset(@_width)).bit_xor(seed).bit_xor(@_secret_1)
+        )
+        if i > @_width * 4 (
+          seed = @_mix(
+            @_read_word(ptr.offset(@_width * 2)).bit_xor(@_secret_2)
+            @_read_word(ptr.offset(@_width * 3)).bit_xor(seed)
+          )
+        )
+      )
+      a = @_read_word(ptr.offset(i - @_width * 2))
+      b = @_read_word(ptr.offset(i - @_width))
+    )
+    a = a.bit_xor(@_secret_1)
+    b = b.bit_xor(seed)
+    pair = a.wide_multiply(b)
+    a = pair.low
+    b = pair.high
+
+    @_mix(
+      a.bit_xor(@_secret_0).bit_xor(count_word)
+      b.bit_xor(@_secret_1)
+    )

--- a/spec/core/Bytes.Spec.savi
+++ b/spec/core/Bytes.Spec.savi
@@ -210,7 +210,64 @@
     assert: b"bar food foo".includes(b"").is_false
 
   :it "hashes the bytes of the buffer"
-    assert: (b"string".hash == 0x4cf51f4a5b5cf110)
+    // TODO: separate tests for 32-bit platforms
+    assert: b"".hash == 0x5a6ef77074ebc84b
+    assert: b"a".hash == 0xc11328477bc0f5d1
+    assert: b"ab".hash == 0x5644ac035e40d569
+    assert: b"abc".hash == 0x0347080fbf5fcd81
+    assert: b"abcd".hash == 0x056b66b8dc802bcc
+    assert: b"abcde".hash == 0xa069c8fd63a91f4d
+    assert: b"abcdef".hash == 0xbeefdee945780801
+    assert: b"abcdefg".hash == 0xe69105bd8738bf8b
+    assert: b"abcdefgh".hash == 0xb6bf9055973aac7c
+    assert: b"abcdefghi".hash == 0x902378a90af0d84c
+    assert: b"abcdefghij".hash == 0xfc9c0d0d762a2620
+    assert: b"abcdefghijk".hash == 0x11282593170377f7
+    assert: b"abcdefghijkl".hash == 0x5838d192cb38726f
+    assert: b"abcdefghijklm".hash == 0xf21a597f01196756
+    assert: b"abcdefghijklmn".hash == 0x6fbbd4bf88ffa42f
+    assert: b"abcdefghijklmno".hash == 0x21b686e60a01d3cf
+    assert: b"abcdefghijklmnop".hash == 0xb9840dda738aa078
+    assert: b"abcdefghijklmnopq".hash == 0x382023e454ce0f17
+    assert: b"abcdefghijklmnopqr".hash == 0xb9a30464d3a84eea
+    assert: b"abcdefghijklmnopqrs".hash == 0x67e3d76421289602
+    assert: b"abcdefghijklmnopqrstuvwxyz".hash == 0xd923d48cb07e0dff
+    assert: b"abcdefghijklmnopqrstuvwxyz123456".hash == 0xf0313df4c45d2356
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567".hash == 0x318142938d302ca7
+    assert: b"abcdefghijklmnopqrstuvwxyz12345678".hash == 0xc252e12245234d53
+    assert: b"abcdefghijklmnopqrstuvwxyz123456789".hash == 0x67b87093be2c643a
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890".hash == 0xd08871fe67966b9c
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJK".hash == 0x1e869b7a9afa4380
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKL".hash == 0x3148b1484f8b67f2
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLM".hash == 0x49c301d536254663
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMN".hash == 0xf98dad6467aa9e59
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNO".hash == 0x6352087a94e85ca3
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ".hash == 0x92c520d7bb0dd005
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~".hash == 0x3e9cc8a6eb110aad
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!".hash == 0x664e401443fa34ec
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@".hash == 0xcdc385ef7bd81768
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#".hash == 0xcc161e1b3e08cf38
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12345".hash == 0xf18118a7f80edff2
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123456".hash == 0xb8f457fb4ac286be
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567".hash == 0x6d0219d3b753429b
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12345678".hash == 0x1634233e81d92880
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123456789".hash == 0x525edfc527066bfe
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFG".hash == 0x750d408a38757d76
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGH".hash == 0x1c2bc74026bb4958
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHI".hash == 0xa14567c14f4be1d1
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJ".hash == 0xde4bacbd8259d7cd
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?".hash == 0x9f111429a3962a45
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1".hash == 0x692ea9f400b93866
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12".hash == 0xc4fa4248bbe8a596
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123".hash == 0x5ef404e32a583530
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234".hash == 0x7aac74791ad8ffef
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12345".hash == 0x14a019e4c3504be2
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123456".hash == 0xd28ff4b8190e9ea1
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABC".hash == 0x46a67d7d761bcad3
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCD".hash == 0x3d5638a13d12c777
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDE".hash == 0xc5a0044838e12f99
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEF".hash == 0xb0b208ca9308b584
+    assert: b"abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFG".hash == 0xc5910f257439a31e
 
   :it "returns the byte at the given byte offset"
     assert: b"example"[3]! == 'm'

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -145,7 +145,64 @@
     assert: "bar food foo".includes("").is_false
 
   :it "hashes the bytes of the string"
-    assert: ("string".hash == 0x4cf51f4a5b5cf110)
+    // TODO: separate tests for 32-bit platforms
+    assert: "".hash == 0x5a6ef77074ebc84b
+    assert: "a".hash == 0xc11328477bc0f5d1
+    assert: "ab".hash == 0x5644ac035e40d569
+    assert: "abc".hash == 0x0347080fbf5fcd81
+    assert: "abcd".hash == 0x056b66b8dc802bcc
+    assert: "abcde".hash == 0xa069c8fd63a91f4d
+    assert: "abcdef".hash == 0xbeefdee945780801
+    assert: "abcdefg".hash == 0xe69105bd8738bf8b
+    assert: "abcdefgh".hash == 0xb6bf9055973aac7c
+    assert: "abcdefghi".hash == 0x902378a90af0d84c
+    assert: "abcdefghij".hash == 0xfc9c0d0d762a2620
+    assert: "abcdefghijk".hash == 0x11282593170377f7
+    assert: "abcdefghijkl".hash == 0x5838d192cb38726f
+    assert: "abcdefghijklm".hash == 0xf21a597f01196756
+    assert: "abcdefghijklmn".hash == 0x6fbbd4bf88ffa42f
+    assert: "abcdefghijklmno".hash == 0x21b686e60a01d3cf
+    assert: "abcdefghijklmnop".hash == 0xb9840dda738aa078
+    assert: "abcdefghijklmnopq".hash == 0x382023e454ce0f17
+    assert: "abcdefghijklmnopqr".hash == 0xb9a30464d3a84eea
+    assert: "abcdefghijklmnopqrs".hash == 0x67e3d76421289602
+    assert: "abcdefghijklmnopqrstuvwxyz".hash == 0xd923d48cb07e0dff
+    assert: "abcdefghijklmnopqrstuvwxyz123456".hash == 0xf0313df4c45d2356
+    assert: "abcdefghijklmnopqrstuvwxyz1234567".hash == 0x318142938d302ca7
+    assert: "abcdefghijklmnopqrstuvwxyz12345678".hash == 0xc252e12245234d53
+    assert: "abcdefghijklmnopqrstuvwxyz123456789".hash == 0x67b87093be2c643a
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890".hash == 0xd08871fe67966b9c
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJK".hash == 0x1e869b7a9afa4380
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKL".hash == 0x3148b1484f8b67f2
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLM".hash == 0x49c301d536254663
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMN".hash == 0xf98dad6467aa9e59
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNO".hash == 0x6352087a94e85ca3
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ".hash == 0x92c520d7bb0dd005
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~".hash == 0x3e9cc8a6eb110aad
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!".hash == 0x664e401443fa34ec
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@".hash == 0xcdc385ef7bd81768
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#".hash == 0xcc161e1b3e08cf38
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12345".hash == 0xf18118a7f80edff2
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123456".hash == 0xb8f457fb4ac286be
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567".hash == 0x6d0219d3b753429b
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12345678".hash == 0x1634233e81d92880
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123456789".hash == 0x525edfc527066bfe
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFG".hash == 0x750d408a38757d76
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGH".hash == 0x1c2bc74026bb4958
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHI".hash == 0xa14567c14f4be1d1
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJ".hash == 0xde4bacbd8259d7cd
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?".hash == 0x9f111429a3962a45
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1".hash == 0x692ea9f400b93866
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12".hash == 0xc4fa4248bbe8a596
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123".hash == 0x5ef404e32a583530
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234".hash == 0x7aac74791ad8ffef
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?12345".hash == 0x14a019e4c3504be2
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?123456".hash == 0xd28ff4b8190e9ea1
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABC".hash == 0x46a67d7d761bcad3
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCD".hash == 0x3d5638a13d12c777
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDE".hash == 0xc5a0044838e12f99
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEF".hash == 0xb0b208ca9308b584
+    assert: "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ~!@#$^&*()_+-=[]{}|;':,./<>?1234567890abcdefghijklmnopqrstuvwxyz1234567890ABCDEFG".hash == 0xc5910f257439a31e
 
   :it "returns the byte at the given byte offset"
     assert: "example"[3]! == 'm'

--- a/spec/core/manifest.savi
+++ b/spec/core/manifest.savi
@@ -1,6 +1,6 @@
 :manifest bin "spec"
   :sources "*.savi"
-  :sources "../../core/_*.savi" // (load private type files for unit testing)
+  :sources "../../core/_Ryu*.savi" // (load some private files for unit testing)
 
   :dependency Spec v0
     :from "github:savi-lang/Spec"

--- a/src/savi/compiler/code_gen.cr
+++ b/src/savi/compiler/code_gen.cr
@@ -1085,8 +1085,6 @@ class Savi::Compiler::CodeGen
         gen_none
       when "_compare"
         gen_call_named("memcmp", [params[0], params[1], params[2]])
-      when "_hash"
-        gen_call_named("ponyint_hash_block", [params[0], params[1]])
       when "is_null"
         @builder.is_null(params[0])
       when "is_not_null"

--- a/src/savi/compiler/code_gen/ponyrt.cr
+++ b/src/savi/compiler/code_gen/ponyrt.cr
@@ -236,13 +236,6 @@ class Savi::Compiler::CodeGen::PonyRT
       {"ponyint_next_pow2", [@isize], @isize, [
         LLVM::Attribute::NoUnwind, LLVM::Attribute::ReadNone,
       ]},
-      {"ponyint_hash_block", [@ptr, @isize], @isize, [
-        LLVM::Attribute::NoRecurse, LLVM::Attribute::NoUnwind,
-        LLVM::Attribute::ReadOnly,
-        {1, LLVM::Attribute::ReadOnly},
-      ]},
-
-      # TODO: ponyint_personality_v0
 
       # Miscellaneous non-pony functions we depend on.
       {"puts", [@ptr], @i32, [] of LLVM::Attribute},


### PR DESCRIPTION
These now use the more modern rapidhash algorithm
instead of the older algorithm used in `ponyint_hash_block`.

It also removes the dependency on the Pony-internal function.