### PR TITLE
Add simple `String.parse_f64!` method.

### DIFF
--- a/core/String.savi
+++ b/core/String.savi
@@ -485,7 +485,7 @@
     )
     result
 
-  :fun parse_i64! // TODO: Use something like Crystal's Char::Reader instead?
+  :fun parse_i64! I64 // TODO: Use something like Crystal's Char::Reader instead?
     output I64 = 0
     possible_negation I64 = 1
     @each_byte_with_index -> (byte, index |
@@ -497,6 +497,15 @@
       )
     )
     output * possible_negation
+
+  :fun parse_f64! F64 // TODO: Use something like Crystal's Char::Reader instead?
+    // TODO: Avoid FFI and use a pure Savi `strtod` implementation.
+    start_pointer = @cstring
+    end_pointer = CPointer(U8).null
+    value = _FFI.strtod(start_pointer, stack_address_of_variable end_pointer)
+    error! if value == 0 && end_pointer.address == start_pointer.address
+    error! if end_pointer.address != start_pointer.address + @size
+    value
 
   :fun substring(from USize, to USize = 0) String'iso
     if to == 0 || to > @_size (

--- a/core/_FFI.savi
+++ b/core/_FFI.savi
@@ -3,6 +3,7 @@
   :ffi strlen(string CPointer(U8)) USize
   :ffi memset(pointer CPointer(U8), char I32, count USize) None
   :ffi variadic snprintf(buffer CPointer(U8), buffer_size I32, fmt CPointer(U8)) I32
+  :ffi strtod(start_pointer CPointer(U8), end_pointer CPointer(CPointer(U8))) F64
 
   :ffi pony_exitcode(code I32) None
   :ffi pony_os_stdout_setup() None

--- a/spec/core/String.Spec.savi
+++ b/spec/core/String.Spec.savi
@@ -306,6 +306,10 @@
     assert: "-36".parse_i64! == -36
     assert error: "36bad".parse_i64!
 
+  :it "parses a floating point from the string decimal representation"
+    assert: "36.3".parse_f64!  == 36.3
+    assert error: "36.3bad".parse_f64!
+
   :it "returns the unicode codepoint found at the given offset, if valid"
     string = "नमस्ते"
     assert: string.char_at!(0) == 'न' // valid


### PR DESCRIPTION
This isn't as flexible an interface as it could be, and isn't as performant as it could be if it were in pure Savi using a modern algorithm, but it at least gets the job done in a simple way.

We can come back to it later to improve.