### PR TITLE
Fix for FFI casting a struct to its pointer field.

### DIFF
--- a/spec/language/semantics/struct_spec.savi
+++ b/spec/language/semantics/struct_spec.savi
@@ -1,8 +1,34 @@
 :struct _StructWithFieldInitializer
   :let array Array(String): []
 
+:struct _StructWithSingleStringField
+  :let string String
+  :new(@string)
+
+:module _FFI.Cast(A, B)
+  :: An FFI-only utility function for bit-casting type A to B.
+  ::
+  :: This is only meant to be used for pointer types, and will
+  :: fail badly if either A or B is not an ABI pointer type
+  ::
+  :: Obviously this utility function makes it easy to break
+  :: memory safety, so it should be used with great care.
+  ::
+  :: Being private, It is only accessible from within the core library,
+  :: though other libraries can set up similar mechanisms as well,
+  :: provided that they are explicitly allowed by the root manifest to use FFI.
+  :ffi pointer(input A) B
+    :foreign_name savi_cast_pointer
+
 :module StructSpec
   :fun run(test MicroTest)
     s_w_f_i = _StructWithFieldInitializer.new
     s_w_f_i.array << "example"
     test["struct with field initializer"].pass = s_w_f_i.array == ["example"]
+
+    s_w_s_s_f = _StructWithSingleStringField.new("example")
+    test["struct FFI cast to its one field"].pass =
+      _FFI.Cast(_StructWithSingleStringField, String).pointer(s_w_s_s_f) == "example"
+
+    test["struct FFI cast from its one field"].pass =
+      _FFI.Cast(String, _StructWithSingleStringField).pointer("example").string == "example"


### PR DESCRIPTION
FFI casting for pointer-containing structs is a pattern I'm using in my LLVM library that's currently in progress.