### PR TITLE
Remove `*_until`-style iteration methods.

### DIFF
--- a/core/Indexable.savi
+++ b/core/Indexable.savi
@@ -31,30 +31,6 @@
       yield value
     )
 
-  :: DEPRECATED: Use `break` to exit early from `each` if needed.
-  :fun each_until(
-    from USize = 0
-    to = USize.max_value
-    stride USize = 1
-  )
-    :yields for Bool // TODO: this type hint shouldn't be needed
-    @each(from, to, stride) -> (value |
-      return True if (yield value)
-    )
-    False
-
-  :: DEPRECATED: Use `break` to exit early from `each_with_index` if needed.
-  :fun each_with_index_until(
-    from USize = 0
-    to = USize.max_value
-    stride USize = 1
-  )
-    :yields for Bool // TODO: this type hint shouldn't be needed
-    @each_with_index(from, to, stride) -> (value, index |
-      return True if (yield (value, index))
-    )
-    False
-
   :fun has_any(
     from USize = 0
     to = USize.max_value

--- a/core/String.savi
+++ b/core/String.savi
@@ -230,14 +230,6 @@
       yield value
     )
 
-  :: DEPRECATED: Use `break` to exit early from `each_byte` if needed.
-  :fun each_byte_until(from USize = 0, to = USize.max_value, stride USize = 1)
-    :yields for Bool
-    @each_byte(from, to, stride) -> (byte |
-      return True if (yield byte)
-    )
-    False
-
   // TODO: Move to be on a new `Indexable.Bytes` trait?
   :fun each_byte_with_index(from USize = 0, to = USize.max_value, stride USize = 1)
     index = from


### PR DESCRIPTION
This style/convention is a legacy from an old version of the Savi language, in which yield blocks could not be "jumped out of".

Now that `return`, `error!`, and `break` can all jump out of a yield block, the pattern (of allowing the caller to yield back a `Bool` to indicate whether iteration should continue) is obsolete, and should be removed to reduce complexity and maintenance burden.