### PR TITLE
Update `ReflectionOfType` to implement `IntoString` trait.

### DIFF
--- a/core/Reflection.savi
+++ b/core/Reflection.savi
@@ -13,6 +13,10 @@
 
   :let features Array(ReflectionFeatureOfType(A)): []
 
+  :is IntoString
+  :fun into_string_space USize: @string.size
+  :fun into_string(out String'ref) None: @string.into_string(out)
+
 :class val ReflectionFeatureOfType(A)
   :let name String: ""
   :let tags Array(String): []

--- a/spec/language/semantics/reflection_spec.savi
+++ b/spec/language/semantics/reflection_spec.savi
@@ -2,10 +2,12 @@
   :fun run(test MicroTest)
     test["reflection_of_type.string String"].pass =
       (reflection_of_type "example").string == "String"
-    test["reflection_of_type.string String'ref"].pass =
-      (reflection_of_type String.new).string == "String'ref"
-    test["reflection_of_type.string Array(U8)"].pass =
-      (reflection_of_type Array(U8).new).string == "Array(U8)"
+    test["reflection_of_type string String"].pass =
+      "\(reflection_of_type "example")" == "String"
+    test["reflection_of_type string String'ref"].pass =
+      "\(reflection_of_type String.new)" == "String'ref"
+    test["reflection_of_type string Array(U8)"].pass =
+      "\(reflection_of_type Array(U8).new)" == "Array(U8)"
 
     test["reflection_of_runtime_type_name U64"].pass =
       (reflection_of_runtime_type_name U64[0]) == "U64"


### PR DESCRIPTION
This allows for easier printing of the `reflection_of_type` macro.